### PR TITLE
[UI]リストページ作成 (#8)

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -36,6 +36,9 @@ abstract class AppStrings {
   static const categoryGoods = '雑貨屋';
   static const categoryOther = 'そのほか';
 
+  // リストページ
+  static const listWentTab = '行った！';
+
   // スポット
   static const statusWantToGo = '行きたい';
   static const statusVisited = '行った';

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/presentation/pages/spot/spot_list_page.dart';
 import 'package:tekushare/presentation/pages/walk/walk_page.dart';
 import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/presentation/widgets/common/clock_header.dart';
@@ -84,7 +85,17 @@ class _HomePageState extends State<HomePage>
           ],
         ),
       ),
-      bottomNavigationBar: const AppBottomNav(currentIndex: 0),
+      bottomNavigationBar: AppBottomNav(
+        currentIndex: 0,
+        onTap: (index) {
+          if (index == 1 && ModalRoute.of(context)?.isCurrent == true) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const SpotListPage()),
+            );
+          }
+        },
+      ),
     );
   }
 }

--- a/lib/presentation/pages/spot/spot_list_page.dart
+++ b/lib/presentation/pages/spot/spot_list_page.dart
@@ -1,1 +1,255 @@
-// スポットリスト画面
+import 'package:flutter/material.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
+import 'package:tekushare/presentation/widgets/common/category_chip_group.dart';
+
+/// リストページ（行きたい！／行った！タブ付き）
+class SpotListPage extends StatefulWidget {
+  const SpotListPage({super.key});
+
+  @override
+  State<SpotListPage> createState() => _SpotListPageState();
+}
+
+class _SpotListPageState extends State<SpotListPage> {
+  bool _isWantToGoTab = true;
+  String _selectedCategory = AppStrings.categoryPark;
+
+  static const _categories = [
+    AppStrings.categoryPark,
+    AppStrings.categoryCafe,
+    AppStrings.categoryLunch,
+    AppStrings.categoryDinner,
+    AppStrings.categoryGoods,
+    AppStrings.categoryOther,
+  ];
+
+  static const _wantToGoItems = [
+    (date: '4/12', title: 'ひだまりパーク'),
+    (date: '5/12', title: 'Cafe&Gallery'),
+    (date: '6/12', title: 'カフェ Noce'),
+    (date: '7/12', title: 'むすび屋（雑貨屋）'),
+    (date: '8/12', title: 'ごはん処 まるふく'),
+    (date: '9/12', title: 'cafe hanahana'),
+    (date: '10/12', title: 'time spot'),
+  ];
+
+  static const _wentItems = [
+    (date: '1/15', title: '新宿御苑'),
+    (date: '2/03', title: 'タリーズ 銀座店'),
+    (date: '3/20', title: 'ブルーボトルコーヒー'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final items = _isWantToGoTab ? _wantToGoItems : _wentItems;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: const Text(AppStrings.navList),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: SafeArea(
+        top: false,
+        bottom: false,
+        child: Column(
+          children: [
+            const SizedBox(height: 34),
+            _TabRow(
+              isWantToGo: _isWantToGoTab,
+              onTap: (v) => setState(() => _isWantToGoTab = v),
+            ),
+            const SizedBox(height: 32),
+            // TODO(#8): カテゴリフィルタリングはデータ連携issueで実装
+            CategoryChipGroup(
+              categories: _categories,
+              selectedCategory: _selectedCategory,
+              onSelected: (cat) => setState(() => _selectedCategory = cat),
+            ),
+            const SizedBox(height: 32),
+            Expanded(
+              child: ListView.separated(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: items.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                itemBuilder: (_, i) => _ListItem(
+                  date: items[i].date,
+                  title: items[i].title,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: AppBottomNav(
+        currentIndex: 1,
+        onTap: (index) {
+          if (index == 0 && Navigator.canPop(context)) Navigator.pop(context);
+        },
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// アンダーライン式タブ
+// ──────────────────────────────────────────
+
+class _TabRow extends StatelessWidget {
+  const _TabRow({required this.isWantToGo, required this.onTap});
+
+  final bool isWantToGo;
+  final ValueChanged<bool> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            _TabLabel(
+              label: AppStrings.wantToGo,
+              isSelected: isWantToGo,
+              onTap: () => onTap(true),
+            ),
+            _TabLabel(
+              label: AppStrings.listWentTab,
+              isSelected: !isWantToGo,
+              onTap: () => onTap(false),
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: Center(
+                child: Container(
+                  width: 160,
+                  height: 5,
+                  decoration: BoxDecoration(
+                    color: isWantToGo ? AppColors.primary : null,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: Container(
+                  width: 160,
+                  height: 5,
+                  decoration: BoxDecoration(
+                    color: !isWantToGo ? AppColors.primary : null,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _TabLabel extends StatelessWidget {
+  const _TabLabel({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 14),
+          child: Center(
+            child: Text(
+              label,
+              style: TextStyle(
+                color: isSelected ? AppColors.primary : AppColors.textDisabled,
+                fontSize: AppTextStyle.x2l,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// リストアイテム
+// ──────────────────────────────────────────
+
+class _ListItem extends StatelessWidget {
+  const _ListItem({required this.date, required this.title});
+
+  final String date;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.25),
+            blurRadius: 4,
+            offset: const Offset(0, 4),
+          ),
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 6,
+            spreadRadius: 1,
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Text(
+            date,
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontSize: AppTextStyle.xl,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(width: 32),
+          Expanded(
+            child: Text(
+              title,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.xl,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          const Icon(
+            Icons.chevron_right,
+            color: AppColors.primary,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/presentation/pages/spot/spot_list_page_test.dart
+++ b/test/presentation/pages/spot/spot_list_page_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/presentation/pages/spot/spot_list_page.dart';
+import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
+
+void main() {
+  group('SpotListPage', () {
+    Future<void> pumpPage(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(home: SpotListPage()),
+      );
+      await tester.pump();
+    }
+
+    // 行きたいリストにのみ存在するアイテム
+    const wantToGoOnly = 'ひだまりパーク';
+    // 行ったリストにのみ存在するアイテム
+    const wentOnly = '新宿御苑';
+
+    testWidgets('ページタイトル「リスト」が表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text(AppStrings.navList),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('「行きたい！」「行った！」の2つのタブが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.wantToGo), findsOneWidget);
+      expect(find.text(AppStrings.listWentTab), findsOneWidget);
+    });
+
+    testWidgets('初期状態で「行きたい！」タブが選択されている', (tester) async {
+      await pumpPage(tester);
+
+      // 行きたい専用アイテムが表示され、行った専用アイテムは非表示
+      expect(find.text(wantToGoOnly), findsOneWidget);
+      expect(find.text(wentOnly), findsNothing);
+    });
+
+    testWidgets('「行った！」タブをタップすると行った一覧に切り替わる', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.listWentTab));
+      await tester.pump();
+
+      // 行った専用アイテムが表示され、行きたい専用アイテムは非表示
+      expect(find.text(wentOnly), findsOneWidget);
+      expect(find.text(wantToGoOnly), findsNothing);
+    });
+
+    testWidgets('6つのカテゴリチップが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.categoryPark), findsOneWidget);
+      expect(find.text(AppStrings.categoryCafe), findsOneWidget);
+      expect(find.text(AppStrings.categoryLunch), findsOneWidget);
+      expect(find.text(AppStrings.categoryDinner), findsOneWidget);
+      expect(find.text(AppStrings.categoryGoods), findsOneWidget);
+      expect(find.text(AppStrings.categoryOther), findsOneWidget);
+    });
+
+    testWidgets('カテゴリチップをタップすると選択状態が変わる', (tester) async {
+      await pumpPage(tester);
+
+      // 初期は公園が選択色
+      expect(
+        find.ancestor(
+          of: find.text(AppStrings.categoryPark),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == AppColors.listSelected),
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text(AppStrings.categoryCafe));
+      await tester.pump();
+
+      // カフェが選択色になり、公園は非選択色になる
+      expect(
+        find.ancestor(
+          of: find.text(AppStrings.categoryCafe),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == AppColors.listSelected),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.ancestor(
+          of: find.text(AppStrings.categoryPark),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == AppColors.listSelected),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('一覧に日付と矢印アイコンが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text('4/12'), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsWidgets);
+    });
+
+    testWidgets('ボトムナビが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.byType(AppBottomNav), findsOneWidget);
+    });
+
+    testWidgets('AppBarに戻るボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SpotListPage()),
+              ),
+              child: const Text('start'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('start'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BackButton), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## 📝 説明
リストページ（`SpotListPage`）のUI実装。「行きたい！」「行った！」のタブ切り替え、カテゴリチップ選択、スポット一覧表示を実装。ホーム画面のボトムナビ「リスト」から遷移できるように対応。

## 🔗 関連 Issue
closes #8

## 📋 変更内容
- [ ] 機能追加
- [x] UI 作成
- [ ] バグ修正
- [ ] ドキュメント更新
- [ ] その他：

## ✅ チェックリスト
- [x] コードレビュー済み
- [x] ユニットテスト実施済み
- [ ] ドキュメント更新済み
- [ ] 自分でテスト確認済み

## 📸 スクリーンショット（UI変更の場合）
<!-- 変更前後の画像を貼り付けてください -->

## 🚀 備考
- カテゴリチップのフィルタリングはデータ連携issueで対応予定（TODOコメントあり）
- 一覧データは現在スタブ
- ウィジェットテスト9件追加・全件パス済み
