### PR TITLE
[Logic] ドメインエンティティの実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "editor.selectionHighlight": false,
     "editor.suggestSelection": "first",
     "editor.tabCompletion": "onlySnippets"
-  }
+  },
+  "cmake.sourceDirectory": "C:/programming/tekushare-app/linux"
 }

--- a/lib/domain/entities/lat_lng.dart
+++ b/lib/domain/entities/lat_lng.dart
@@ -1,0 +1,15 @@
+class LatLng {
+  const LatLng(this.latitude, this.longitude);
+
+  final double latitude;
+  final double longitude;
+
+  @override
+  bool operator ==(Object other) =>
+      other is LatLng &&
+      other.latitude == latitude &&
+      other.longitude == longitude;
+
+  @override
+  int get hashCode => Object.hash(latitude, longitude);
+}

--- a/lib/domain/entities/spot.dart
+++ b/lib/domain/entities/spot.dart
@@ -21,14 +21,17 @@ class Spot {
   final String? photoPath;
   final DateTime createdAt;
 
+  // memo / photoPath は null に戻せる必要があるためセンチネル値で未指定と明示的 null を区別する
+  static const Object _sentinel = Object();
+
   Spot copyWith({
     String? id,
     String? title,
     double? latitude,
     double? longitude,
     SpotStatus? status,
-    String? memo,
-    String? photoPath,
+    Object? memo = _sentinel,
+    Object? photoPath = _sentinel,
     DateTime? createdAt,
   }) {
     return Spot(
@@ -37,8 +40,8 @@ class Spot {
       latitude: latitude ?? this.latitude,
       longitude: longitude ?? this.longitude,
       status: status ?? this.status,
-      memo: memo ?? this.memo,
-      photoPath: photoPath ?? this.photoPath,
+      memo: memo == _sentinel ? this.memo : memo as String?,
+      photoPath: photoPath == _sentinel ? this.photoPath : photoPath as String?,
       createdAt: createdAt ?? this.createdAt,
     );
   }

--- a/lib/domain/entities/spot.dart
+++ b/lib/domain/entities/spot.dart
@@ -1,1 +1,49 @@
-// スポットエンティティ
+enum SpotStatus { wantToGo, visited }
+
+class Spot {
+  const Spot({
+    required this.id,
+    required this.title,
+    required this.latitude,
+    required this.longitude,
+    required this.status,
+    required this.createdAt,
+    this.memo,
+    this.photoPath,
+  });
+
+  final String id;
+  final String title;
+  final double latitude;
+  final double longitude;
+  final SpotStatus status;
+  final String? memo;
+  final String? photoPath;
+  final DateTime createdAt;
+
+  Spot copyWith({
+    String? id,
+    String? title,
+    double? latitude,
+    double? longitude,
+    SpotStatus? status,
+    String? memo,
+    String? photoPath,
+    DateTime? createdAt,
+  }) {
+    return Spot(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+      status: status ?? this.status,
+      memo: memo ?? this.memo,
+      photoPath: photoPath ?? this.photoPath,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Spot markAsVisited() => copyWith(status: SpotStatus.visited);
+
+  Spot markAsWantToGo() => copyWith(status: SpotStatus.wantToGo);
+}

--- a/lib/domain/entities/walk_route.dart
+++ b/lib/domain/entities/walk_route.dart
@@ -1,12 +1,12 @@
 import 'package:tekushare/domain/entities/lat_lng.dart';
 
 class WalkRoute {
-  const WalkRoute({
+  WalkRoute({
     required this.id,
     required this.walkSessionId,
-    required this.points,
+    required List<LatLng> points,
     required this.createdAt,
-  });
+  }) : points = List.unmodifiable(points);
 
   final String id;
   final String walkSessionId;

--- a/lib/domain/entities/walk_route.dart
+++ b/lib/domain/entities/walk_route.dart
@@ -1,1 +1,29 @@
-// 散歩ルートエンティティ
+import 'package:tekushare/domain/entities/lat_lng.dart';
+
+class WalkRoute {
+  const WalkRoute({
+    required this.id,
+    required this.walkSessionId,
+    required this.points,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String walkSessionId;
+  final List<LatLng> points;
+  final DateTime createdAt;
+
+  WalkRoute copyWith({
+    String? id,
+    String? walkSessionId,
+    List<LatLng>? points,
+    DateTime? createdAt,
+  }) {
+    return WalkRoute(
+      id: id ?? this.id,
+      walkSessionId: walkSessionId ?? this.walkSessionId,
+      points: points ?? this.points,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/domain/entities/walk_session.dart
+++ b/lib/domain/entities/walk_session.dart
@@ -1,1 +1,29 @@
-// 散歩セッションエンティティ
+enum WalkStatus { idle, walking, finished }
+
+class WalkSession {
+  const WalkSession({
+    required this.status,
+    this.startedAt,
+    this.finishedAt,
+    this.elapsedSeconds = 0,
+  });
+
+  final WalkStatus status;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+  final int elapsedSeconds;
+
+  WalkSession copyWith({
+    WalkStatus? status,
+    DateTime? startedAt,
+    DateTime? finishedAt,
+    int? elapsedSeconds,
+  }) {
+    return WalkSession(
+      status: status ?? this.status,
+      startedAt: startedAt ?? this.startedAt,
+      finishedAt: finishedAt ?? this.finishedAt,
+      elapsedSeconds: elapsedSeconds ?? this.elapsedSeconds,
+    );
+  }
+}

--- a/lib/domain/entities/walk_session.dart
+++ b/lib/domain/entities/walk_session.dart
@@ -13,16 +13,19 @@ class WalkSession {
   final DateTime? finishedAt;
   final int elapsedSeconds;
 
+  // startedAt / finishedAt は null に戻せる必要があるためセンチネル値で未指定と明示的 null を区別する
+  static const Object _sentinel = Object();
+
   WalkSession copyWith({
     WalkStatus? status,
-    DateTime? startedAt,
-    DateTime? finishedAt,
+    Object? startedAt = _sentinel,
+    Object? finishedAt = _sentinel,
     int? elapsedSeconds,
   }) {
     return WalkSession(
       status: status ?? this.status,
-      startedAt: startedAt ?? this.startedAt,
-      finishedAt: finishedAt ?? this.finishedAt,
+      startedAt: startedAt == _sentinel ? this.startedAt : startedAt as DateTime?,
+      finishedAt: finishedAt == _sentinel ? this.finishedAt : finishedAt as DateTime?,
       elapsedSeconds: elapsedSeconds ?? this.elapsedSeconds,
     );
   }

--- a/lib/domain/entities/walk_session.dart
+++ b/lib/domain/entities/walk_session.dart
@@ -24,8 +24,10 @@ class WalkSession {
   }) {
     return WalkSession(
       status: status ?? this.status,
-      startedAt: startedAt == _sentinel ? this.startedAt : startedAt as DateTime?,
-      finishedAt: finishedAt == _sentinel ? this.finishedAt : finishedAt as DateTime?,
+      startedAt:
+          startedAt == _sentinel ? this.startedAt : startedAt as DateTime?,
+      finishedAt:
+          finishedAt == _sentinel ? this.finishedAt : finishedAt as DateTime?,
       elapsedSeconds: elapsedSeconds ?? this.elapsedSeconds,
     );
   }

--- a/test/domain/entities/lat_lng_test.dart
+++ b/test/domain/entities/lat_lng_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart';
+
+void main() {
+  group('LatLng', () {
+    test('同じ座標は等しい', () {
+      const a = LatLng(35.6895, 139.6917);
+      const b = LatLng(35.6895, 139.6917);
+
+      expect(a, equals(b));
+    });
+
+    test('異なる座標は等しくない', () {
+      const a = LatLng(35.6895, 139.6917);
+      const b = LatLng(34.6937, 135.5023);
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('同じ座標は hashCode が一致する', () {
+      const a = LatLng(35.6895, 139.6917);
+      const b = LatLng(35.6895, 139.6917);
+
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+}

--- a/test/domain/entities/spot_test.dart
+++ b/test/domain/entities/spot_test.dart
@@ -64,5 +64,26 @@ void main() {
       expect(updated.memo, 'おすすめのカフェ');
       expect(updated.photoPath, '/photos/cafe.jpg');
     });
+
+    test('copyWith で memo を null に戻せる', () {
+      final spot = makeSpot().copyWith(memo: 'メモあり');
+      final updated = spot.copyWith(memo: null);
+
+      expect(updated.memo, isNull);
+    });
+
+    test('copyWith で photoPath を null に戻せる', () {
+      final spot = makeSpot().copyWith(photoPath: '/photos/cafe.jpg');
+      final updated = spot.copyWith(photoPath: null);
+
+      expect(updated.photoPath, isNull);
+    });
+
+    test('copyWith で memo を指定しないと元の値を保持する', () {
+      final spot = makeSpot().copyWith(memo: 'メモあり');
+      final updated = spot.copyWith(title: '新しいタイトル');
+
+      expect(updated.memo, 'メモあり');
+    });
   });
 }

--- a/test/domain/entities/spot_test.dart
+++ b/test/domain/entities/spot_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+
+void main() {
+  final createdAt = DateTime(2024, 1, 1);
+
+  Spot makeSpot({SpotStatus status = SpotStatus.wantToGo}) {
+    return Spot(
+      id: 'spot-1',
+      title: 'テストスポット',
+      latitude: 35.6895,
+      longitude: 139.6917,
+      status: status,
+      createdAt: createdAt,
+    );
+  }
+
+  group('Spot', () {
+    test('初期値が正しく設定される', () {
+      final spot = makeSpot();
+
+      expect(spot.id, 'spot-1');
+      expect(spot.title, 'テストスポット');
+      expect(spot.latitude, 35.6895);
+      expect(spot.longitude, 139.6917);
+      expect(spot.status, SpotStatus.wantToGo);
+      expect(spot.memo, isNull);
+      expect(spot.photoPath, isNull);
+      expect(spot.createdAt, createdAt);
+    });
+
+    test('markAsVisited でステータスが visited になる', () {
+      final spot = makeSpot(status: SpotStatus.wantToGo);
+      final updated = spot.markAsVisited();
+
+      expect(updated.status, SpotStatus.visited);
+      expect(updated.id, spot.id);
+      expect(updated.title, spot.title);
+    });
+
+    test('markAsWantToGo でステータスが wantToGo になる', () {
+      final spot = makeSpot(status: SpotStatus.visited);
+      final updated = spot.markAsWantToGo();
+
+      expect(updated.status, SpotStatus.wantToGo);
+    });
+
+    test('copyWith でタイトルを変更できる', () {
+      final spot = makeSpot();
+      final updated = spot.copyWith(title: '新しいスポット');
+
+      expect(updated.title, '新しいスポット');
+      expect(updated.id, spot.id);
+      expect(updated.status, spot.status);
+    });
+
+    test('copyWith でメモと写真パスを設定できる', () {
+      final spot = makeSpot();
+      final updated = spot.copyWith(
+        memo: 'おすすめのカフェ',
+        photoPath: '/photos/cafe.jpg',
+      );
+
+      expect(updated.memo, 'おすすめのカフェ');
+      expect(updated.photoPath, '/photos/cafe.jpg');
+    });
+  });
+}

--- a/test/domain/entities/walk_route_test.dart
+++ b/test/domain/entities/walk_route_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+
+void main() {
+  final createdAt = DateTime(2024, 1, 1);
+  const points = [
+    LatLng(35.6895, 139.6917),
+    LatLng(35.6900, 139.6920),
+  ];
+
+  WalkRoute makeRoute() {
+    return WalkRoute(
+      id: 'route-1',
+      walkSessionId: 'session-1',
+      points: points,
+      createdAt: createdAt,
+    );
+  }
+
+  group('WalkRoute', () {
+    test('初期値が正しく設定される', () {
+      final route = makeRoute();
+
+      expect(route.id, 'route-1');
+      expect(route.walkSessionId, 'session-1');
+      expect(route.points, points);
+      expect(route.createdAt, createdAt);
+    });
+
+    test('copyWith でポイントリストを更新できる', () {
+      final route = makeRoute();
+      const newPoints = [
+        LatLng(35.6895, 139.6917),
+        LatLng(35.6900, 139.6920),
+        LatLng(35.6910, 139.6930),
+      ];
+      final updated = route.copyWith(points: newPoints);
+
+      expect(updated.points, newPoints);
+      expect(updated.points.length, 3);
+      expect(updated.id, route.id);
+    });
+
+    test('copyWith で変更しないフィールドは元の値を保持する', () {
+      final route = makeRoute();
+      final updated = route.copyWith(walkSessionId: 'session-2');
+
+      expect(updated.walkSessionId, 'session-2');
+      expect(updated.id, route.id);
+      expect(updated.points, route.points);
+      expect(updated.createdAt, route.createdAt);
+    });
+  });
+}

--- a/test/domain/entities/walk_route_test.dart
+++ b/test/domain/entities/walk_route_test.dart
@@ -51,5 +51,20 @@ void main() {
       expect(updated.points, route.points);
       expect(updated.createdAt, route.createdAt);
     });
+
+    test('points は外部から変更できない', () {
+      final mutablePoints = [const LatLng(35.6895, 139.6917)];
+      final route = WalkRoute(
+        id: 'route-1',
+        walkSessionId: 'session-1',
+        points: mutablePoints,
+        createdAt: createdAt,
+      );
+
+      expect(
+        () => route.points.add(const LatLng(35.6900, 139.6920)),
+        throwsUnsupportedError,
+      );
+    });
   });
 }

--- a/test/domain/entities/walk_session_test.dart
+++ b/test/domain/entities/walk_session_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
+
+void main() {
+  group('WalkSession', () {
+    test('デフォルト状態は idle で経過秒数 0', () {
+      const session = WalkSession(status: WalkStatus.idle);
+
+      expect(session.status, WalkStatus.idle);
+      expect(session.elapsedSeconds, 0);
+      expect(session.startedAt, isNull);
+      expect(session.finishedAt, isNull);
+    });
+
+    test('copyWith でステータスを walking に変更できる', () {
+      const session = WalkSession(status: WalkStatus.idle);
+      final started = DateTime(2024, 1, 1, 9, 0);
+      final updated = session.copyWith(
+        status: WalkStatus.walking,
+        startedAt: started,
+      );
+
+      expect(updated.status, WalkStatus.walking);
+      expect(updated.startedAt, started);
+      expect(updated.elapsedSeconds, 0);
+    });
+
+    test('copyWith でステータスを finished に変更できる', () {
+      final started = DateTime(2024, 1, 1, 9, 0);
+      final finished = DateTime(2024, 1, 1, 9, 30);
+      final session = WalkSession(
+        status: WalkStatus.walking,
+        startedAt: started,
+        elapsedSeconds: 1800,
+      );
+      final updated = session.copyWith(
+        status: WalkStatus.finished,
+        finishedAt: finished,
+      );
+
+      expect(updated.status, WalkStatus.finished);
+      expect(updated.finishedAt, finished);
+      expect(updated.elapsedSeconds, 1800);
+    });
+
+    test('copyWith で変更しないフィールドは元の値を保持する', () {
+      final started = DateTime(2024, 1, 1, 9, 0);
+      final session = WalkSession(
+        status: WalkStatus.walking,
+        startedAt: started,
+        elapsedSeconds: 60,
+      );
+      final updated = session.copyWith(elapsedSeconds: 120);
+
+      expect(updated.status, WalkStatus.walking);
+      expect(updated.startedAt, started);
+      expect(updated.elapsedSeconds, 120);
+    });
+  });
+}

--- a/test/domain/entities/walk_session_test.dart
+++ b/test/domain/entities/walk_session_test.dart
@@ -56,5 +56,25 @@ void main() {
       expect(updated.startedAt, started);
       expect(updated.elapsedSeconds, 120);
     });
+
+    test('copyWith で startedAt を null に戻せる', () {
+      final session = WalkSession(
+        status: WalkStatus.idle,
+        startedAt: DateTime(2024, 1, 1, 9, 0),
+      );
+      final updated = session.copyWith(startedAt: null);
+
+      expect(updated.startedAt, isNull);
+    });
+
+    test('copyWith で finishedAt を null に戻せる', () {
+      final session = WalkSession(
+        status: WalkStatus.finished,
+        finishedAt: DateTime(2024, 1, 1, 9, 30),
+      );
+      final updated = session.copyWith(finishedAt: null);
+
+      expect(updated.finishedAt, isNull);
+    });
   });
 }


### PR DESCRIPTION
## 📝 説明
クリーンアーキテクチャのドメイン層にエンティティクラスを実装しました。
すべてイミュータブルクラスとして実装し、外部パッケージに依存しない純粋な Dart 実装です。

## 🔗 関連 Issue
closes #22

## 📋 変更内容
- [x] 機能追加

## ✅ チェックリスト
- [x] コードレビュー済み
- [x] ユニットテスト実施済み（15件 all passed）
- [ ] ドキュメント更新済み
- [x] 自分でテスト確認済み

## 🔧 変更内容詳細

### `lib/domain/entities/walk_session.dart`
- `WalkStatus` enum（idle / walking / finished）
- `WalkSession` クラス（startedAt / finishedAt / elapsedSeconds / copyWith）

### `lib/domain/entities/spot.dart`
- `SpotStatus` enum（wantToGo / visited）
- `Spot` クラス（id / title / latitude / longitude / memo / photoPath / createdAt / copyWith）
- `markAsVisited()` / `markAsWantToGo()` でステータス変更

### `lib/domain/entities/lat_lng.dart`（新規）
- 外部パッケージに依存しない純粋 Dart の `LatLng` 値オブジェクト
- `==` / `hashCode` 実装済み

### `lib/domain/entities/walk_route.dart`
- `WalkRoute` クラス（id / walkSessionId / points / createdAt / copyWith）
- `List<LatLng>` でルートポイントを保持

### `test/domain/entities/`（新規）
- 各エンティティのユニットテストを追加（計15件）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 位置情報、スポット、散歩ルート、散歩セッションを表すデータが追加されました。
  * スポットの訪問済み／行きたい状態を切り替えられるようになりました。
  * 各データは一部だけ更新して新しい値を作れるようになりました。

* **テスト**
  * 各データの初期値、更新、状態変更、等価性の確認テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->