### PR TITLE
[UI]「行きたい！」ページ作成

### DIFF
--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -9,6 +9,8 @@ abstract class AppColors {
   static const textOnPrimary = Color(0xFFFFFFFF);
   static const background = Color(0xFFF9F9F9);
   static const surface = Color(0xFFFFFFFF);
+  static const chipUnselected = Color(0xFFD9D9D9);
+  static const listSelected = Color(0xFF17A6C8);
   static const navActive = primary;
   static const navInactive = Color(0xFFB0B0B0);
 }

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -16,15 +16,29 @@ abstract class AppStrings {
   static const wantToGo = '行きたい！';
   static const safetyOk = '元気です';
 
+  // 行きたい！ページ
+  static const wantToGoPageTitle = '行きたい！';
+  static const wantToGoNoTitle = '（タイトルなし）';
+  static const wantToGoSave = '行きたい！に保存';
+  static const wantToGoConfirmMessage = '「行きたい！」に保存しますか？';
+  static const wantToGoSaved = '保存しました！';
+  static const saveButton = '保存する';
+  static const cancelButton = 'キャンセル';
+  static const closeButton = '閉じる';
+  static const realtimeLocation = 'リアルタイム位置';
+  static const addPhoto = '写真を追加';
+
+  // カテゴリ
+  static const categoryPark = '公園';
+  static const categoryCafe = 'カフェ';
+  static const categoryLunch = 'ランチ';
+  static const categoryDinner = 'ディナー';
+  static const categoryGoods = '雑貨屋';
+  static const categoryOther = 'そのほか';
+
   // スポット
   static const statusWantToGo = '行きたい';
   static const statusVisited = '行った';
   static const categoryChange = '行った！に変更';
 
-  // カテゴリ
-  static const categoryCafe = 'カフェ';
-  static const categoryPark = '公園';
-  static const categoryShop = '店';
-  static const categoryRestaurant = '飲食店';
-  static const categoryOther = 'その他';
 }

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -40,5 +40,4 @@ abstract class AppStrings {
   static const statusWantToGo = '行きたい';
   static const statusVisited = '行った';
   static const categoryChange = '行った！に変更';
-
 }

--- a/lib/core/constants/app_text_style.dart
+++ b/lib/core/constants/app_text_style.dart
@@ -6,12 +6,17 @@ abstract class AppTextStyle {
   // サイズ定数
   static const double xs = 11.0;
   static const double sm = 13.0;
+  static const double sm2 = 14.0;
   static const double md = 15.0;
+  static const double md2 = 16.0;
   static const double lg = 17.0;
+  static const double lg2 = 18.0;
   static const double xl = 20.0;
+  static const double x1l = 22.0;
   static const double x2l = 24.0;
   static const double x3l = 32.0;
   static const double timer = 56.0;
+  static const double clock = 96.0;
 
   // ウェイト定数
   static const regular = FontWeight.w400;

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/presentation/pages/walk/walk_page.dart';
@@ -9,7 +8,6 @@ import 'package:tekushare/presentation/widgets/common/clock_header.dart';
 import 'package:tekushare/presentation/widgets/common/primary_button.dart';
 
 /// ホーム画面
-/// 現在時刻・片道設定を表示し、足あとアニメーション後に散歩開始ボタンを表示する
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
 

--- a/lib/presentation/pages/spot/want_to_go_page.dart
+++ b/lib/presentation/pages/spot/want_to_go_page.dart
@@ -1,0 +1,404 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
+import 'package:tekushare/presentation/widgets/common/category_chip_group.dart';
+
+/// 行きたい！ページ
+class WantToGoPage extends StatefulWidget {
+  const WantToGoPage({super.key});
+
+  @override
+  State<WantToGoPage> createState() => _WantToGoPageState();
+}
+
+class _WantToGoPageState extends State<WantToGoPage> {
+  String _selectedCategory = AppStrings.categoryPark;
+  final _titleController = TextEditingController();
+
+  static const _categories = [
+    AppStrings.categoryPark,
+    AppStrings.categoryCafe,
+    AppStrings.categoryLunch,
+    AppStrings.categoryDinner,
+    AppStrings.categoryGoods,
+    AppStrings.categoryOther,
+  ];
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  void _onSavePressed() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => _ConfirmDialog(
+        title: _titleController.text.isEmpty
+            ? AppStrings.wantToGoNoTitle
+            : _titleController.text,
+        onConfirm: () {
+          Navigator.pop(context);
+          if (!mounted) return;
+          _showSavedDialog();
+        },
+        onCancel: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  void _showSavedDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => _SavedDialog(
+        onClose: () {
+          Navigator.pop(context); // ダイアログを閉じる
+          Navigator.pop(context); // 行きたいリストへ戻る
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: const Text(AppStrings.wantToGoPageTitle),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const _LocationArea(),
+              const SizedBox(height: 34),
+              CategoryChipGroup(
+                categories: _categories,
+                selectedCategory: _selectedCategory,
+                onSelected: (cat) => setState(() => _selectedCategory = cat),
+              ),
+              const SizedBox(height: 34),
+              _TitleInput(controller: _titleController),
+              const SizedBox(height: 34),
+              const _PhotoBox(),
+              const SizedBox(height: 34),
+              _SaveButton(onPressed: _onSavePressed),
+              const SizedBox(height: 34),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: const AppBottomNav(currentIndex: 0),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// リアルタイム位置エリア
+// ──────────────────────────────────────────
+
+class _LocationArea extends StatelessWidget {
+  const _LocationArea();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: 161,
+      decoration: BoxDecoration(
+        color: AppColors.chipUnselected,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: const Center(
+        child: Text(
+          AppStrings.realtimeLocation,
+          style: TextStyle(
+            color: AppColors.textDisabled,
+            fontSize: AppTextStyle.md2,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// タイトル入力
+// ──────────────────────────────────────────
+
+class _TitleInput extends StatelessWidget {
+  const _TitleInput({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: 'タイトルを設定する',
+        hintStyle: const TextStyle(
+            color: AppColors.textDisabled, fontSize: AppTextStyle.x2l),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary),
+        ),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 写真エリア
+// ──────────────────────────────────────────
+
+class _PhotoBox extends StatelessWidget {
+  const _PhotoBox();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 176,
+      height: 100,
+      child: CustomPaint(
+        painter: _DashedBorderPainter(),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SvgPicture.asset(
+              'assets/SVG/camera.svg',
+              width: 24,
+              height: 24,
+              colorFilter: const ColorFilter.mode(
+                AppColors.textAccent,
+                BlendMode.srcIn,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              AppStrings.addPhoto,
+              style: TextStyle(
+                color: AppColors.textAccent,
+                fontSize: AppTextStyle.sm,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DashedBorderPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = AppColors.textAccent
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+
+    final rrect = RRect.fromRectAndRadius(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      const Radius.circular(12),
+    );
+    final path = Path()..addRRect(rrect);
+    canvas.drawPath(_dashPath(path), paint);
+  }
+
+  Path _dashPath(Path source, {double dashWidth = 6, double dashSpace = 4}) {
+    final dest = Path();
+    for (final metric in source.computeMetrics()) {
+      double distance = 0;
+      bool draw = true;
+      while (distance < metric.length) {
+        final len = draw ? dashWidth : dashSpace;
+        if (draw) {
+          dest.addPath(
+            metric.extractPath(distance, distance + len),
+            Offset.zero,
+          );
+        }
+        distance += len;
+        draw = !draw;
+      }
+    }
+    return dest;
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+// ──────────────────────────────────────────
+// 保存ボタン
+// ──────────────────────────────────────────
+
+class _SaveButton extends StatelessWidget {
+  const _SaveButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 94,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(47),
+          ),
+        ),
+        child: const Text(
+          AppStrings.wantToGoSave,
+          style: TextStyle(
+              fontSize: AppTextStyle.lg2, fontWeight: FontWeight.w500),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 確認ダイアログ
+// ──────────────────────────────────────────
+
+class _ConfirmDialog extends StatelessWidget {
+  const _ConfirmDialog({
+    required this.title,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String title;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              AppStrings.wantToGoConfirmMessage,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: onCancel,
+                    style: OutlinedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text(AppStrings.cancelButton),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: onConfirm,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text(AppStrings.saveButton),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 保存完了ダイアログ
+// ──────────────────────────────────────────
+
+class _SavedDialog extends StatelessWidget {
+  const _SavedDialog({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              AppStrings.wantToGoSaved,
+              style: TextStyle(
+                  fontSize: AppTextStyle.lg2, fontWeight: FontWeight.w500),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: ElevatedButton(
+                onPressed: onClose,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text(AppStrings.closeButton),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/walk/walk_page.dart
+++ b/lib/presentation/pages/walk/walk_page.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/presentation/pages/spot/want_to_go_page.dart';
 import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/presentation/widgets/common/clock_header.dart';
 import 'package:tekushare/presentation/widgets/common/primary_button.dart';
 
 /// 散歩モード画面
-/// 「散歩をはじめる」押下後に表示される画面
 class WalkPage extends StatelessWidget {
   const WalkPage({super.key});
 
@@ -26,9 +26,9 @@ class WalkPage extends StatelessWidget {
               child: _WalkActionButton(
                 label: AppStrings.takePhoto,
                 svgAsset: 'assets/SVG/camera.svg',
-                fontSize: 22,
+                fontSize: AppTextStyle.x1l,
                 onPressed: () {
-                  // TODO(#7): 撮影処理
+                  // TODO: 撮影処理
                 },
               ),
             ),
@@ -36,9 +36,10 @@ class WalkPage extends StatelessWidget {
             Center(
               child: _WalkActionButton(
                 label: AppStrings.saveToWantToGo,
-                onPressed: () {
-                  // TODO(#7): 行きたいリストへ保存
-                },
+                onPressed: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const WantToGoPage()),
+                ),
               ),
             ),
             const SizedBox(height: 70),
@@ -65,7 +66,7 @@ class _WalkActionButton extends StatelessWidget {
   const _WalkActionButton({
     required this.label,
     this.svgAsset,
-    this.fontSize = 20,
+    this.fontSize = AppTextStyle.xl,
     required this.onPressed,
   });
 

--- a/lib/presentation/widgets/common/app_bottom_nav.dart
+++ b/lib/presentation/widgets/common/app_bottom_nav.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
 
 /// アプリ共通のボトムナビゲーションバー（Material 3 NavigationBar）
 class AppBottomNav extends StatelessWidget {
@@ -39,7 +40,7 @@ class AppBottomNav extends StatelessWidget {
             final color = states.contains(WidgetState.selected)
                 ? Colors.white
                 : AppColors.navInactive;
-            return TextStyle(fontSize: 11, color: color);
+            return TextStyle(fontSize: AppTextStyle.xs, color: color);
           }),
         ),
       ),

--- a/lib/presentation/widgets/common/category_chip_group.dart
+++ b/lib/presentation/widgets/common/category_chip_group.dart
@@ -10,7 +10,8 @@ class CategoryChipGroup extends StatelessWidget {
     required this.categories,
     required this.selectedCategory,
     required this.onSelected,
-  }) : assert(categories.length == 6, 'CategoryChipGroup requires exactly 6 categories');
+  }) : assert(categories.length == 6,
+            'CategoryChipGroup requires exactly 6 categories');
 
   final List<String> categories;
   final String selectedCategory;

--- a/lib/presentation/widgets/common/category_chip_group.dart
+++ b/lib/presentation/widgets/common/category_chip_group.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+
+/// カテゴリ選択チップグループ（3列2行）
+class CategoryChipGroup extends StatelessWidget {
+  const CategoryChipGroup({
+    super.key,
+    required this.categories,
+    required this.selectedCategory,
+    required this.onSelected,
+  }) : assert(categories.length == 6, 'CategoryChipGroup requires exactly 6 categories');
+
+  final List<String> categories;
+  final String selectedCategory;
+  final ValueChanged<String> onSelected;
+
+  Widget _chip(String cat) {
+    final isSelected = selectedCategory == cat;
+    return GestureDetector(
+      onTap: () => onSelected(cat),
+      child: Container(
+        width: 108,
+        height: 48,
+        decoration: BoxDecoration(
+          color: isSelected ? AppColors.listSelected : AppColors.chipUnselected,
+          borderRadius: BorderRadius.circular(48),
+        ),
+        child: Center(
+          child: Text(
+            cat,
+            style: TextStyle(
+              color: isSelected ? Colors.white : AppColors.textPrimary,
+              fontSize: AppTextStyle.sm2,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _chip(categories[0]),
+            const SizedBox(width: 16),
+            _chip(categories[1]),
+            const SizedBox(width: 16),
+            _chip(categories[2]),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _chip(categories[3]),
+            const SizedBox(width: 16),
+            _chip(categories[4]),
+            const SizedBox(width: 16),
+            _chip(categories[5]),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/common/clock_header.dart
+++ b/lib/presentation/widgets/common/clock_header.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_defaults.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
@@ -31,7 +30,7 @@ class ClockHeader extends ConsumerWidget {
             '$h:$m',
             style: AppTextStyle.timerDisplay.copyWith(
               color: AppColors.primary,
-              fontSize: 96,
+              fontSize: AppTextStyle.clock,
               height: 1.0,
             ),
           ),
@@ -40,7 +39,7 @@ class ClockHeader extends ConsumerWidget {
             '片道  00:$minutes',
             style: AppTextStyle.bodyMedium.copyWith(
               color: AppColors.primary,
-              fontSize: 32,
+              fontSize: AppTextStyle.x3l,
               fontWeight: FontWeight.w500,
               height: 1.0,
             ),

--- a/test/presentation/pages/spot/want_to_go_page_test.dart
+++ b/test/presentation/pages/spot/want_to_go_page_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/presentation/pages/spot/want_to_go_page.dart';
+import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
+
+void main() {
+  group('WantToGoPage', () {
+    Future<void> pumpPage(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(home: WantToGoPage()),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('ページタイトルが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.wantToGoPageTitle), findsOneWidget);
+    });
+
+    testWidgets('6つのカテゴリチップが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.categoryPark), findsOneWidget);
+      expect(find.text(AppStrings.categoryCafe), findsOneWidget);
+      expect(find.text(AppStrings.categoryLunch), findsOneWidget);
+      expect(find.text(AppStrings.categoryDinner), findsOneWidget);
+      expect(find.text(AppStrings.categoryGoods), findsOneWidget);
+      expect(find.text(AppStrings.categoryOther), findsOneWidget);
+    });
+
+    testWidgets('写真を追加ボタンが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.addPhoto), findsOneWidget);
+    });
+
+    testWidgets('保存ボタンが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.wantToGoSave), findsOneWidget);
+    });
+
+    testWidgets('ボトムナビが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.byType(AppBottomNav), findsOneWidget);
+    });
+
+    testWidgets('保存ボタンを押すと確認ダイアログが表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.wantToGoSave));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.wantToGoConfirmMessage), findsOneWidget);
+    });
+
+    testWidgets('タイトル未入力時の確認ダイアログに（タイトルなし）が表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.wantToGoSave));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.wantToGoNoTitle), findsOneWidget);
+    });
+
+    testWidgets('タイトル入力時の確認ダイアログに入力値が表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.enterText(find.byType(TextField), 'テストスポット');
+      await tester.tap(find.text(AppStrings.wantToGoSave));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text('テストスポット'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('確認ダイアログのキャンセルでダイアログが閉じる', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.wantToGoSave));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.wantToGoConfirmMessage), findsNothing);
+    });
+
+    testWidgets('確認ダイアログの保存で保存完了ダイアログが表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.wantToGoSave));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.wantToGoSaved), findsOneWidget);
+    });
+
+    testWidgets('保存完了ダイアログの閉じるでページを離れる', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const WantToGoPage()),
+              ),
+              child: const Text('start'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('start'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(AppStrings.wantToGoSave));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WantToGoPage), findsNothing);
+    });
+  });
+}

--- a/test/presentation/widgets/common/category_chip_group_test.dart
+++ b/test/presentation/widgets/common/category_chip_group_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/presentation/widgets/common/category_chip_group.dart';
+
+void main() {
+  const categories = [
+    AppStrings.categoryPark,
+    AppStrings.categoryCafe,
+    AppStrings.categoryLunch,
+    AppStrings.categoryDinner,
+    AppStrings.categoryGoods,
+    AppStrings.categoryOther,
+  ];
+
+  Future<void> pumpWidget(
+    WidgetTester tester, {
+    String selected = AppStrings.categoryPark,
+    ValueChanged<String>? onSelected,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CategoryChipGroup(
+            categories: categories,
+            selectedCategory: selected,
+            onSelected: onSelected ?? (_) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('CategoryChipGroup', () {
+    testWidgets('6つのカテゴリが表示される', (tester) async {
+      await pumpWidget(tester);
+
+      for (final cat in categories) {
+        expect(find.text(cat), findsOneWidget);
+      }
+    });
+
+    testWidgets('選択中のカテゴリをタップするとonSelectedが呼ばれる', (tester) async {
+      String? tapped;
+      await pumpWidget(tester, onSelected: (cat) => tapped = cat);
+
+      await tester.tap(find.text(AppStrings.categoryCafe));
+      expect(tapped, AppStrings.categoryCafe);
+    });
+
+    testWidgets('selectedCategory が変わると表示に反映される', (tester) async {
+      String selected = AppStrings.categoryPark;
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (context, setState) => MaterialApp(
+            home: Scaffold(
+              body: CategoryChipGroup(
+                categories: categories,
+                selectedCategory: selected,
+                onSelected: (cat) => setState(() => selected = cat),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(AppStrings.categoryDinner));
+      await tester.pump();
+
+      expect(selected, AppStrings.categoryDinner);
+    });
+  });
+}


### PR DESCRIPTION
## 📝 説明
「行きたい！ページ」のUI実装。現在地をスポットとして保存する画面を新規作成。
あわせてデザイントークン（AppTextStyle・AppColors・AppStrings）の整備と、
ハードコードされたフォントサイズ・カラーの定数化を実施。

## 🔗 関連 Issue
closes #7

## 📋 変更内容
- [x] 機能追加
- [x] UI 作成
- [x] バグ修正（カテゴリチップ幅のオーバーフロー修正）

## ✅ チェックリスト
- [x] コードレビュー済み
- [x] ユニットテスト実施済み（22件すべてパス）
- [x] テスト確認済み

## 🚀 備考
### 新規ファイル
- `want_to_go_page.dart` — 行きたい！ページ本体（カテゴリ選択・タイトル入力・写真追加・保存ダイアログ）
- `category_chip_group.dart` — カテゴリ選択チップグループ Widget

### デザイントークン整備
- `AppTextStyle` にサイズ定数を追加（sm2=14, md2=16, lg2=18, x1l=22, clock=96）
- `AppColors` に `chipUnselected`, `listSelected` を追加
- `AppStrings` に行きたい！ページ関連文字列・カテゴリ文字列を追加
- 全ファイルのハードコードされた fontSize を AppTextStyle 定数に統一


### 写真追加機能について
写真追加（ギャラリー連携・複数選択）は別 Issue で実装予定。
現在は写真エリアのプレースホルダー UI のみ。