### PR TITLE
散歩ルートページの実装 

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -15,21 +15,6 @@ migration:
     - platform: root
       create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
       base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-    - platform: android
-      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-    - platform: ios
-      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-    - platform: linux
-      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-    - platform: macos
-      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-    - platform: web
-      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
-      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
     - platform: windows
       create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
       base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -59,7 +59,7 @@ abstract class AppStrings {
   static const walkStartEndTime = '開始終了時間';
   static const walkDuration = '散歩時間';
   static const walkDistanceLabel = '距離';
-  static const walkSpotCount = '行きたいスポット：1件';
+  static const walkSpotCount = '行きたいスポット';
   static const viewDetails = '詳しく見る';
 
   // スポット詳細

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -49,6 +49,19 @@ abstract class AppStrings {
   static const statusVisited = '行った';
   static const categoryChange = '行った！に変更';
 
+  // 散歩ルートページ
+  static const walkRoutePageTitle = '散歩ルート';
+  static const savedRoutes = '保存済みのルートから選ぶ';
+  static const selectedRoute = '選択中のルート';
+  static const routeNameHint = '名前を設定する';
+  static const saveRouteConfirmMessage = 'この散歩ルートを保存しますか？';
+  static const saveRouteButton = 'このルートを保存する';
+  static const walkStartEndTime = '開始終了時間';
+  static const walkDuration = '散歩時間';
+  static const walkDistanceLabel = '距離';
+  static const walkSpotCount = '行きたいスポット：1件';
+  static const viewDetails = '詳しく見る';
+
   // スポット詳細
   static const spotDetailSaveButton = '上書き保存';
   static const spotDetailDeleteButton = '削除する';

--- a/lib/screens/pages/home/view/home_page.dart
+++ b/lib/screens/pages/home/view/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
@@ -92,6 +93,11 @@ class _HomePageState extends State<HomePage>
             Navigator.push(
               context,
               MaterialPageRoute(builder: (_) => const SpotListPage()),
+            );
+          } else if (index == 2 && ModalRoute.of(context)?.isCurrent == true) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const WalkRoutePage()),
             );
           }
         },

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -1,0 +1,956 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_spacing.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
+import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+import 'package:tekushare/screens/widgets/common/dashed_border_painter.dart';
+
+/// 散歩ルートページ
+class WalkRoutePage extends ConsumerStatefulWidget {
+  const WalkRoutePage({super.key, this.showSaveDialogOnLoad = false});
+
+  final bool showSaveDialogOnLoad;
+
+  @override
+  ConsumerState<WalkRoutePage> createState() => _WalkRoutePageState();
+}
+
+class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
+  final _nameController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.showSaveDialogOnLoad) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _showSaveConfirmDialog();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _showSaveConfirmDialog() {
+    final vm = ref.read(walkRouteViewModelProvider.notifier);
+    final state = ref.read(walkRouteViewModelProvider);
+    showDialog<void>(
+      context: context,
+      builder: (_) => _SaveConfirmDialog(
+        nameController: _nameController,
+        onSave: () {
+          final name = _nameController.text.isEmpty
+              ? state.defaultRouteName
+              : _nameController.text;
+          vm.saveRoute((
+            date: state.selectedRoute.date,
+            name: name,
+            distance: state.selectedRoute.distance,
+            time: state.selectedRoute.time,
+          ));
+          _nameController.clear();
+          Navigator.pop(context);
+          if (!mounted) return;
+          _showSavedDialog();
+        },
+        onCancel: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  void _showSavedDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => _SavedDialog(
+        onClose: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(walkRouteViewModelProvider);
+    final vm = ref.read(walkRouteViewModelProvider.notifier);
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: const Text(AppStrings.walkRoutePageTitle),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: SafeArea(
+        top: false,
+        bottom: false,
+        child: Stack(
+          children: [
+            SingleChildScrollView(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: AppSpacing.lg),
+                  _RouteListCard(
+                    routes: state.routes,
+                    selectedIndex: state.selectedRouteIndex,
+                    onSelect: vm.selectRoute,
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  _SelectedRouteCard(route: state.selectedRoute),
+                  const SizedBox(height: AppSpacing.lg),
+                  _CalendarRow(
+                    selectedDay: state.selectedDay,
+                    onSelect: vm.selectDay,
+                  ),
+                  _WalkInfoCard(
+                      log: state.selectedLog, onSave: _showSaveConfirmDialog),
+                  const SizedBox(height: AppSpacing.lg),
+                ],
+              ),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: 80,
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        AppColors.background.withValues(alpha: 0),
+                        AppColors.background,
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: AppBottomNav(
+        currentIndex: 2,
+        onTap: (index) {
+          if (index == 0) {
+            Navigator.popUntil(context, (route) => route.isFirst);
+          } else if (index == 1) {
+            Navigator.pop(context);
+          }
+        },
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 保存済みルートリストカード
+// ──────────────────────────────────────────
+
+class _RouteListCard extends StatefulWidget {
+  const _RouteListCard({
+    required this.routes,
+    required this.selectedIndex,
+    required this.onSelect,
+  });
+
+  final List<WalkRoute> routes;
+  final int selectedIndex;
+  final ValueChanged<int> onSelect;
+
+  @override
+  State<_RouteListCard> createState() => _RouteListCardState();
+}
+
+class _RouteListCardState extends State<_RouteListCard> {
+  static const _pageSize = 3;
+  int _currentPage = 0;
+  int _slideDirection = 1; // 1: 左スワイプ(次), -1: 右スワイプ(前)
+
+  int get _pageCount => (widget.routes.length / _pageSize).ceil();
+
+  void _goToPage(int page) {
+    _slideDirection = page > _currentPage ? 1 : -1;
+    setState(() => _currentPage = page);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final offset = _currentPage * _pageSize;
+    final end = (offset + _pageSize).clamp(0, widget.routes.length);
+    final pageRoutes = widget.routes.sublist(offset, end);
+
+    return GestureDetector(
+      onHorizontalDragEnd: (details) {
+        if (details.primaryVelocity == null) return;
+        if (details.primaryVelocity! < -200 && _currentPage < _pageCount - 1) {
+          _goToPage(_currentPage + 1);
+        } else if (details.primaryVelocity! > 200 && _currentPage > 0) {
+          _goToPage(_currentPage - 1);
+        }
+      },
+      child: Container(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: AppColors.primary),
+          borderRadius: BorderRadius.circular(5),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.06),
+              blurRadius: AppSpacing.sm,
+              offset: const Offset(0, AppSpacing.xs),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              AppStrings.savedRoutes,
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: AppTextStyle.semiBold,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            ClipRect(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 280),
+                layoutBuilder: (currentChild, previousChildren) => Stack(
+                  alignment: Alignment.topLeft,
+                  children: [
+                    ...previousChildren,
+                    if (currentChild != null) currentChild,
+                  ],
+                ),
+                transitionBuilder: (child, animation) {
+                  final isEntering = child.key == ValueKey(_currentPage);
+                  final begin = isEntering
+                      ? Offset(_slideDirection.toDouble(), 0)
+                      : Offset(-_slideDirection.toDouble(), 0);
+                  return FadeTransition(
+                    opacity: animation,
+                    child: SlideTransition(
+                      position: Tween<Offset>(
+                        begin: begin,
+                        end: Offset.zero,
+                      ).animate(CurvedAnimation(
+                        parent: animation,
+                        curve: Curves.easeOut,
+                      )),
+                      child: child,
+                    ),
+                  );
+                },
+                child: Column(
+                  key: ValueKey(_currentPage),
+                  children: List.generate(_pageSize, (i) {
+                    final hasItem = i < pageRoutes.length;
+                    return Visibility(
+                      visible: hasItem,
+                      maintainSize: true,
+                      maintainAnimation: true,
+                      maintainState: true,
+                      child: Column(
+                        children: [
+                          _RouteItem(
+                            route: hasItem
+                                ? pageRoutes[i]
+                                : (date: '', name: '', distance: '', time: ''),
+                            isSelected:
+                                hasItem && (offset + i) == widget.selectedIndex,
+                            onTap: hasItem
+                                ? () => widget.onSelect(offset + i)
+                                : () {},
+                          ),
+                          if (i < _pageSize - 1)
+                            const SizedBox(height: AppSpacing.sm),
+                        ],
+                      ),
+                    );
+                  }),
+                ),
+              ),
+            ),
+            if (_pageCount > 1) ...[
+              const SizedBox(height: AppSpacing.md),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  IconButton(
+                    onPressed: _currentPage > 0
+                        ? () => _goToPage(_currentPage - 1)
+                        : null,
+                    icon: const Icon(Icons.chevron_left),
+                    color: AppColors.primary,
+                    disabledColor: AppColors.textDisabled,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                  const SizedBox(width: AppSpacing.lg),
+                  Text(
+                    '${_currentPage + 1}',
+                    style: const TextStyle(
+                      fontSize: AppTextStyle.md,
+                      fontWeight: AppTextStyle.semiBold,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.lg),
+                  IconButton(
+                    onPressed: _currentPage < _pageCount - 1
+                        ? () => _goToPage(_currentPage + 1)
+                        : null,
+                    icon: const Icon(Icons.chevron_right),
+                    color: AppColors.primary,
+                    disabledColor: AppColors.textDisabled,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteItem extends StatelessWidget {
+  const _RouteItem({
+    required this.route,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final WalkRoute route;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.md,
+        ),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? AppColors.primary.withValues(alpha: 0.05)
+              : Colors.white,
+          borderRadius: BorderRadius.circular(5),
+          border: Border.all(
+            color: isSelected ? AppColors.primary : AppColors.chipUnselected,
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    route.name,
+                    style: TextStyle(
+                      fontSize: AppTextStyle.md2,
+                      fontWeight: AppTextStyle.medium,
+                      color: isSelected ? AppColors.primary : Colors.black,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    '距離 ${route.distance} / ${route.time}',
+                    style: TextStyle(
+                      fontSize: AppTextStyle.sm,
+                      color: isSelected ? AppColors.primary : Colors.black,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            ExcludeSemantics(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Transform.translate(
+                    offset: const Offset(8, -8),
+                    child: Transform.rotate(
+                      angle: -0.9,
+                      child: SvgPicture.asset(
+                        'assets/SVG/foot.svg',
+                        width: AppSize.iconMd,
+                        height: AppSize.iconMd,
+                        colorFilter: ColorFilter.mode(
+                          isSelected
+                              ? AppColors.primary
+                              : AppColors.chipUnselected,
+                          BlendMode.srcIn,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Transform.translate(
+                    offset: const Offset(-8, 8),
+                    child: Transform.rotate(
+                      angle: 0.9,
+                      child: Transform.scale(
+                        scaleX: -1,
+                        child: SvgPicture.asset(
+                          'assets/SVG/foot.svg',
+                          width: AppSize.iconMd,
+                          height: AppSize.iconMd,
+                          colorFilter: ColorFilter.mode(
+                            isSelected
+                                ? AppColors.primary
+                                : AppColors.chipUnselected,
+                            BlendMode.srcIn,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 選択中ルートカード
+// ──────────────────────────────────────────
+
+class _SelectedRouteCard extends StatelessWidget {
+  const _SelectedRouteCard({required this.route});
+
+  final WalkRoute route;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      padding: const EdgeInsets.symmetric(horizontal: 25),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(5),
+        border: Border.all(color: AppColors.primary),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: AppSpacing.sm,
+            offset: const Offset(0, AppSpacing.xs),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(
+              0,
+              AppSpacing.lg,
+              AppSpacing.lg,
+              AppSpacing.md,
+            ),
+            child: Text(
+              AppStrings.selectedRoute,
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: AppTextStyle.semiBold,
+              ),
+            ),
+          ),
+          // 地図プレースホルダー
+          Container(
+            width: double.infinity,
+            height: 160,
+            color: AppColors.chipUnselected,
+            child: const Center(
+              child: Icon(
+                Icons.map_outlined,
+                size: 48,
+                color: AppColors.textDisabled,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Wrap(
+              spacing: AppSpacing.sm,
+              alignment: WrapAlignment.start,
+              children: [
+                _RouteTag(label: route.name),
+                _RouteTag(label: route.distance),
+                _RouteTag(label: route.time),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RouteTag extends StatelessWidget {
+  const _RouteTag({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(AppRadius.full),
+        border: Border.all(color: AppColors.primary),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppColors.primary,
+          fontSize: 10,
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// カレンダー行
+// ──────────────────────────────────────────
+
+class _CalendarRow extends StatelessWidget {
+  const _CalendarRow({required this.selectedDay, required this.onSelect});
+
+  final int selectedDay;
+  final ValueChanged<int> onSelect;
+
+  static const _dayNames = ['日', '月', '火', '水', '木', '金', '土'];
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: List.generate(7, (i) {
+        final day = i + 1;
+        final isSelected = day == selectedDay;
+        return GestureDetector(
+          onTap: () => onSelect(day),
+          child: Column(
+            children: [
+              Text(
+                _dayNames[i],
+                style: const TextStyle(
+                  fontSize: AppTextStyle.xs,
+                  color: AppColors.textDisabled,
+                ),
+              ),
+              Text(
+                '$day',
+                style: TextStyle(
+                  fontSize: isSelected ? AppTextStyle.xl : AppTextStyle.md2,
+                  fontWeight:
+                      isSelected ? AppTextStyle.semiBold : AppTextStyle.regular,
+                  color: isSelected ? AppColors.primary : AppColors.textPrimary,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              Container(
+                height: 3,
+                width: 46,
+                decoration: BoxDecoration(
+                  color: isSelected ? AppColors.primary : Colors.transparent,
+                  borderRadius: BorderRadius.circular(AppRadius.xs),
+                ),
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 散歩情報カード
+// ──────────────────────────────────────────
+
+class _WalkInfoCard extends StatelessWidget {
+  const _WalkInfoCard({required this.log, required this.onSave});
+
+  final WalkLog log;
+  final VoidCallback onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        vertical: AppSpacing.x3l,
+        horizontal: 18,
+      ),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(5),
+        border: Border.all(color: AppColors.primary),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: AppSpacing.sm,
+            offset: const Offset(0, AppSpacing.xs),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            log.date,
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontSize: AppTextStyle.x2l,
+              fontWeight: AppTextStyle.semiBold,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          _InfoRow(
+            label: AppStrings.walkStartEndTime,
+            value: log.startEndTime,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          _InfoRow(
+            label: AppStrings.walkDuration,
+            value: log.duration,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          _InfoRow(
+            label: AppStrings.walkDistanceLabel,
+            value: log.distance,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            children: [
+              const Text(
+                AppStrings.walkSpotCount,
+                style: TextStyle(
+                  fontSize: AppTextStyle.md,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+              const SizedBox(width: 30),
+              SizedBox(
+                width: 108,
+                height: 24,
+                child: OutlinedButton(
+                  onPressed: () {},
+                  style: OutlinedButton.styleFrom(
+                    side: const BorderSide(color: AppColors.primary),
+                    foregroundColor: AppColors.primary,
+                    padding: EdgeInsets.zero,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.full),
+                    ),
+                  ),
+                  child: const Text(
+                    AppStrings.viewDetails,
+                    style: TextStyle(fontSize: AppTextStyle.sm),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.xl),
+          SizedBox(
+            width: 176,
+            height: 90,
+            child: CustomPaint(
+              painter: const DashedBorderPainter(),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  ExcludeSemantics(
+                    child: SvgPicture.asset(
+                      'assets/SVG/camera.svg',
+                      width: AppSize.iconMd,
+                      height: AppSize.iconMd,
+                      colorFilter: const ColorFilter.mode(
+                        AppColors.textAccent,
+                        BlendMode.srcIn,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  const Text(
+                    AppStrings.addPhoto,
+                    style: TextStyle(
+                      color: AppColors.textAccent,
+                      fontSize: AppTextStyle.sm,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 30),
+          SizedBox(
+            width: double.infinity,
+            height: AppSize.buttonHeightLg,
+            child: ElevatedButton(
+              onPressed: onSave,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                foregroundColor: Colors.white,
+                elevation: 0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppRadius.full),
+                ),
+              ),
+              child: const Text(
+                AppStrings.saveRouteButton,
+                style: TextStyle(
+                  fontSize: AppTextStyle.xl,
+                  fontWeight: AppTextStyle.medium,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          '$label：',
+          style: const TextStyle(
+            fontSize: AppTextStyle.md,
+            color: AppColors.textPrimary,
+          ),
+        ),
+        Text(
+          value,
+          style: const TextStyle(
+            fontSize: AppTextStyle.md,
+            color: AppColors.textPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 保存確認ダイアログ
+// ──────────────────────────────────────────
+
+class _SaveConfirmDialog extends StatelessWidget {
+  const _SaveConfirmDialog({
+    required this.nameController,
+    required this.onSave,
+    required this.onCancel,
+  });
+
+  final TextEditingController nameController;
+  final VoidCallback onSave;
+  final VoidCallback onCancel;
+
+  static const double _buttonWidth = 125.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.x2l,
+          AppSpacing.x3l,
+          AppSpacing.x2l,
+          AppSpacing.x2l,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // 日付
+            const Text(
+              '2月2日（木）',
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.x2l,
+                fontWeight: AppTextStyle.semiBold,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            // 散歩時間・距離
+            const Text(
+              '散歩時間00:15 / 距離1.2km',
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.sm,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            // 名前入力
+            TextField(
+              controller: nameController,
+              decoration: InputDecoration(
+                hintText: AppStrings.routeNameHint,
+                hintStyle: const TextStyle(
+                  color: AppColors.textDisabled,
+                  fontSize: AppTextStyle.md,
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                  borderSide: const BorderSide(color: AppColors.chipUnselected),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                  borderSide: const BorderSide(color: AppColors.chipUnselected),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                  borderSide: const BorderSide(color: AppColors.primary),
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.lg,
+                  vertical: AppSpacing.md,
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            const Text(
+              AppStrings.saveRouteConfirmMessage,
+              style: TextStyle(fontSize: AppTextStyle.md),
+            ),
+            const SizedBox(height: AppSpacing.x2l),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SizedBox(
+                  width: _buttonWidth,
+                  height: AppSpacing.x5l,
+                  child: ElevatedButton(
+                    onPressed: onSave,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.sm),
+                      ),
+                    ),
+                    child: const Text(AppStrings.saveButton),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.md),
+                SizedBox(
+                  width: _buttonWidth,
+                  height: AppSpacing.x5l,
+                  child: OutlinedButton(
+                    onPressed: onCancel,
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: AppColors.primary),
+                      foregroundColor: AppColors.primary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.sm),
+                      ),
+                    ),
+                    child: const Text(AppStrings.cancelButton),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 保存完了ダイアログ
+// ──────────────────────────────────────────
+
+class _SavedDialog extends StatelessWidget {
+  const _SavedDialog({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.x2l,
+          AppSpacing.x3l,
+          AppSpacing.x2l,
+          AppSpacing.x2l,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              AppStrings.saved,
+              style: TextStyle(
+                fontSize: AppTextStyle.lg2,
+                fontWeight: AppTextStyle.medium,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.x2l),
+            SizedBox(
+              width: double.infinity,
+              height: AppSize.buttonHeight,
+              child: ElevatedButton(
+                onPressed: onClose,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(AppRadius.sm),
+                  ),
+                ),
+                child: const Text(AppStrings.closeButton),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -45,6 +45,7 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
       context: context,
       builder: (_) => _SaveConfirmDialog(
         nameController: _nameController,
+        log: state.selectedLog,
         onSave: () {
           final name = _nameController.text.isEmpty
               ? state.defaultRouteName
@@ -297,10 +298,7 @@ class _RouteListCardState extends State<_RouteListCard> {
                     icon: const Icon(Icons.chevron_left),
                     color: AppColors.primary,
                     disabledColor: AppColors.textDisabled,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
                   ),
-                  const SizedBox(width: AppSpacing.lg),
                   Text(
                     '${_currentPage + 1}',
                     style: const TextStyle(
@@ -309,7 +307,6 @@ class _RouteListCardState extends State<_RouteListCard> {
                       color: AppColors.primary,
                     ),
                   ),
-                  const SizedBox(width: AppSpacing.lg),
                   IconButton(
                     onPressed: _currentPage < _pageCount - 1
                         ? () => _goToPage(_currentPage + 1)
@@ -317,8 +314,6 @@ class _RouteListCardState extends State<_RouteListCard> {
                     icon: const Icon(Icons.chevron_right),
                     color: AppColors.primary,
                     disabledColor: AppColors.textDisabled,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
                   ),
                 ],
               ),
@@ -653,31 +648,29 @@ class _WalkInfoCard extends StatelessWidget {
           const SizedBox(height: AppSpacing.sm),
           Row(
             children: [
-              const Text(
-                AppStrings.walkSpotCount,
-                style: TextStyle(
+              Text(
+                '${AppStrings.walkSpotCount}：${log.spotCount}件',
+                style: const TextStyle(
                   fontSize: AppTextStyle.md,
                   color: AppColors.textPrimary,
                 ),
               ),
               const SizedBox(width: 30),
-              SizedBox(
-                width: 108,
-                height: 24,
-                child: OutlinedButton(
-                  onPressed: () {},
-                  style: OutlinedButton.styleFrom(
-                    side: const BorderSide(color: AppColors.primary),
-                    foregroundColor: AppColors.primary,
-                    padding: EdgeInsets.zero,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(AppRadius.full),
-                    ),
+              OutlinedButton(
+                onPressed: () {},
+                style: OutlinedButton.styleFrom(
+                  side: const BorderSide(color: AppColors.primary),
+                  foregroundColor: AppColors.primary,
+                  minimumSize: const Size(108, 24),
+                  tapTargetSize: MaterialTapTargetSize.padded,
+                  padding: EdgeInsets.zero,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(AppRadius.full),
                   ),
-                  child: const Text(
-                    AppStrings.viewDetails,
-                    style: TextStyle(fontSize: AppTextStyle.sm),
-                  ),
+                ),
+                child: const Text(
+                  AppStrings.viewDetails,
+                  style: TextStyle(fontSize: AppTextStyle.sm),
                 ),
               ),
             ],
@@ -779,13 +772,21 @@ class _InfoRow extends StatelessWidget {
 class _SaveConfirmDialog extends StatelessWidget {
   const _SaveConfirmDialog({
     required this.nameController,
+    required this.log,
     required this.onSave,
     required this.onCancel,
   });
 
   final TextEditingController nameController;
+  final WalkLog log;
   final VoidCallback onSave;
   final VoidCallback onCancel;
+
+  String get _shortDate {
+    final match = RegExp(r'\d+年0?(\d+)月0?(\d+)日\((.+)\)').firstMatch(log.date);
+    if (match == null) return log.date;
+    return '${match.group(1)}月${match.group(2)}日（${match.group(3)}）';
+  }
 
   static const double _buttonWidth = 125.0;
 
@@ -805,20 +806,18 @@ class _SaveConfirmDialog extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // 日付
-            const Text(
-              '2月2日（木）',
-              style: TextStyle(
+            Text(
+              _shortDate,
+              style: const TextStyle(
                 color: AppColors.primary,
                 fontSize: AppTextStyle.x2l,
                 fontWeight: AppTextStyle.semiBold,
               ),
             ),
             const SizedBox(height: AppSpacing.xs),
-            // 散歩時間・距離
-            const Text(
-              '散歩時間00:15 / 距離1.2km',
-              style: TextStyle(
+            Text(
+              '散歩時間${log.duration} / 距離${log.distance}',
+              style: const TextStyle(
                 color: AppColors.primary,
                 fontSize: AppTextStyle.sm,
               ),

--- a/lib/screens/pages/map/viewmodel/walk_route_viewmodel.dart
+++ b/lib/screens/pages/map/viewmodel/walk_route_viewmodel.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+typedef WalkRoute = ({String date, String name, String distance, String time});
+typedef WalkLog = ({
+  String date,
+  String startEndTime,
+  String duration,
+  String distance,
+});
+
+class WalkRouteState {
+  const WalkRouteState({
+    this.selectedRouteIndex = 0,
+    this.selectedDay = 2,
+    this.routes = _defaultRoutes,
+    this.logs = _defaultLogs,
+  });
+
+  final int selectedRouteIndex;
+  final int selectedDay;
+  final List<WalkRoute> routes;
+  final List<WalkLog> logs;
+
+  static const _defaultRoutes = <WalkRoute>[
+    (date: '2/7', name: '公園まわりコース（朝用）', distance: '1.2km', time: '約15分'),
+    (date: '2/6', name: '川沿いコース（休日用）', distance: '2.5km', time: '約30分'),
+    (date: '2/5', name: '商店街コース', distance: '1.2km', time: '約15分'),
+    (date: '2/4', name: '公園まわりコース（朝用）', distance: '1.2km', time: '約15分'),
+    (date: '2/3', name: '川沿いコース（休日用）', distance: '2.5km', time: '約30分'),
+    (date: '2/2', name: '商店街コース', distance: '1.2km', time: '約15分'),
+    (date: '2/1', name: '公園まわりコース（朝用）', distance: '1.2km', time: '約15分'),
+  ];
+
+  static const _defaultLogs = <WalkLog>[
+    (
+      date: '2026年02月01日(日)',
+      startEndTime: '6:30~6:45',
+      duration: '00:15',
+      distance: '1.2km',
+    ),
+    (
+      date: '2026年02月02日(月)',
+      startEndTime: '7:05~7:20',
+      duration: '00:15',
+      distance: '1.2km',
+    ),
+    (
+      date: '2026年02月03日(火)',
+      startEndTime: '8:00~8:30',
+      duration: '00:30',
+      distance: '2.5km',
+    ),
+    (
+      date: '2026年02月04日(水)',
+      startEndTime: '7:00~7:15',
+      duration: '00:15',
+      distance: '1.2km',
+    ),
+    (
+      date: '2026年02月05日(木)',
+      startEndTime: '7:30~7:45',
+      duration: '00:15',
+      distance: '1.2km',
+    ),
+    (
+      date: '2026年02月06日(金)',
+      startEndTime: '8:10~8:40',
+      duration: '00:30',
+      distance: '2.5km',
+    ),
+    (
+      date: '2026年02月07日(土)',
+      startEndTime: '9:00~9:15',
+      duration: '00:15',
+      distance: '1.2km',
+    ),
+  ];
+
+  WalkRoute get selectedRoute => routes[selectedRouteIndex];
+  WalkLog get selectedLog => logs[selectedDay - 1];
+
+  String get defaultRouteName {
+    final log = selectedLog;
+    final match = RegExp(r'\d+年0?(\d+)月0?(\d+)日\((.+)\)').firstMatch(log.date);
+    if (match == null) return log.date;
+    final month = match.group(1)!;
+    final day = match.group(2)!;
+    final weekday = match.group(3)!;
+    final startTime = log.startEndTime.split('~').first;
+    final parts = startTime.split(':');
+    final paddedTime =
+        '${parts[0].padLeft(2, '0')}:${parts.length > 1 ? parts[1] : '00'}';
+    return '$month月$day日（$weekday）$paddedTime~';
+  }
+
+  WalkRouteState copyWith({
+    int? selectedRouteIndex,
+    int? selectedDay,
+    List<WalkRoute>? routes,
+    List<WalkLog>? logs,
+  }) =>
+      WalkRouteState(
+        selectedRouteIndex: selectedRouteIndex ?? this.selectedRouteIndex,
+        selectedDay: selectedDay ?? this.selectedDay,
+        routes: routes ?? this.routes,
+        logs: logs ?? this.logs,
+      );
+}
+
+class WalkRouteViewModel extends Notifier<WalkRouteState> {
+  @override
+  WalkRouteState build() => const WalkRouteState();
+
+  void selectRoute(int index) {
+    state = state.copyWith(selectedRouteIndex: index);
+  }
+
+  void selectDay(int day) {
+    state = state.copyWith(selectedDay: day);
+  }
+
+  void saveRoute(WalkRoute route) {
+    state = state.copyWith(routes: [route, ...state.routes]);
+  }
+}
+
+final walkRouteViewModelProvider =
+    NotifierProvider<WalkRouteViewModel, WalkRouteState>(
+  WalkRouteViewModel.new,
+);

--- a/lib/screens/pages/map/viewmodel/walk_route_viewmodel.dart
+++ b/lib/screens/pages/map/viewmodel/walk_route_viewmodel.dart
@@ -6,6 +6,7 @@ typedef WalkLog = ({
   String startEndTime,
   String duration,
   String distance,
+  int spotCount,
 });
 
 class WalkRouteState {
@@ -37,42 +38,49 @@ class WalkRouteState {
       startEndTime: '6:30~6:45',
       duration: '00:15',
       distance: '1.2km',
+      spotCount: 1,
     ),
     (
       date: '2026年02月02日(月)',
       startEndTime: '7:05~7:20',
       duration: '00:15',
       distance: '1.2km',
+      spotCount: 1,
     ),
     (
       date: '2026年02月03日(火)',
       startEndTime: '8:00~8:30',
       duration: '00:30',
       distance: '2.5km',
+      spotCount: 2,
     ),
     (
       date: '2026年02月04日(水)',
       startEndTime: '7:00~7:15',
       duration: '00:15',
       distance: '1.2km',
+      spotCount: 1,
     ),
     (
       date: '2026年02月05日(木)',
       startEndTime: '7:30~7:45',
       duration: '00:15',
       distance: '1.2km',
+      spotCount: 1,
     ),
     (
       date: '2026年02月06日(金)',
       startEndTime: '8:10~8:40',
       duration: '00:30',
       distance: '2.5km',
+      spotCount: 3,
     ),
     (
       date: '2026年02月07日(土)',
       startEndTime: '9:00~9:15',
       duration: '00:15',
       distance: '1.2km',
+      spotCount: 1,
     ),
   ];
 

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/viewmodel/spot_detail_viewmodel.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/category_chip_group.dart';
@@ -137,6 +138,11 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
             Navigator.pop(context);
           } else if (index == 0) {
             Navigator.popUntil(context, (route) => route.isFirst);
+          } else if (index == 2) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const WalkRoutePage()),
+            );
           }
         },
       ),

--- a/lib/screens/pages/spot/view/spot_list_page.dart
+++ b/lib/screens/pages/spot/view/spot_list_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
 import 'package:tekushare/screens/pages/spot/viewmodel/spot_list_viewmodel.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
@@ -77,7 +78,14 @@ class SpotListPage extends ConsumerWidget {
       bottomNavigationBar: AppBottomNav(
         currentIndex: 1,
         onTap: (index) {
-          if (index == 0 && Navigator.canPop(context)) Navigator.pop(context);
+          if (index == 0 && Navigator.canPop(context)) {
+            Navigator.pop(context);
+          } else if (index == 2) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const WalkRoutePage()),
+            );
+          }
         },
       ),
     );

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -5,6 +5,7 @@ import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/screens/pages/spot/viewmodel/want_to_go_viewmodel.dart';
+import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/category_chip_group.dart';
@@ -113,6 +114,11 @@ class _WantToGoPageState extends ConsumerState<WantToGoPage> {
             Navigator.push(
               context,
               MaterialPageRoute(builder: (_) => const SpotListPage()),
+            );
+          } else if (index == 2) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const WalkRoutePage()),
             );
           }
         },

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -4,6 +4,7 @@ import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
@@ -84,8 +85,13 @@ class _EndWalkPageState extends State<EndWalkPage>
                       opacity: _cardFade,
                       child: _ConfirmCard(
                         onCancel: () => Navigator.pop(context),
-                        onConfirm: () => Navigator.popUntil(
+                        onConfirm: () => Navigator.pushAndRemoveUntil(
                           context,
+                          MaterialPageRoute(
+                            builder: (_) => const WalkRoutePage(
+                              showSaveDialogOnLoad: true,
+                            ),
+                          ),
                           (route) => route.isFirst,
                         ),
                       ),
@@ -107,6 +113,11 @@ class _EndWalkPageState extends State<EndWalkPage>
             Navigator.push(
               context,
               MaterialPageRoute(builder: (_) => const SpotListPage()),
+            );
+          } else if (index == 2) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const WalkRoutePage()),
             );
           }
         },

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
@@ -65,6 +66,11 @@ class WalkPage extends StatelessWidget {
             Navigator.push(
               context,
               MaterialPageRoute(builder: (_) => const SpotListPage()),
+            );
+          } else if (index == 2) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const WalkRoutePage()),
             );
           }
         },

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
+import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+void main() {
+  group('WalkRoutePage', () {
+    Future<void> pumpPage(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: WalkRoutePage()),
+        ),
+      );
+      await tester.pump();
+    }
+
+    // ページタイトルが表示される
+    testWidgets('shows page title', (tester) async {
+      await pumpPage(tester);
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text(AppStrings.walkRoutePageTitle),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    // 保存済みルートセクションが表示される
+    testWidgets('shows saved routes section', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.savedRoutes), findsOneWidget);
+    });
+
+    // ルート一覧が表示される
+    testWidgets('shows route list items', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text('公園まわりコース（朝用）'), findsWidgets);
+      expect(find.text('川沿いコース（休日用）'), findsOneWidget);
+      expect(find.text('商店街コース'), findsOneWidget);
+    });
+
+    // 選択中のルートセクションが表示される
+    testWidgets('shows selected route section', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.text(AppStrings.selectedRoute), findsOneWidget);
+    });
+
+    // ボトムナビが表示される
+    testWidgets('shows bottom navigation', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.byType(AppBottomNav), findsOneWidget);
+    });
+
+    // ルートをタップすると選択状態が変わる
+    testWidgets('tapping a route changes selection', (tester) async {
+      await pumpPage(tester);
+
+      await tester.tap(find.text('川沿いコース（休日用）'));
+      await tester.pump();
+
+      expect(find.text('川沿いコース（休日用）'), findsWidgets);
+    });
+
+    // showSaveDialogOnLoadがtrueのとき保存確認ダイアログが表示される
+    testWidgets(
+        'shows save confirmation dialog when showSaveDialogOnLoad is true',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: WalkRoutePage(showSaveDialogOnLoad: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.saveRouteConfirmMessage), findsOneWidget);
+    });
+
+    // 保存確認ダイアログのキャンセルでダイアログが閉じる
+    testWidgets('canceling save dialog closes dialog', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: WalkRoutePage(showSaveDialogOnLoad: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.saveRouteConfirmMessage), findsNothing);
+    });
+
+    // 保存確認ダイアログの保存で保存完了ダイアログが表示される
+    testWidgets('confirming save shows saved dialog', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: WalkRoutePage(showSaveDialogOnLoad: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.saved), findsOneWidget);
+    });
+
+    // 保存完了ダイアログの閉じるでダイアログが閉じる
+    testWidgets('closing saved dialog closes dialog', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: WalkRoutePage(showSaveDialogOnLoad: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.saved), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## 📝 説明
散歩ルートページ（WalkRoutePage）を新規実装しました。
保存済みルートの一覧表示・選択・カレンダー連動・ルート保存が行えます。

## 🔗 関連 Issue
closes #18

## 📋 変更内容
- [x] 機能追加
- [x] UI 作成

## ✅ チェックリスト
- [x] コードレビュー済み
- [x] ユニットテスト実施済み
- [x] ドキュメント更新済み
- [x] 自分でテスト確認済み

## 📸 スクリーンショット（UI変更の場合）
<!-- 変更前後の画像を貼り付けてください -->

## 🚀 備考
**実装内容**
- `WalkRoutePage` を新規作成
  - 保存済みルートリストを 3 件固定・ページネーション表示（横スワイプでページ切り替え、スライド＋フェードアニメーション）
  - 選択状態でテキスト・アイコン・枠が primary カラーに変化
  - 選択中ルートカードにタグ（ルート名・距離・時間）を表示
  - カレンダー行（7日間）と散歩情報カードが連動し、選択日の日付・時間・距離を動的表示
  - ルート保存ダイアログで名前未入力時は `2月2日（月）07:05~` 形式のタイトルを自動生成
  - 画面下部にスクロール促進グラデーション
- `WalkRouteViewModel` を新規作成（Riverpod `Notifier` で状態管理）
- `AppStrings` に散歩ルートページ関連の文言を追加
- `WalkRoutePage` のウィジェットテスト 10 件追加
