### PR TITLE
[Logic] Isarデータモデルの実装

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - "**/*.g.dart"

--- a/lib/data/models/spot_model.dart
+++ b/lib/data/models/spot_model.dart
@@ -1,1 +1,47 @@
-// スポットのデータモデル（Isar）
+import 'package:isar/isar.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+
+part 'spot_model.g.dart';
+
+@Collection()
+class SpotModel {
+  Id id = Isar.autoIncrement;
+
+  @Index(unique: true)
+  late String uid;
+  late String title;
+  late double latitude;
+  late double longitude;
+
+  @Enumerated(EnumType.name)
+  late SpotStatus status;
+
+  String? memo;
+  String? photoPath;
+  late DateTime createdAt;
+
+  Spot toEntity() {
+    return Spot(
+      id: uid,
+      title: title,
+      latitude: latitude,
+      longitude: longitude,
+      status: status,
+      memo: memo,
+      photoPath: photoPath,
+      createdAt: createdAt,
+    );
+  }
+
+  static SpotModel fromEntity(Spot spot) {
+    return SpotModel()
+      ..uid = spot.id
+      ..title = spot.title
+      ..latitude = spot.latitude
+      ..longitude = spot.longitude
+      ..status = spot.status
+      ..memo = spot.memo
+      ..photoPath = spot.photoPath
+      ..createdAt = spot.createdAt;
+  }
+}

--- a/lib/data/models/spot_model.g.dart
+++ b/lib/data/models/spot_model.g.dart
@@ -1,0 +1,1622 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'spot_model.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetSpotModelCollection on Isar {
+  IsarCollection<SpotModel> get spotModels => this.collection();
+}
+
+const SpotModelSchema = CollectionSchema(
+  name: r'SpotModel',
+  id: -2749345920550038888,
+  properties: {
+    r'createdAt': PropertySchema(
+      id: 0,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'latitude': PropertySchema(
+      id: 1,
+      name: r'latitude',
+      type: IsarType.double,
+    ),
+    r'longitude': PropertySchema(
+      id: 2,
+      name: r'longitude',
+      type: IsarType.double,
+    ),
+    r'memo': PropertySchema(
+      id: 3,
+      name: r'memo',
+      type: IsarType.string,
+    ),
+    r'photoPath': PropertySchema(
+      id: 4,
+      name: r'photoPath',
+      type: IsarType.string,
+    ),
+    r'status': PropertySchema(
+      id: 5,
+      name: r'status',
+      type: IsarType.string,
+      enumMap: _SpotModelstatusEnumValueMap,
+    ),
+    r'title': PropertySchema(
+      id: 6,
+      name: r'title',
+      type: IsarType.string,
+    ),
+    r'uid': PropertySchema(
+      id: 7,
+      name: r'uid',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _spotModelEstimateSize,
+  serialize: _spotModelSerialize,
+  deserialize: _spotModelDeserialize,
+  deserializeProp: _spotModelDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'uid': IndexSchema(
+      id: 8193695471701937315,
+      name: r'uid',
+      unique: true,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'uid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _spotModelGetId,
+  getLinks: _spotModelGetLinks,
+  attach: _spotModelAttach,
+  version: '3.1.0+1',
+);
+
+int _spotModelEstimateSize(
+  SpotModel object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.memo;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.photoPath;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.status.name.length * 3;
+  bytesCount += 3 + object.title.length * 3;
+  bytesCount += 3 + object.uid.length * 3;
+  return bytesCount;
+}
+
+void _spotModelSerialize(
+  SpotModel object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeDateTime(offsets[0], object.createdAt);
+  writer.writeDouble(offsets[1], object.latitude);
+  writer.writeDouble(offsets[2], object.longitude);
+  writer.writeString(offsets[3], object.memo);
+  writer.writeString(offsets[4], object.photoPath);
+  writer.writeString(offsets[5], object.status.name);
+  writer.writeString(offsets[6], object.title);
+  writer.writeString(offsets[7], object.uid);
+}
+
+SpotModel _spotModelDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = SpotModel();
+  object.createdAt = reader.readDateTime(offsets[0]);
+  object.id = id;
+  object.latitude = reader.readDouble(offsets[1]);
+  object.longitude = reader.readDouble(offsets[2]);
+  object.memo = reader.readStringOrNull(offsets[3]);
+  object.photoPath = reader.readStringOrNull(offsets[4]);
+  object.status =
+      _SpotModelstatusValueEnumMap[reader.readStringOrNull(offsets[5])] ??
+          SpotStatus.wantToGo;
+  object.title = reader.readString(offsets[6]);
+  object.uid = reader.readString(offsets[7]);
+  return object;
+}
+
+P _spotModelDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readDateTime(offset)) as P;
+    case 1:
+      return (reader.readDouble(offset)) as P;
+    case 2:
+      return (reader.readDouble(offset)) as P;
+    case 3:
+      return (reader.readStringOrNull(offset)) as P;
+    case 4:
+      return (reader.readStringOrNull(offset)) as P;
+    case 5:
+      return (_SpotModelstatusValueEnumMap[reader.readStringOrNull(offset)] ??
+          SpotStatus.wantToGo) as P;
+    case 6:
+      return (reader.readString(offset)) as P;
+    case 7:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+const _SpotModelstatusEnumValueMap = {
+  r'wantToGo': r'wantToGo',
+  r'visited': r'visited',
+};
+const _SpotModelstatusValueEnumMap = {
+  r'wantToGo': SpotStatus.wantToGo,
+  r'visited': SpotStatus.visited,
+};
+
+Id _spotModelGetId(SpotModel object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _spotModelGetLinks(SpotModel object) {
+  return [];
+}
+
+void _spotModelAttach(IsarCollection<dynamic> col, Id id, SpotModel object) {
+  object.id = id;
+}
+
+extension SpotModelByIndex on IsarCollection<SpotModel> {
+  Future<SpotModel?> getByUid(String uid) {
+    return getByIndex(r'uid', [uid]);
+  }
+
+  SpotModel? getByUidSync(String uid) {
+    return getByIndexSync(r'uid', [uid]);
+  }
+
+  Future<bool> deleteByUid(String uid) {
+    return deleteByIndex(r'uid', [uid]);
+  }
+
+  bool deleteByUidSync(String uid) {
+    return deleteByIndexSync(r'uid', [uid]);
+  }
+
+  Future<List<SpotModel?>> getAllByUid(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return getAllByIndex(r'uid', values);
+  }
+
+  List<SpotModel?> getAllByUidSync(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'uid', values);
+  }
+
+  Future<int> deleteAllByUid(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'uid', values);
+  }
+
+  int deleteAllByUidSync(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'uid', values);
+  }
+
+  Future<Id> putByUid(SpotModel object) {
+    return putByIndex(r'uid', object);
+  }
+
+  Id putByUidSync(SpotModel object, {bool saveLinks = true}) {
+    return putByIndexSync(r'uid', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByUid(List<SpotModel> objects) {
+    return putAllByIndex(r'uid', objects);
+  }
+
+  List<Id> putAllByUidSync(List<SpotModel> objects, {bool saveLinks = true}) {
+    return putAllByIndexSync(r'uid', objects, saveLinks: saveLinks);
+  }
+}
+
+extension SpotModelQueryWhereSort
+    on QueryBuilder<SpotModel, SpotModel, QWhere> {
+  QueryBuilder<SpotModel, SpotModel, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension SpotModelQueryWhere
+    on QueryBuilder<SpotModel, SpotModel, QWhereClause> {
+  QueryBuilder<SpotModel, SpotModel, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterWhereClause> uidEqualTo(String uid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'uid',
+        value: [uid],
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterWhereClause> uidNotEqualTo(
+      String uid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [],
+              upper: [uid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [uid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [uid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [],
+              upper: [uid],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension SpotModelQueryFilter
+    on QueryBuilder<SpotModel, SpotModel, QFilterCondition> {
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> createdAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition>
+      createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> latitudeEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'latitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> latitudeGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'latitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> latitudeLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'latitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> latitudeBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'latitude',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> longitudeEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'longitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition>
+      longitudeGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'longitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> longitudeLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'longitude',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> longitudeBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'longitude',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'memo',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'memo',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'memo',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'memo',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'memo',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'memo',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'memo',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'memo',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'memo',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'memo',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'memo',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> memoIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'memo',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'photoPath',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition>
+      photoPathIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'photoPath',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'photoPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition>
+      photoPathGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'photoPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'photoPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'photoPath',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'photoPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'photoPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'photoPath',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'photoPath',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> photoPathIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'photoPath',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition>
+      photoPathIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'photoPath',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusEqualTo(
+    SpotStatus value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusGreaterThan(
+    SpotStatus value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusLessThan(
+    SpotStatus value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusBetween(
+    SpotStatus lower,
+    SpotStatus upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'status',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'status',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'status',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> statusIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'status',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'title',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'title',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'title',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> titleIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'title',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'uid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'uid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterFilterCondition> uidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'uid',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension SpotModelQueryObject
+    on QueryBuilder<SpotModel, SpotModel, QFilterCondition> {}
+
+extension SpotModelQueryLinks
+    on QueryBuilder<SpotModel, SpotModel, QFilterCondition> {}
+
+extension SpotModelQuerySortBy on QueryBuilder<SpotModel, SpotModel, QSortBy> {
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByLatitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByLongitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByMemo() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'memo', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByMemoDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'memo', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByPhotoPath() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'photoPath', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByPhotoPathDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'photoPath', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByTitle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByTitleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> sortByUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.desc);
+    });
+  }
+}
+
+extension SpotModelQuerySortThenBy
+    on QueryBuilder<SpotModel, SpotModel, QSortThenBy> {
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByLatitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'latitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByLongitudeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longitude', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByMemo() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'memo', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByMemoDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'memo', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByPhotoPath() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'photoPath', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByPhotoPathDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'photoPath', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByTitle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByTitleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QAfterSortBy> thenByUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.desc);
+    });
+  }
+}
+
+extension SpotModelQueryWhereDistinct
+    on QueryBuilder<SpotModel, SpotModel, QDistinct> {
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByLatitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'latitude');
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByLongitude() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'longitude');
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByMemo(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'memo', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByPhotoPath(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'photoPath', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByStatus(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'status', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByTitle(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'title', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotModel, QDistinct> distinctByUid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'uid', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension SpotModelQueryProperty
+    on QueryBuilder<SpotModel, SpotModel, QQueryProperty> {
+  QueryBuilder<SpotModel, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<SpotModel, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<SpotModel, double, QQueryOperations> latitudeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'latitude');
+    });
+  }
+
+  QueryBuilder<SpotModel, double, QQueryOperations> longitudeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'longitude');
+    });
+  }
+
+  QueryBuilder<SpotModel, String?, QQueryOperations> memoProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'memo');
+    });
+  }
+
+  QueryBuilder<SpotModel, String?, QQueryOperations> photoPathProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'photoPath');
+    });
+  }
+
+  QueryBuilder<SpotModel, SpotStatus, QQueryOperations> statusProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'status');
+    });
+  }
+
+  QueryBuilder<SpotModel, String, QQueryOperations> titleProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'title');
+    });
+  }
+
+  QueryBuilder<SpotModel, String, QQueryOperations> uidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'uid');
+    });
+  }
+}

--- a/lib/data/models/walk_route_model.dart
+++ b/lib/data/models/walk_route_model.dart
@@ -1,1 +1,52 @@
-// 散歩ルートのデータモデル（Isar）
+import 'dart:convert';
+
+import 'package:isar/isar.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+
+part 'walk_route_model.g.dart';
+
+@Collection()
+class WalkRouteModel {
+  Id id = Isar.autoIncrement;
+
+  @Index(unique: true)
+  late String uid;
+  late String walkSessionId;
+
+  // List<LatLng> を JSON 文字列として保存
+  late String pointsJson;
+
+  late DateTime createdAt;
+
+  WalkRoute toEntity() {
+    final decoded = jsonDecode(pointsJson) as List<dynamic>;
+    final points = decoded
+        .map((e) => LatLng(
+              (e['lat'] as num).toDouble(),
+              (e['lng'] as num).toDouble(),
+            ))
+        .toList();
+
+    return WalkRoute(
+      id: uid,
+      walkSessionId: walkSessionId,
+      points: points,
+      createdAt: createdAt,
+    );
+  }
+
+  static WalkRouteModel fromEntity(WalkRoute route) {
+    final pointsJson = jsonEncode(
+      route.points
+          .map((p) => {'lat': p.latitude, 'lng': p.longitude})
+          .toList(),
+    );
+
+    return WalkRouteModel()
+      ..uid = route.id
+      ..walkSessionId = route.walkSessionId
+      ..pointsJson = pointsJson
+      ..createdAt = route.createdAt;
+  }
+}

--- a/lib/data/models/walk_route_model.dart
+++ b/lib/data/models/walk_route_model.dart
@@ -12,6 +12,8 @@ class WalkRouteModel {
 
   @Index(unique: true)
   late String uid;
+
+  @Index()
   late String walkSessionId;
 
   // List<LatLng> を JSON 文字列として保存

--- a/lib/data/models/walk_route_model.dart
+++ b/lib/data/models/walk_route_model.dart
@@ -38,9 +38,7 @@ class WalkRouteModel {
 
   static WalkRouteModel fromEntity(WalkRoute route) {
     final pointsJson = jsonEncode(
-      route.points
-          .map((p) => {'lat': p.latitude, 'lng': p.longitude})
-          .toList(),
+      route.points.map((p) => {'lat': p.latitude, 'lng': p.longitude}).toList(),
     );
 
     return WalkRouteModel()

--- a/lib/data/models/walk_route_model.g.dart
+++ b/lib/data/models/walk_route_model.g.dart
@@ -1,0 +1,1038 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'walk_route_model.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetWalkRouteModelCollection on Isar {
+  IsarCollection<WalkRouteModel> get walkRouteModels => this.collection();
+}
+
+const WalkRouteModelSchema = CollectionSchema(
+  name: r'WalkRouteModel',
+  id: -2714677804956036537,
+  properties: {
+    r'createdAt': PropertySchema(
+      id: 0,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'pointsJson': PropertySchema(
+      id: 1,
+      name: r'pointsJson',
+      type: IsarType.string,
+    ),
+    r'uid': PropertySchema(
+      id: 2,
+      name: r'uid',
+      type: IsarType.string,
+    ),
+    r'walkSessionId': PropertySchema(
+      id: 3,
+      name: r'walkSessionId',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _walkRouteModelEstimateSize,
+  serialize: _walkRouteModelSerialize,
+  deserialize: _walkRouteModelDeserialize,
+  deserializeProp: _walkRouteModelDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'uid': IndexSchema(
+      id: 8193695471701937315,
+      name: r'uid',
+      unique: true,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'uid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _walkRouteModelGetId,
+  getLinks: _walkRouteModelGetLinks,
+  attach: _walkRouteModelAttach,
+  version: '3.1.0+1',
+);
+
+int _walkRouteModelEstimateSize(
+  WalkRouteModel object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.pointsJson.length * 3;
+  bytesCount += 3 + object.uid.length * 3;
+  bytesCount += 3 + object.walkSessionId.length * 3;
+  return bytesCount;
+}
+
+void _walkRouteModelSerialize(
+  WalkRouteModel object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeDateTime(offsets[0], object.createdAt);
+  writer.writeString(offsets[1], object.pointsJson);
+  writer.writeString(offsets[2], object.uid);
+  writer.writeString(offsets[3], object.walkSessionId);
+}
+
+WalkRouteModel _walkRouteModelDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = WalkRouteModel();
+  object.createdAt = reader.readDateTime(offsets[0]);
+  object.id = id;
+  object.pointsJson = reader.readString(offsets[1]);
+  object.uid = reader.readString(offsets[2]);
+  object.walkSessionId = reader.readString(offsets[3]);
+  return object;
+}
+
+P _walkRouteModelDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readDateTime(offset)) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    case 2:
+      return (reader.readString(offset)) as P;
+    case 3:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _walkRouteModelGetId(WalkRouteModel object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _walkRouteModelGetLinks(WalkRouteModel object) {
+  return [];
+}
+
+void _walkRouteModelAttach(
+    IsarCollection<dynamic> col, Id id, WalkRouteModel object) {
+  object.id = id;
+}
+
+extension WalkRouteModelByIndex on IsarCollection<WalkRouteModel> {
+  Future<WalkRouteModel?> getByUid(String uid) {
+    return getByIndex(r'uid', [uid]);
+  }
+
+  WalkRouteModel? getByUidSync(String uid) {
+    return getByIndexSync(r'uid', [uid]);
+  }
+
+  Future<bool> deleteByUid(String uid) {
+    return deleteByIndex(r'uid', [uid]);
+  }
+
+  bool deleteByUidSync(String uid) {
+    return deleteByIndexSync(r'uid', [uid]);
+  }
+
+  Future<List<WalkRouteModel?>> getAllByUid(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return getAllByIndex(r'uid', values);
+  }
+
+  List<WalkRouteModel?> getAllByUidSync(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'uid', values);
+  }
+
+  Future<int> deleteAllByUid(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'uid', values);
+  }
+
+  int deleteAllByUidSync(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'uid', values);
+  }
+
+  Future<Id> putByUid(WalkRouteModel object) {
+    return putByIndex(r'uid', object);
+  }
+
+  Id putByUidSync(WalkRouteModel object, {bool saveLinks = true}) {
+    return putByIndexSync(r'uid', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByUid(List<WalkRouteModel> objects) {
+    return putAllByIndex(r'uid', objects);
+  }
+
+  List<Id> putAllByUidSync(List<WalkRouteModel> objects,
+      {bool saveLinks = true}) {
+    return putAllByIndexSync(r'uid', objects, saveLinks: saveLinks);
+  }
+}
+
+extension WalkRouteModelQueryWhereSort
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QWhere> {
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension WalkRouteModelQueryWhere
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QWhereClause> {
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause> idEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause> idNotEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause> idGreaterThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause> idLessThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause> uidEqualTo(
+      String uid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'uid',
+        value: [uid],
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause> uidNotEqualTo(
+      String uid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [],
+              upper: [uid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [uid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [uid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [],
+              upper: [uid],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension WalkRouteModelQueryFilter
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QFilterCondition> {
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      createdAtEqualTo(DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'pointsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'pointsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'pointsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'pointsJson',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'pointsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'pointsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'pointsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'pointsJson',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'pointsJson',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      pointsJsonIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'pointsJson',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'uid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'uid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      uidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'uid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'walkSessionId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'walkSessionId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'walkSessionId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'walkSessionId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'walkSessionId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'walkSessionId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'walkSessionId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'walkSessionId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'walkSessionId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      walkSessionIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'walkSessionId',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension WalkRouteModelQueryObject
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QFilterCondition> {}
+
+extension WalkRouteModelQueryLinks
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QFilterCondition> {}
+
+extension WalkRouteModelQuerySortBy
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QSortBy> {
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      sortByPointsJson() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'pointsJson', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      sortByPointsJsonDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'pointsJson', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> sortByUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> sortByUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      sortByWalkSessionId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'walkSessionId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      sortByWalkSessionIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'walkSessionId', Sort.desc);
+    });
+  }
+}
+
+extension WalkRouteModelQuerySortThenBy
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QSortThenBy> {
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      thenByPointsJson() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'pointsJson', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      thenByPointsJsonDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'pointsJson', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> thenByUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> thenByUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      thenByWalkSessionId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'walkSessionId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      thenByWalkSessionIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'walkSessionId', Sort.desc);
+    });
+  }
+}
+
+extension WalkRouteModelQueryWhereDistinct
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QDistinct> {
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QDistinct>
+      distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QDistinct> distinctByPointsJson(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'pointsJson', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QDistinct> distinctByUid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'uid', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QDistinct>
+      distinctByWalkSessionId({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'walkSessionId',
+          caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension WalkRouteModelQueryProperty
+    on QueryBuilder<WalkRouteModel, WalkRouteModel, QQueryProperty> {
+  QueryBuilder<WalkRouteModel, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, String, QQueryOperations> pointsJsonProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'pointsJson');
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, String, QQueryOperations> uidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'uid');
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, String, QQueryOperations>
+      walkSessionIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'walkSessionId');
+    });
+  }
+}

--- a/lib/data/models/walk_route_model.g.dart
+++ b/lib/data/models/walk_route_model.g.dart
@@ -56,6 +56,19 @@ const WalkRouteModelSchema = CollectionSchema(
           caseSensitive: true,
         )
       ],
+    ),
+    r'walkSessionId': IndexSchema(
+      id: 6869786109258476304,
+      name: r'walkSessionId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'walkSessionId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
     )
   },
   links: {},
@@ -312,6 +325,51 @@ extension WalkRouteModelQueryWhere
               indexName: r'uid',
               lower: [],
               upper: [uid],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause>
+      walkSessionIdEqualTo(String walkSessionId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'walkSessionId',
+        value: [walkSessionId],
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause>
+      walkSessionIdNotEqualTo(String walkSessionId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'walkSessionId',
+              lower: [],
+              upper: [walkSessionId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'walkSessionId',
+              lower: [walkSessionId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'walkSessionId',
+              lower: [walkSessionId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'walkSessionId',
+              lower: [],
+              upper: [walkSessionId],
               includeUpper: false,
             ));
       }

--- a/lib/data/models/walk_session_model.dart
+++ b/lib/data/models/walk_session_model.dart
@@ -1,0 +1,37 @@
+import 'package:isar/isar.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
+
+part 'walk_session_model.g.dart';
+
+@Collection()
+class WalkSessionModel {
+  Id id = Isar.autoIncrement;
+
+  @Index(unique: true)
+  late String uid;
+
+  @Enumerated(EnumType.name)
+  late WalkStatus status;
+
+  DateTime? startedAt;
+  DateTime? finishedAt;
+  late int elapsedSeconds;
+
+  WalkSession toEntity() {
+    return WalkSession(
+      status: status,
+      startedAt: startedAt,
+      finishedAt: finishedAt,
+      elapsedSeconds: elapsedSeconds,
+    );
+  }
+
+  static WalkSessionModel fromEntity(String uid, WalkSession session) {
+    return WalkSessionModel()
+      ..uid = uid
+      ..status = session.status
+      ..startedAt = session.startedAt
+      ..finishedAt = session.finishedAt
+      ..elapsedSeconds = session.elapsedSeconds;
+  }
+}

--- a/lib/data/models/walk_session_model.dart
+++ b/lib/data/models/walk_session_model.dart
@@ -19,6 +19,7 @@ class WalkSessionModel {
 
   WalkSession toEntity() {
     return WalkSession(
+      id: uid,
       status: status,
       startedAt: startedAt,
       finishedAt: finishedAt,
@@ -26,9 +27,9 @@ class WalkSessionModel {
     );
   }
 
-  static WalkSessionModel fromEntity(String uid, WalkSession session) {
+  static WalkSessionModel fromEntity(WalkSession session) {
     return WalkSessionModel()
-      ..uid = uid
+      ..uid = session.id
       ..status = session.status
       ..startedAt = session.startedAt
       ..finishedAt = session.finishedAt

--- a/lib/data/models/walk_session_model.g.dart
+++ b/lib/data/models/walk_session_model.g.dart
@@ -1,0 +1,1121 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'walk_session_model.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetWalkSessionModelCollection on Isar {
+  IsarCollection<WalkSessionModel> get walkSessionModels => this.collection();
+}
+
+const WalkSessionModelSchema = CollectionSchema(
+  name: r'WalkSessionModel',
+  id: 4513058577258910417,
+  properties: {
+    r'elapsedSeconds': PropertySchema(
+      id: 0,
+      name: r'elapsedSeconds',
+      type: IsarType.long,
+    ),
+    r'finishedAt': PropertySchema(
+      id: 1,
+      name: r'finishedAt',
+      type: IsarType.dateTime,
+    ),
+    r'startedAt': PropertySchema(
+      id: 2,
+      name: r'startedAt',
+      type: IsarType.dateTime,
+    ),
+    r'status': PropertySchema(
+      id: 3,
+      name: r'status',
+      type: IsarType.string,
+      enumMap: _WalkSessionModelstatusEnumValueMap,
+    ),
+    r'uid': PropertySchema(
+      id: 4,
+      name: r'uid',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _walkSessionModelEstimateSize,
+  serialize: _walkSessionModelSerialize,
+  deserialize: _walkSessionModelDeserialize,
+  deserializeProp: _walkSessionModelDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'uid': IndexSchema(
+      id: 8193695471701937315,
+      name: r'uid',
+      unique: true,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'uid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _walkSessionModelGetId,
+  getLinks: _walkSessionModelGetLinks,
+  attach: _walkSessionModelAttach,
+  version: '3.1.0+1',
+);
+
+int _walkSessionModelEstimateSize(
+  WalkSessionModel object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.status.name.length * 3;
+  bytesCount += 3 + object.uid.length * 3;
+  return bytesCount;
+}
+
+void _walkSessionModelSerialize(
+  WalkSessionModel object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeLong(offsets[0], object.elapsedSeconds);
+  writer.writeDateTime(offsets[1], object.finishedAt);
+  writer.writeDateTime(offsets[2], object.startedAt);
+  writer.writeString(offsets[3], object.status.name);
+  writer.writeString(offsets[4], object.uid);
+}
+
+WalkSessionModel _walkSessionModelDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = WalkSessionModel();
+  object.elapsedSeconds = reader.readLong(offsets[0]);
+  object.finishedAt = reader.readDateTimeOrNull(offsets[1]);
+  object.id = id;
+  object.startedAt = reader.readDateTimeOrNull(offsets[2]);
+  object.status = _WalkSessionModelstatusValueEnumMap[
+          reader.readStringOrNull(offsets[3])] ??
+      WalkStatus.idle;
+  object.uid = reader.readString(offsets[4]);
+  return object;
+}
+
+P _walkSessionModelDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readLong(offset)) as P;
+    case 1:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 2:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 3:
+      return (_WalkSessionModelstatusValueEnumMap[
+              reader.readStringOrNull(offset)] ??
+          WalkStatus.idle) as P;
+    case 4:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+const _WalkSessionModelstatusEnumValueMap = {
+  r'idle': r'idle',
+  r'walking': r'walking',
+  r'finished': r'finished',
+};
+const _WalkSessionModelstatusValueEnumMap = {
+  r'idle': WalkStatus.idle,
+  r'walking': WalkStatus.walking,
+  r'finished': WalkStatus.finished,
+};
+
+Id _walkSessionModelGetId(WalkSessionModel object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _walkSessionModelGetLinks(WalkSessionModel object) {
+  return [];
+}
+
+void _walkSessionModelAttach(
+    IsarCollection<dynamic> col, Id id, WalkSessionModel object) {
+  object.id = id;
+}
+
+extension WalkSessionModelByIndex on IsarCollection<WalkSessionModel> {
+  Future<WalkSessionModel?> getByUid(String uid) {
+    return getByIndex(r'uid', [uid]);
+  }
+
+  WalkSessionModel? getByUidSync(String uid) {
+    return getByIndexSync(r'uid', [uid]);
+  }
+
+  Future<bool> deleteByUid(String uid) {
+    return deleteByIndex(r'uid', [uid]);
+  }
+
+  bool deleteByUidSync(String uid) {
+    return deleteByIndexSync(r'uid', [uid]);
+  }
+
+  Future<List<WalkSessionModel?>> getAllByUid(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return getAllByIndex(r'uid', values);
+  }
+
+  List<WalkSessionModel?> getAllByUidSync(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'uid', values);
+  }
+
+  Future<int> deleteAllByUid(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'uid', values);
+  }
+
+  int deleteAllByUidSync(List<String> uidValues) {
+    final values = uidValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'uid', values);
+  }
+
+  Future<Id> putByUid(WalkSessionModel object) {
+    return putByIndex(r'uid', object);
+  }
+
+  Id putByUidSync(WalkSessionModel object, {bool saveLinks = true}) {
+    return putByIndexSync(r'uid', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByUid(List<WalkSessionModel> objects) {
+    return putAllByIndex(r'uid', objects);
+  }
+
+  List<Id> putAllByUidSync(List<WalkSessionModel> objects,
+      {bool saveLinks = true}) {
+    return putAllByIndexSync(r'uid', objects, saveLinks: saveLinks);
+  }
+}
+
+extension WalkSessionModelQueryWhereSort
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QWhere> {
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension WalkSessionModelQueryWhere
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QWhereClause> {
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause> idEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause>
+      idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause>
+      idGreaterThan(Id id, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause>
+      idLessThan(Id id, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause>
+      uidEqualTo(String uid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'uid',
+        value: [uid],
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause>
+      uidNotEqualTo(String uid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [],
+              upper: [uid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [uid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [uid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uid',
+              lower: [],
+              upper: [uid],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension WalkSessionModelQueryFilter
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QFilterCondition> {
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      elapsedSecondsEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'elapsedSeconds',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      elapsedSecondsGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'elapsedSeconds',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      elapsedSecondsLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'elapsedSeconds',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      elapsedSecondsBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'elapsedSeconds',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      finishedAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'finishedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      finishedAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'finishedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      finishedAtEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'finishedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      finishedAtGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'finishedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      finishedAtLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'finishedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      finishedAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'finishedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      idEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      startedAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'startedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      startedAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'startedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      startedAtEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'startedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      startedAtGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'startedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      startedAtLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'startedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      startedAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'startedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusEqualTo(
+    WalkStatus value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusGreaterThan(
+    WalkStatus value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusLessThan(
+    WalkStatus value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusBetween(
+    WalkStatus lower,
+    WalkStatus upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'status',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'status',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'status',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'status',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      statusIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'status',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'uid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'uid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'uid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      uidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'uid',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension WalkSessionModelQueryObject
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QFilterCondition> {}
+
+extension WalkSessionModelQueryLinks
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QFilterCondition> {}
+
+extension WalkSessionModelQuerySortBy
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QSortBy> {
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByElapsedSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'elapsedSeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByElapsedSecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'elapsedSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByFinishedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'finishedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByFinishedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'finishedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByStartedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByStartedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy> sortByUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.desc);
+    });
+  }
+}
+
+extension WalkSessionModelQuerySortThenBy
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QSortThenBy> {
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByElapsedSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'elapsedSeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByElapsedSecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'elapsedSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByFinishedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'finishedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByFinishedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'finishedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByStartedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByStartedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'status', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy> thenByUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uid', Sort.desc);
+    });
+  }
+}
+
+extension WalkSessionModelQueryWhereDistinct
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QDistinct> {
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QDistinct>
+      distinctByElapsedSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'elapsedSeconds');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QDistinct>
+      distinctByFinishedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'finishedAt');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QDistinct>
+      distinctByStartedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'startedAt');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QDistinct> distinctByStatus(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'status', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QDistinct> distinctByUid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'uid', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension WalkSessionModelQueryProperty
+    on QueryBuilder<WalkSessionModel, WalkSessionModel, QQueryProperty> {
+  QueryBuilder<WalkSessionModel, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, int, QQueryOperations>
+      elapsedSecondsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'elapsedSeconds');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, DateTime?, QQueryOperations>
+      finishedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'finishedAt');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, DateTime?, QQueryOperations>
+      startedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'startedAt');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkStatus, QQueryOperations>
+      statusProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'status');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, String, QQueryOperations> uidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'uid');
+    });
+  }
+}

--- a/lib/domain/entities/walk_session.dart
+++ b/lib/domain/entities/walk_session.dart
@@ -2,12 +2,14 @@ enum WalkStatus { idle, walking, finished }
 
 class WalkSession {
   const WalkSession({
+    required this.id,
     required this.status,
     this.startedAt,
     this.finishedAt,
     this.elapsedSeconds = 0,
   });
 
+  final String id;
   final WalkStatus status;
   final DateTime? startedAt;
   final DateTime? finishedAt;
@@ -17,12 +19,14 @@ class WalkSession {
   static const Object _sentinel = Object();
 
   WalkSession copyWith({
+    String? id,
     WalkStatus? status,
     Object? startedAt = _sentinel,
     Object? finishedAt = _sentinel,
     int? elapsedSeconds,
   }) {
     return WalkSession(
+      id: id ?? this.id,
       status: status ?? this.status,
       startedAt:
           startedAt == _sentinel ? this.startedAt : startedAt as DateTime?,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,9 @@ dependencies:
   flutter_riverpod: ^2.6.1
   flutter_svg: ^2.0.10+1
   google_fonts: ^6.2.1
+  isar: ^3.1.0
+  isar_flutter_libs: ^3.1.0
+  path_provider: ^2.1.6
 
 dev_dependencies:
   flutter_test:
@@ -20,6 +23,8 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ^4.0.0
+  isar_generator: ^3.1.0
+  build_runner: ^2.4.0
 
 flutter:
   uses-material-design: true

--- a/test/data/models/spot_model_test.dart
+++ b/test/data/models/spot_model_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/data/models/spot_model.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+
+void main() {
+  final createdAt = DateTime(2024, 1, 1);
+
+  Spot makeSpot({String? memo, String? photoPath}) {
+    return Spot(
+      id: 'spot-1',
+      title: 'テストスポット',
+      latitude: 35.6895,
+      longitude: 139.6917,
+      status: SpotStatus.wantToGo,
+      memo: memo,
+      photoPath: photoPath,
+      createdAt: createdAt,
+    );
+  }
+
+  group('SpotModel', () {
+    test('fromEntity でエンティティからモデルに変換できる', () {
+      final spot = makeSpot(memo: 'メモ', photoPath: '/photos/test.jpg');
+      final model = SpotModel.fromEntity(spot);
+
+      expect(model.uid, 'spot-1');
+      expect(model.title, 'テストスポット');
+      expect(model.latitude, 35.6895);
+      expect(model.longitude, 139.6917);
+      expect(model.status, SpotStatus.wantToGo);
+      expect(model.memo, 'メモ');
+      expect(model.photoPath, '/photos/test.jpg');
+      expect(model.createdAt, createdAt);
+    });
+
+    test('toEntity でモデルからエンティティに変換できる', () {
+      final model = SpotModel.fromEntity(makeSpot());
+      final spot = model.toEntity();
+
+      expect(spot.id, 'spot-1');
+      expect(spot.title, 'テストスポット');
+      expect(spot.latitude, 35.6895);
+      expect(spot.longitude, 139.6917);
+      expect(spot.status, SpotStatus.wantToGo);
+      expect(spot.createdAt, createdAt);
+    });
+
+    test('memo / photoPath が null のまま変換できる', () {
+      final model = SpotModel.fromEntity(makeSpot());
+      final spot = model.toEntity();
+
+      expect(spot.memo, isNull);
+      expect(spot.photoPath, isNull);
+    });
+
+    test('visited ステータスが正しく変換される', () {
+      final spot = makeSpot().markAsVisited();
+      final model = SpotModel.fromEntity(spot);
+      final restored = model.toEntity();
+
+      expect(restored.status, SpotStatus.visited);
+    });
+  });
+}

--- a/test/data/models/walk_route_model_test.dart
+++ b/test/data/models/walk_route_model_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/data/models/walk_route_model.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+
+void main() {
+  final createdAt = DateTime(2024, 1, 1);
+  final points = [
+    const LatLng(35.6895, 139.6917),
+    const LatLng(35.6900, 139.6920),
+  ];
+
+  WalkRoute makeRoute() {
+    return WalkRoute(
+      id: 'route-1',
+      walkSessionId: 'session-1',
+      points: points,
+      createdAt: createdAt,
+    );
+  }
+
+  group('WalkRouteModel', () {
+    test('fromEntity でエンティティからモデルに変換できる', () {
+      final model = WalkRouteModel.fromEntity(makeRoute());
+
+      expect(model.uid, 'route-1');
+      expect(model.walkSessionId, 'session-1');
+      expect(model.createdAt, createdAt);
+      expect(model.pointsJson, isNotEmpty);
+    });
+
+    test('toEntity でモデルからエンティティに変換できる', () {
+      final model = WalkRouteModel.fromEntity(makeRoute());
+      final route = model.toEntity();
+
+      expect(route.id, 'route-1');
+      expect(route.walkSessionId, 'session-1');
+      expect(route.createdAt, createdAt);
+    });
+
+    test('ポイントリストが正しく変換される', () {
+      final model = WalkRouteModel.fromEntity(makeRoute());
+      final route = model.toEntity();
+
+      expect(route.points.length, 2);
+      expect(route.points[0].latitude, 35.6895);
+      expect(route.points[0].longitude, 139.6917);
+      expect(route.points[1].latitude, 35.6900);
+      expect(route.points[1].longitude, 139.6920);
+    });
+
+    test('空のポイントリストが変換できる', () {
+      final emptyRoute = WalkRoute(
+        id: 'route-1',
+        walkSessionId: 'session-1',
+        points: [],
+        createdAt: createdAt,
+      );
+      final model = WalkRouteModel.fromEntity(emptyRoute);
+      final route = model.toEntity();
+
+      expect(route.points, isEmpty);
+    });
+  });
+}

--- a/test/data/models/walk_session_model_test.dart
+++ b/test/data/models/walk_session_model_test.dart
@@ -5,8 +5,8 @@ import 'package:tekushare/domain/entities/walk_session.dart';
 void main() {
   group('WalkSessionModel', () {
     test('fromEntity で idle セッションを変換できる', () {
-      const session = WalkSession(status: WalkStatus.idle);
-      final model = WalkSessionModel.fromEntity('session-1', session);
+      const session = WalkSession(id: 'session-1', status: WalkStatus.idle);
+      final model = WalkSessionModel.fromEntity(session);
 
       expect(model.uid, 'session-1');
       expect(model.status, WalkStatus.idle);
@@ -19,12 +19,13 @@ void main() {
       final startedAt = DateTime(2024, 1, 1, 9, 0);
       final finishedAt = DateTime(2024, 1, 1, 9, 30);
       final session = WalkSession(
+        id: 'session-1',
         status: WalkStatus.finished,
         startedAt: startedAt,
         finishedAt: finishedAt,
         elapsedSeconds: 1800,
       );
-      final model = WalkSessionModel.fromEntity('session-1', session);
+      final model = WalkSessionModel.fromEntity(session);
 
       expect(model.status, WalkStatus.finished);
       expect(model.startedAt, startedAt);
@@ -35,13 +36,15 @@ void main() {
     test('toEntity でモデルからエンティティに変換できる', () {
       final startedAt = DateTime(2024, 1, 1, 9, 0);
       final session = WalkSession(
+        id: 'session-1',
         status: WalkStatus.walking,
         startedAt: startedAt,
         elapsedSeconds: 300,
       );
-      final model = WalkSessionModel.fromEntity('session-1', session);
+      final model = WalkSessionModel.fromEntity(session);
       final restored = model.toEntity();
 
+      expect(restored.id, 'session-1');
       expect(restored.status, WalkStatus.walking);
       expect(restored.startedAt, startedAt);
       expect(restored.elapsedSeconds, 300);

--- a/test/data/models/walk_session_model_test.dart
+++ b/test/data/models/walk_session_model_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/data/models/walk_session_model.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
+
+void main() {
+  group('WalkSessionModel', () {
+    test('fromEntity で idle セッションを変換できる', () {
+      const session = WalkSession(status: WalkStatus.idle);
+      final model = WalkSessionModel.fromEntity('session-1', session);
+
+      expect(model.uid, 'session-1');
+      expect(model.status, WalkStatus.idle);
+      expect(model.startedAt, isNull);
+      expect(model.finishedAt, isNull);
+      expect(model.elapsedSeconds, 0);
+    });
+
+    test('fromEntity で finished セッションを変換できる', () {
+      final startedAt = DateTime(2024, 1, 1, 9, 0);
+      final finishedAt = DateTime(2024, 1, 1, 9, 30);
+      final session = WalkSession(
+        status: WalkStatus.finished,
+        startedAt: startedAt,
+        finishedAt: finishedAt,
+        elapsedSeconds: 1800,
+      );
+      final model = WalkSessionModel.fromEntity('session-1', session);
+
+      expect(model.status, WalkStatus.finished);
+      expect(model.startedAt, startedAt);
+      expect(model.finishedAt, finishedAt);
+      expect(model.elapsedSeconds, 1800);
+    });
+
+    test('toEntity でモデルからエンティティに変換できる', () {
+      final startedAt = DateTime(2024, 1, 1, 9, 0);
+      final session = WalkSession(
+        status: WalkStatus.walking,
+        startedAt: startedAt,
+        elapsedSeconds: 300,
+      );
+      final model = WalkSessionModel.fromEntity('session-1', session);
+      final restored = model.toEntity();
+
+      expect(restored.status, WalkStatus.walking);
+      expect(restored.startedAt, startedAt);
+      expect(restored.elapsedSeconds, 300);
+    });
+  });
+}

--- a/test/domain/entities/walk_session_test.dart
+++ b/test/domain/entities/walk_session_test.dart
@@ -4,8 +4,9 @@ import 'package:tekushare/domain/entities/walk_session.dart';
 void main() {
   group('WalkSession', () {
     test('デフォルト状態は idle で経過秒数 0', () {
-      const session = WalkSession(status: WalkStatus.idle);
+      const session = WalkSession(id: 'session-1', status: WalkStatus.idle);
 
+      expect(session.id, 'session-1');
       expect(session.status, WalkStatus.idle);
       expect(session.elapsedSeconds, 0);
       expect(session.startedAt, isNull);
@@ -13,13 +14,14 @@ void main() {
     });
 
     test('copyWith でステータスを walking に変更できる', () {
-      const session = WalkSession(status: WalkStatus.idle);
+      const session = WalkSession(id: 'session-1', status: WalkStatus.idle);
       final started = DateTime(2024, 1, 1, 9, 0);
       final updated = session.copyWith(
         status: WalkStatus.walking,
         startedAt: started,
       );
 
+      expect(updated.id, 'session-1');
       expect(updated.status, WalkStatus.walking);
       expect(updated.startedAt, started);
       expect(updated.elapsedSeconds, 0);
@@ -29,6 +31,7 @@ void main() {
       final started = DateTime(2024, 1, 1, 9, 0);
       final finished = DateTime(2024, 1, 1, 9, 30);
       final session = WalkSession(
+        id: 'session-1',
         status: WalkStatus.walking,
         startedAt: started,
         elapsedSeconds: 1800,
@@ -46,12 +49,14 @@ void main() {
     test('copyWith で変更しないフィールドは元の値を保持する', () {
       final started = DateTime(2024, 1, 1, 9, 0);
       final session = WalkSession(
+        id: 'session-1',
         status: WalkStatus.walking,
         startedAt: started,
         elapsedSeconds: 60,
       );
       final updated = session.copyWith(elapsedSeconds: 120);
 
+      expect(updated.id, 'session-1');
       expect(updated.status, WalkStatus.walking);
       expect(updated.startedAt, started);
       expect(updated.elapsedSeconds, 120);
@@ -59,6 +64,7 @@ void main() {
 
     test('copyWith で startedAt を null に戻せる', () {
       final session = WalkSession(
+        id: 'session-1',
         status: WalkStatus.idle,
         startedAt: DateTime(2024, 1, 1, 9, 0),
       );
@@ -69,6 +75,7 @@ void main() {
 
     test('copyWith で finishedAt を null に戻せる', () {
       final session = WalkSession(
+        id: 'session-1',
         status: WalkStatus.finished,
         finishedAt: DateTime(2024, 1, 1, 9, 30),
       );


### PR DESCRIPTION
## 📝 説明
ローカルDBである Isar のスキーマ定義を実装しました。
ドメインエンティティとの相互変換（toEntity / fromEntity）も含みます。

## 🔗 関連 Issue
closes #23

## 📋 変更内容
- [x] 機能追加

## ✅ チェックリスト
- [x] コードレビュー済み
- [x] ユニットテスト実施済み（11件 all passed）
- [ ] ドキュメント更新済み
- [x] 自分でテスト確認済み

## 🔧 変更内容詳細

### `pubspec.yaml`
- `isar` / `isar_flutter_libs` / `path_provider` を dependencies に追加
- `isar_generator` / `build_runner` を dev_dependencies に追加

### `lib/data/models/spot_model.dart`
- `@Collection()` アノテーション付きの Isar スキーマ定義
- `SpotStatus` enum を `@Enumerated(EnumType.name)` で保存
- `toEntity()` / `fromEntity()` でエンティティとの相互変換

### `lib/data/models/walk_session_model.dart`
- `WalkStatus` enum を `@Enumerated(EnumType.name)` で保存
- `startedAt` / `finishedAt` を nullable で保持

### `lib/data/models/walk_route_model.dart`
- `List<LatLng>` を JSON 文字列（`pointsJson`）として保存
- `toEntity()` で JSON デコードして `WalkRoute` に変換

### `*.g.dart`（自動生成）
- `dart run build_runner build` で生成

### `analysis_options.yaml`
- 生成ファイル（`**/*.g.dart`）を解析対象から除外

### `test/data/models/`（新規）
- 各モデルの変換ロジックのユニットテストを追加（計11件）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 位置スポット、歩行ルート、歩行セッションのデータをローカルに保存できるようになりました。
  * ローカル保存用データとドメインデータの相互変換に対応しました。
* **テスト**
  * スポット、ルート、セッションの変換処理に関する自動テストを追加しました。
* **その他**
  * 生成コードの解析除外設定を追加しました。
  * ローカル保存とコード生成に必要な依存関係を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->