### PR TITLE
行きたい！/行った！共通詳細ページ作成

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -18,15 +18,18 @@ abstract class AppStrings {
 
   // 行きたい！ページ
   static const wantToGoPageTitle = '行きたい！';
-  static const wantToGoNoTitle = '（タイトルなし）';
   static const wantToGoSave = '行きたい！に保存';
   static const wantToGoConfirmMessage = '「行きたい！」に保存しますか？';
-  static const wantToGoSaved = '保存しました！';
   static const saveButton = '保存する';
   static const cancelButton = 'キャンセル';
   static const closeButton = '閉じる';
   static const realtimeLocation = 'リアルタイム位置';
   static const addPhoto = '写真を追加';
+  static const titleHint = 'タイトルを設定する';
+
+  // 共通
+  static const noTitle = '（タイトルなし）';
+  static const saved = '保存しました！';
 
   // カテゴリ
   static const categoryPark = '公園';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -43,4 +43,11 @@ abstract class AppStrings {
   static const statusWantToGo = '行きたい';
   static const statusVisited = '行った';
   static const categoryChange = '行った！に変更';
+
+  // スポット詳細
+  static const spotDetailSaveButton = '上書き保存';
+  static const spotDetailDeleteButton = '削除する';
+  static const spotDetailSaveConfirmMessage = '上書き保存しますか？';
+  static const spotDetailDeleteConfirmMessage = '削除しますか？';
+  static const spotDetailDeleted = '削除しました！';
 }

--- a/lib/presentation/pages/spot/spot_detail_page.dart
+++ b/lib/presentation/pages/spot/spot_detail_page.dart
@@ -41,12 +41,12 @@ class _SpotDetailPageState extends State<SpotDetailPage> {
       context: context,
       builder: (_) => _SaveConfirmDialog(
         title: _titleController.text.isEmpty
-            ? AppStrings.wantToGoNoTitle
+            ? AppStrings.noTitle
             : _titleController.text,
         onConfirm: () {
           Navigator.pop(context);
           if (!mounted) return;
-          _showResultDialog(AppStrings.wantToGoSaved);
+          _showResultDialog(AppStrings.saved);
         },
         onCancel: () => Navigator.pop(context),
       ),
@@ -58,7 +58,7 @@ class _SpotDetailPageState extends State<SpotDetailPage> {
       context: context,
       builder: (_) => _DeleteConfirmDialog(
         title: _titleController.text.isEmpty
-            ? AppStrings.wantToGoNoTitle
+            ? AppStrings.noTitle
             : _titleController.text,
         onConfirm: () {
           Navigator.pop(context);
@@ -183,7 +183,7 @@ class _TitleInput extends StatelessWidget {
     return TextField(
       controller: controller,
       decoration: InputDecoration(
-        hintText: 'タイトルを設定する',
+        hintText: AppStrings.titleHint,
         hintStyle: const TextStyle(
           color: AppColors.textDisabled,
           fontSize: AppTextStyle.x2l,

--- a/lib/presentation/pages/spot/spot_detail_page.dart
+++ b/lib/presentation/pages/spot/spot_detail_page.dart
@@ -1,1 +1,531 @@
-// スポット詳細画面
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
+import 'package:tekushare/presentation/widgets/common/category_chip_group.dart';
+import 'package:tekushare/presentation/widgets/common/dashed_border_painter.dart';
+
+/// 行きたい！／行った！共通詳細ページ
+class SpotDetailPage extends StatefulWidget {
+  const SpotDetailPage({super.key, required this.isWantToGo});
+
+  final bool isWantToGo;
+
+  @override
+  State<SpotDetailPage> createState() => _SpotDetailPageState();
+}
+
+class _SpotDetailPageState extends State<SpotDetailPage> {
+  String _selectedCategory = AppStrings.categoryPark;
+  final _titleController = TextEditingController();
+
+  static const _categories = [
+    AppStrings.categoryPark,
+    AppStrings.categoryCafe,
+    AppStrings.categoryLunch,
+    AppStrings.categoryDinner,
+    AppStrings.categoryGoods,
+    AppStrings.categoryOther,
+  ];
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  void _onSavePressed() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => _SaveConfirmDialog(
+        title: _titleController.text.isEmpty
+            ? AppStrings.wantToGoNoTitle
+            : _titleController.text,
+        onConfirm: () {
+          Navigator.pop(context);
+          if (!mounted) return;
+          _showResultDialog(AppStrings.wantToGoSaved);
+        },
+        onCancel: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  void _onDeletePressed() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => _DeleteConfirmDialog(
+        title: _titleController.text.isEmpty
+            ? AppStrings.wantToGoNoTitle
+            : _titleController.text,
+        onConfirm: () {
+          Navigator.pop(context);
+          if (!mounted) return;
+          _showResultDialog(AppStrings.spotDetailDeleted);
+        },
+        onCancel: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  void _showResultDialog(String message) {
+    showDialog<void>(
+      context: context,
+      builder: (_) => _ResultDialog(
+        message: message,
+        onClose: () {
+          Navigator.pop(context);
+          Navigator.pop(context);
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: Text(
+          widget.isWantToGo
+              ? AppStrings.wantToGoPageTitle
+              : AppStrings.listWentTab,
+        ),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: SafeArea(
+        top: false,
+        bottom: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const _LocationArea(),
+              const SizedBox(height: 34),
+              CategoryChipGroup(
+                categories: _categories,
+                selectedCategory: _selectedCategory,
+                onSelected: (cat) => setState(() => _selectedCategory = cat),
+              ),
+              const SizedBox(height: 34),
+              _TitleInput(controller: _titleController),
+              const SizedBox(height: 34),
+              const _TwoPhotoRow(),
+              const SizedBox(height: 34),
+              _DeleteButton(onPressed: _onDeletePressed),
+              const SizedBox(height: 16),
+              _SaveButton(onPressed: _onSavePressed),
+              const SizedBox(height: 34),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: AppBottomNav(
+        currentIndex: 1,
+        onTap: (index) {
+          if (index == 1) {
+            Navigator.pop(context);
+          } else if (index == 0) {
+            Navigator.popUntil(context, (route) => route.isFirst);
+          }
+        },
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// リアルタイム位置エリア
+// ──────────────────────────────────────────
+
+class _LocationArea extends StatelessWidget {
+  const _LocationArea();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: 161,
+      decoration: BoxDecoration(
+        color: AppColors.chipUnselected,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: const Center(
+        child: Text(
+          AppStrings.realtimeLocation,
+          style: TextStyle(
+            color: AppColors.textDisabled,
+            fontSize: AppTextStyle.md2,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// タイトル入力
+// ──────────────────────────────────────────
+
+class _TitleInput extends StatelessWidget {
+  const _TitleInput({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: 'タイトルを設定する',
+        hintStyle: const TextStyle(
+          color: AppColors.textDisabled,
+          fontSize: AppTextStyle.x2l,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary),
+        ),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 写真エリア（2枚横並び）
+// ──────────────────────────────────────────
+
+class _TwoPhotoRow extends StatelessWidget {
+  const _TwoPhotoRow();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Row(
+      children: [
+        Expanded(child: _PhotoBox()),
+        SizedBox(width: 16),
+        Expanded(child: _PhotoBox()),
+      ],
+    );
+  }
+}
+
+class _PhotoBox extends StatelessWidget {
+  const _PhotoBox();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 100,
+      child: CustomPaint(
+        painter: const DashedBorderPainter(),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SvgPicture.asset(
+              'assets/SVG/camera.svg',
+              width: 24,
+              height: 24,
+              colorFilter: const ColorFilter.mode(
+                AppColors.textAccent,
+                BlendMode.srcIn,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              AppStrings.addPhoto,
+              style: TextStyle(
+                color: AppColors.textAccent,
+                fontSize: AppTextStyle.sm,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 削除ボタン
+// ──────────────────────────────────────────
+
+class _DeleteButton extends StatelessWidget {
+  const _DeleteButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.textAccent,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(47),
+          ),
+        ),
+        child: const Text(
+          AppStrings.spotDetailDeleteButton,
+          style: TextStyle(
+            fontSize: AppTextStyle.lg2,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 上書き保存ボタン
+// ──────────────────────────────────────────
+
+class _SaveButton extends StatelessWidget {
+  const _SaveButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(47),
+          ),
+        ),
+        child: const Text(
+          AppStrings.spotDetailSaveButton,
+          style: TextStyle(
+            fontSize: AppTextStyle.lg2,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 上書き保存確認ダイアログ
+// ──────────────────────────────────────────
+
+class _SaveConfirmDialog extends StatelessWidget {
+  const _SaveConfirmDialog({
+    required this.title,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String title;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              AppStrings.spotDetailSaveConfirmMessage,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: onConfirm,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text(AppStrings.saveButton),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: onCancel,
+                    style: OutlinedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text(AppStrings.cancelButton),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 削除確認ダイアログ
+// ──────────────────────────────────────────
+
+class _DeleteConfirmDialog extends StatelessWidget {
+  const _DeleteConfirmDialog({
+    required this.title,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String title;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: AppTextStyle.lg2,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              AppStrings.spotDetailDeleteConfirmMessage,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: onConfirm,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text(AppStrings.spotDetailDeleteButton),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: onCancel,
+                    style: OutlinedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text(AppStrings.cancelButton),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 完了ダイアログ（保存・削除共通）
+// ──────────────────────────────────────────
+
+class _ResultDialog extends StatelessWidget {
+  const _ResultDialog({required this.message, required this.onClose});
+
+  final String message;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              style: const TextStyle(
+                fontSize: AppTextStyle.lg2,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: ElevatedButton(
+                onPressed: onClose,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text(AppStrings.closeButton),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/spot/spot_list_page.dart
+++ b/lib/presentation/pages/spot/spot_list_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/presentation/pages/spot/spot_detail_page.dart';
 import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/presentation/widgets/common/category_chip_group.dart';
 
@@ -78,9 +79,16 @@ class _SpotListPageState extends State<SpotListPage> {
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 itemCount: items.length,
                 separatorBuilder: (_, __) => const SizedBox(height: 8),
-                itemBuilder: (_, i) => _ListItem(
+                itemBuilder: (context, i) => _ListItem(
                   date: items[i].date,
                   title: items[i].title,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          SpotDetailPage(isWantToGo: _isWantToGoTab),
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -198,57 +206,65 @@ class _TabLabel extends StatelessWidget {
 // ──────────────────────────────────────────
 
 class _ListItem extends StatelessWidget {
-  const _ListItem({required this.date, required this.title});
+  const _ListItem({
+    required this.date,
+    required this.title,
+    required this.onTap,
+  });
 
   final String date;
   final String title;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.25),
-            blurRadius: 4,
-            offset: const Offset(0, 4),
-          ),
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.08),
-            blurRadius: 6,
-            spreadRadius: 1,
-          ),
-        ],
-      ),
-      child: Row(
-        children: [
-          Text(
-            date,
-            style: const TextStyle(
-              color: AppColors.primary,
-              fontSize: AppTextStyle.xl,
-              fontWeight: FontWeight.w500,
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.25),
+              blurRadius: 4,
+              offset: const Offset(0, 4),
             ),
-          ),
-          const SizedBox(width: 32),
-          Expanded(
-            child: Text(
-              title,
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.08),
+              blurRadius: 6,
+              spreadRadius: 1,
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Text(
+              date,
               style: const TextStyle(
                 color: AppColors.primary,
                 fontSize: AppTextStyle.xl,
                 fontWeight: FontWeight.w500,
               ),
             ),
-          ),
-          const Icon(
-            Icons.chevron_right,
-            color: AppColors.primary,
-          ),
-        ],
+            const SizedBox(width: 32),
+            Expanded(
+              child: Text(
+                title,
+                style: const TextStyle(
+                  color: AppColors.primary,
+                  fontSize: AppTextStyle.xl,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            const Icon(
+              Icons.chevron_right,
+              color: AppColors.primary,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/pages/spot/want_to_go_page.dart
+++ b/lib/presentation/pages/spot/want_to_go_page.dart
@@ -39,7 +39,7 @@ class _WantToGoPageState extends State<WantToGoPage> {
       context: context,
       builder: (_) => _ConfirmDialog(
         title: _titleController.text.isEmpty
-            ? AppStrings.wantToGoNoTitle
+            ? AppStrings.noTitle
             : _titleController.text,
         onConfirm: () {
           Navigator.pop(context);
@@ -147,7 +147,7 @@ class _TitleInput extends StatelessWidget {
     return TextField(
       controller: controller,
       decoration: InputDecoration(
-        hintText: 'タイトルを設定する',
+        hintText: AppStrings.titleHint,
         hintStyle: const TextStyle(
             color: AppColors.textDisabled, fontSize: AppTextStyle.x2l),
         border: OutlineInputBorder(
@@ -337,7 +337,7 @@ class _SavedDialog extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             const Text(
-              AppStrings.wantToGoSaved,
+              AppStrings.saved,
               style: TextStyle(
                   fontSize: AppTextStyle.lg2, fontWeight: FontWeight.w500),
             ),

--- a/lib/presentation/pages/spot/want_to_go_page.dart
+++ b/lib/presentation/pages/spot/want_to_go_page.dart
@@ -5,6 +5,7 @@ import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/presentation/widgets/common/category_chip_group.dart';
+import 'package:tekushare/presentation/widgets/common/dashed_border_painter.dart';
 
 /// 行きたい！ページ
 class WantToGoPage extends StatefulWidget {
@@ -181,7 +182,7 @@ class _PhotoBox extends StatelessWidget {
       width: 176,
       height: 100,
       child: CustomPaint(
-        painter: _DashedBorderPainter(),
+        painter: const DashedBorderPainter(),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -207,46 +208,6 @@ class _PhotoBox extends StatelessWidget {
       ),
     );
   }
-}
-
-class _DashedBorderPainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = AppColors.textAccent
-      ..strokeWidth = 1.5
-      ..style = PaintingStyle.stroke;
-
-    final rrect = RRect.fromRectAndRadius(
-      Rect.fromLTWH(0, 0, size.width, size.height),
-      const Radius.circular(12),
-    );
-    final path = Path()..addRRect(rrect);
-    canvas.drawPath(_dashPath(path), paint);
-  }
-
-  Path _dashPath(Path source, {double dashWidth = 6, double dashSpace = 4}) {
-    final dest = Path();
-    for (final metric in source.computeMetrics()) {
-      double distance = 0;
-      bool draw = true;
-      while (distance < metric.length) {
-        final len = draw ? dashWidth : dashSpace;
-        if (draw) {
-          dest.addPath(
-            metric.extractPath(distance, distance + len),
-            Offset.zero,
-          );
-        }
-        distance += len;
-        draw = !draw;
-      }
-    }
-    return dest;
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }
 
 // ──────────────────────────────────────────

--- a/lib/presentation/widgets/common/dashed_border_painter.dart
+++ b/lib/presentation/widgets/common/dashed_border_painter.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+
+class DashedBorderPainter extends CustomPainter {
+  const DashedBorderPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = AppColors.textAccent
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+
+    final rrect = RRect.fromRectAndRadius(
+      Rect.fromLTWH(0, 0, size.width, size.height),
+      const Radius.circular(12),
+    );
+    final path = Path()..addRRect(rrect);
+    canvas.drawPath(_dashPath(path), paint);
+  }
+
+  Path _dashPath(Path source, {double dashWidth = 6, double dashSpace = 4}) {
+    final dest = Path();
+    for (final metric in source.computeMetrics()) {
+      double distance = 0;
+      bool draw = true;
+      while (distance < metric.length) {
+        final len = draw ? dashWidth : dashSpace;
+        if (draw) {
+          dest.addPath(
+            metric.extractPath(distance, distance + len),
+            Offset.zero,
+          );
+        }
+        distance += len;
+        draw = !draw;
+      }
+    }
+    return dest;
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/test/presentation/pages/spot/spot_detail_page_test.dart
+++ b/test/presentation/pages/spot/spot_detail_page_test.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/presentation/pages/spot/spot_detail_page.dart';
+import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
+
+void main() {
+  group('SpotDetailPage', () {
+    Future<void> pumpPage(
+      WidgetTester tester, {
+      bool isWantToGo = true,
+    }) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(home: SpotDetailPage(isWantToGo: isWantToGo)),
+      );
+      await tester.pump();
+    }
+
+    Future<void> pumpPushedPage(
+      WidgetTester tester, {
+      bool isWantToGo = true,
+    }) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => SpotDetailPage(isWantToGo: isWantToGo),
+                ),
+              ),
+              child: const Text('start'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('start'));
+      await tester.pumpAndSettle();
+    }
+
+    // ──────────────────────────────────────────
+    // 表示
+    // ──────────────────────────────────────────
+
+    testWidgets('行きたい！モードでタイトルが「行きたい！」になる', (tester) async {
+      await pumpPage(tester, isWantToGo: true);
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text(AppStrings.wantToGoPageTitle),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('行った！モードでタイトルが「行った！」になる', (tester) async {
+      await pumpPage(tester, isWantToGo: false);
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text(AppStrings.listWentTab),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('6つのカテゴリチップが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.categoryPark), findsOneWidget);
+      expect(find.text(AppStrings.categoryCafe), findsOneWidget);
+      expect(find.text(AppStrings.categoryLunch), findsOneWidget);
+      expect(find.text(AppStrings.categoryDinner), findsOneWidget);
+      expect(find.text(AppStrings.categoryGoods), findsOneWidget);
+      expect(find.text(AppStrings.categoryOther), findsOneWidget);
+    });
+
+    testWidgets('写真を追加エリアが2つ表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.addPhoto), findsNWidgets(2));
+    });
+
+    testWidgets('削除ボタンが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.spotDetailDeleteButton), findsOneWidget);
+    });
+
+    testWidgets('上書き保存ボタンが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.spotDetailSaveButton), findsOneWidget);
+    });
+
+    testWidgets('ボトムナビが表示される', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.byType(AppBottomNav), findsOneWidget);
+    });
+
+    testWidgets('カテゴリチップをタップすると選択が切り替わる', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.categoryCafe));
+      await tester.pump();
+
+      // カフェが選択状態になっているか確認（公園は選択解除）
+      // CategoryChipGroup の内部状態として公園チップは非選択色になる
+      expect(find.text(AppStrings.categoryCafe), findsOneWidget);
+    });
+
+    // ──────────────────────────────────────────
+    // 削除フロー
+    // ──────────────────────────────────────────
+
+    testWidgets('削除ボタンを押すと削除確認ダイアログが表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text(AppStrings.spotDetailDeleteConfirmMessage), findsOneWidget);
+    });
+
+    testWidgets('削除確認のキャンセルでダイアログが閉じる', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text(AppStrings.spotDetailDeleteConfirmMessage), findsNothing);
+    });
+
+    testWidgets('削除確認で削除完了ダイアログが表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text(AppStrings.spotDetailDeleteButton),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.spotDetailDeleted), findsOneWidget);
+    });
+
+    testWidgets('削除完了ダイアログの閉じるでページを離れる', (tester) async {
+      await pumpPushedPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text(AppStrings.spotDetailDeleteButton),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SpotDetailPage), findsNothing);
+    });
+
+    // ──────────────────────────────────────────
+    // 上書き保存フロー
+    // ──────────────────────────────────────────
+
+    testWidgets('上書き保存ボタンを押すと保存確認ダイアログが表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailSaveButton));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text(AppStrings.spotDetailSaveConfirmMessage), findsOneWidget);
+    });
+
+    testWidgets('タイトル未入力時の確認ダイアログに（タイトルなし）が表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailSaveButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.wantToGoNoTitle), findsOneWidget);
+    });
+
+    testWidgets('タイトル入力時の確認ダイアログに入力値が表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.enterText(find.byType(TextField), 'テストスポット');
+      await tester.tap(find.text(AppStrings.spotDetailSaveButton));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text('テストスポット'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('保存確認のキャンセルでダイアログが閉じる', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailSaveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.spotDetailSaveConfirmMessage), findsNothing);
+    });
+
+    testWidgets('保存確認で保存完了ダイアログが表示される', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailSaveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.wantToGoSaved), findsOneWidget);
+    });
+
+    testWidgets('保存完了ダイアログの閉じるでページを離れる', (tester) async {
+      await pumpPushedPage(tester);
+
+      await tester.tap(find.text(AppStrings.spotDetailSaveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SpotDetailPage), findsNothing);
+    });
+  });
+}

--- a/test/presentation/pages/spot/spot_detail_page_test.dart
+++ b/test/presentation/pages/spot/spot_detail_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/presentation/pages/spot/spot_detail_page.dart';
 import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
@@ -112,15 +113,45 @@ void main() {
       expect(find.byType(AppBottomNav), findsOneWidget);
     });
 
-    testWidgets('カテゴリチップをタップすると選択が切り替わる', (tester) async {
+    testWidgets('カテゴリチップをタップすると選択色が切り替わる', (tester) async {
       await pumpPage(tester);
+
+      // タップ前：公園が選択色
+      expect(
+        find.ancestor(
+          of: find.text(AppStrings.categoryPark),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == AppColors.listSelected),
+        ),
+        findsOneWidget,
+      );
 
       await tester.tap(find.text(AppStrings.categoryCafe));
       await tester.pump();
 
-      // カフェが選択状態になっているか確認（公園は選択解除）
-      // CategoryChipGroup の内部状態として公園チップは非選択色になる
-      expect(find.text(AppStrings.categoryCafe), findsOneWidget);
+      // タップ後：カフェが選択色、公園は非選択色
+      expect(
+        find.ancestor(
+          of: find.text(AppStrings.categoryCafe),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == AppColors.listSelected),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.ancestor(
+          of: find.text(AppStrings.categoryPark),
+          matching: find.byWidgetPredicate((w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).color == AppColors.listSelected),
+        ),
+        findsNothing,
+      );
     });
 
     // ──────────────────────────────────────────
@@ -203,7 +234,7 @@ void main() {
       await tester.tap(find.text(AppStrings.spotDetailSaveButton));
       await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.wantToGoNoTitle), findsOneWidget);
+      expect(find.text(AppStrings.noTitle), findsOneWidget);
     });
 
     testWidgets('タイトル入力時の確認ダイアログに入力値が表示される', (tester) async {
@@ -241,7 +272,7 @@ void main() {
       await tester.tap(find.text(AppStrings.saveButton));
       await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.wantToGoSaved), findsOneWidget);
+      expect(find.text(AppStrings.saved), findsOneWidget);
     });
 
     testWidgets('保存完了ダイアログの閉じるでページを離れる', (tester) async {

--- a/test/presentation/pages/spot/spot_list_page_test.dart
+++ b/test/presentation/pages/spot/spot_list_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/presentation/pages/spot/spot_detail_page.dart';
 import 'package:tekushare/presentation/pages/spot/spot_list_page.dart';
 import 'package:tekushare/presentation/widgets/common/app_bottom_nav.dart';
 
@@ -146,6 +147,34 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(BackButton), findsOneWidget);
+    });
+
+    testWidgets('リストアイテムをタップすると SpotDetailPage へ遷移する', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(wantToGoOnly));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SpotDetailPage), findsOneWidget);
+    });
+
+    testWidgets('「行った！」タブのアイテムをタップすると行った！モードで SpotDetailPage へ遷移する',
+        (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text(AppStrings.listWentTab));
+      await tester.pump();
+      await tester.tap(find.text(wentOnly));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SpotDetailPage), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text(AppStrings.listWentTab),
+        ),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/presentation/pages/spot/want_to_go_page_test.dart
+++ b/test/presentation/pages/spot/want_to_go_page_test.dart
@@ -68,7 +68,7 @@ void main() {
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.wantToGoNoTitle), findsOneWidget);
+      expect(find.text(AppStrings.noTitle), findsOneWidget);
     });
 
     testWidgets('タイトル入力時の確認ダイアログに入力値が表示される', (tester) async {
@@ -106,7 +106,7 @@ void main() {
       await tester.tap(find.text(AppStrings.saveButton));
       await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.wantToGoSaved), findsOneWidget);
+      expect(find.text(AppStrings.saved), findsOneWidget);
     });
 
     testWidgets('保存完了ダイアログの閉じるでページを離れる', (tester) async {


### PR DESCRIPTION
## 📝 説明
行きたい！と行った！で共通して使うスポット詳細ページを作成しました。
`isWantToGo` フラグで表示を切り替える共通UIとして実装しています。

## 🔗 関連 Issue
closes #9

## 📋 変更内容
- [x] UI 作成

## ✅ チェックリスト
- [x] コードレビュー済み
- [x] ユニットテスト実施済み
- [x] ドキュメント更新済み
- [x] 自分でテスト確認済み

## 🔧 実装内容
- `SpotDetailPage` 新規作成（`isWantToGo` でタイトル・モードを切り替え）
- リアルタイム位置エリア・カテゴリチップ・タイトル入力・写真エリア×2・削除ボタン・上書き保存ボタンを実装
- 保存確認・削除確認・完了の3種ダイアログを実装
- `SpotListPage` のリストアイテムタップで詳細ページへ遷移するよう対応
- `_DashedBorderPainter` を共通化（`dashed_border_painter.dart` に抽出）

## 🚀 スコープ外（将来のissueで対応）
- 保存・削除処理（データ連携）
- タイトル・カテゴリ・写真の初期値投入（データ連携）
- ルート・設定タブへの遷移

## 📸 スクリーンショット（UI変更の場合）
<!-- 変更前後の画像を貼り付けてください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed spot view reachable from spot list; edit title, choose category, add photos, save/delete with confirmations and result messages.
* **UI/Text Updates**
  * Standardized and added UI strings (title hint, no-title fallback, saved/deleted messages, save/delete button labels).
* **Visual/UX**
  * New dashed-border photo placeholder and improved interactive list items for navigation.
* **Tests**
  * New and updated widget tests covering flows and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->