### PR TITLE
[Logic] ホーム画面とロジックの繋ぎ込み (#29)

### DIFF
--- a/lib/screens/pages/home/view/home_page.dart
+++ b/lib/screens/pages/home/view/home_page.dart
@@ -1,23 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
+import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 import 'package:tekushare/screens/widgets/common/primary_button.dart';
 
 /// ホーム画面
-class HomePage extends StatefulWidget {
+class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
 
   @override
-  State<HomePage> createState() => _HomePageState();
+  ConsumerState<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage>
+class _HomePageState extends ConsumerState<HomePage>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late List<Animation<double>> _footprintFades;
@@ -61,6 +64,16 @@ class _HomePageState extends State<HomePage>
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<WalkSession>(walkSessionProvider, (previous, next) {
+      if (next.status == WalkStatus.walking &&
+          previous?.status != WalkStatus.walking) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const WalkPage()),
+        );
+      }
+    });
+
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
@@ -72,10 +85,8 @@ class _HomePageState extends State<HomePage>
               opacity: _buttonFade,
               child: PrimaryButton(
                 label: AppStrings.startWalk,
-                onPressed: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const WalkPage()),
-                ),
+                onPressed: () =>
+                    ref.read(walkSessionProvider.notifier).startWalk(),
               ),
             ),
             const Spacer(),

--- a/lib/screens/pages/home/view/home_page.dart
+++ b/lib/screens/pages/home/view/home_page.dart
@@ -65,8 +65,7 @@ class _HomePageState extends ConsumerState<HomePage>
   @override
   Widget build(BuildContext context) {
     ref.listen<WalkSession>(walkSessionProvider, (previous, next) {
-      if (next.status == WalkStatus.walking &&
-          previous?.status != WalkStatus.walking) {
+      if (next.status == WalkStatus.walking && next.id != previous?.id) {
         Navigator.push(
           context,
           MaterialPageRoute(builder: (_) => const WalkPage()),

--- a/test/screens/pages/home/home_page_test.dart
+++ b/test/screens/pages/home/home_page_test.dart
@@ -2,21 +2,52 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
+import 'package:tekushare/domain/repositories/route_repository.dart';
+import 'package:tekushare/domain/repositories/walk_session_repository.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/clock_provider.dart';
+
+class _FakeWalkSessionRepository implements WalkSessionRepository {
+  @override
+  Future<void> saveSession(WalkSession session) async {}
+  @override
+  Future<List<WalkSession>> getAllSessions() async => [];
+  @override
+  Future<WalkSession?> getSessionById(String id) async => null;
+}
+
+class _FakeRouteRepository implements RouteRepository {
+  @override
+  Future<void> saveRoute(WalkRoute route) async {}
+  @override
+  Future<WalkRoute?> getRouteBySessionId(String sessionId) async => null;
+  @override
+  Future<List<WalkRoute>> getAllRoutes() async => [];
+}
 
 void main() {
   group('HomePage', () {
     Future<void> pumpPage(WidgetTester tester) async {
-      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.physicalSize = const Size(1170, 3600);
       tester.view.devicePixelRatio = 3.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(home: HomePage()),
+        ProviderScope(
+          overrides: [
+            // Stream.periodic のタイマーがテスト後に残らないよう単発に差し替え
+            clockProvider.overrideWith((ref) => Stream.value(DateTime.now())),
+            walkSessionRepositoryProvider
+                .overrideWithValue(_FakeWalkSessionRepository()),
+            routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+          ],
+          child: const MaterialApp(home: HomePage()),
         ),
       );
       // アニメーション（2800ms）を完了させてボタンを操作可能にする

--- a/test/screens/pages/home/view/home_page_test.dart
+++ b/test/screens/pages/home/view/home_page_test.dart
@@ -110,5 +110,39 @@ void main() {
 
       expect(find.byType(WalkPage), findsOneWidget);
     });
+
+    testWidgets('walking 状態のまま戻って再度ボタンを押しても WalkPage へ遷移する', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3600);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final container = ProviderContainer(overrides: _baseOverrides);
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: HomePage()),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 3000));
+
+      // 1回目：WalkPage へ遷移
+      await tester.tap(find.byType(ElevatedButton).first);
+      await tester.pumpAndSettle();
+      expect(find.byType(WalkPage), findsOneWidget);
+
+      // WalkPage から戻る（walking 状態のまま）
+      final NavigatorState navigator = tester.state(find.byType(Navigator));
+      navigator.pop();
+      await tester.pumpAndSettle();
+      expect(find.byType(HomePage), findsOneWidget);
+
+      // 2回目：再度ボタンを押しても WalkPage へ遷移する
+      await tester.tap(find.byType(ElevatedButton).first);
+      await tester.pumpAndSettle();
+      expect(find.byType(WalkPage), findsOneWidget);
+    });
   });
 }

--- a/test/screens/pages/home/view/home_page_test.dart
+++ b/test/screens/pages/home/view/home_page_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/config/flavor.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
+import 'package:tekushare/domain/repositories/route_repository.dart';
+import 'package:tekushare/domain/repositories/walk_session_repository.dart';
+import 'package:tekushare/screens/pages/home/view/home_page.dart';
+import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/walk_session_provider.dart';
+
+class _FakeWalkSessionRepository implements WalkSessionRepository {
+  @override
+  Future<void> saveSession(WalkSession session) async {}
+  @override
+  Future<List<WalkSession>> getAllSessions() async => [];
+  @override
+  Future<WalkSession?> getSessionById(String id) async => null;
+}
+
+class _FakeRouteRepository implements RouteRepository {
+  @override
+  Future<void> saveRoute(WalkRoute route) async {}
+  @override
+  Future<WalkRoute?> getRouteBySessionId(String sessionId) async => null;
+  @override
+  Future<List<WalkRoute>> getAllRoutes() async => [];
+}
+
+Widget _buildTestApp({List<Override> overrides = const []}) {
+  AppConfig.setFlavor(Flavor.dev);
+  return ProviderScope(
+    overrides: [
+      walkSessionRepositoryProvider
+          .overrideWithValue(_FakeWalkSessionRepository()),
+      routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+      ...overrides,
+    ],
+    child: const MaterialApp(home: HomePage()),
+  );
+}
+
+void main() {
+  group('HomePage', () {
+    testWidgets('初期状態でホーム画面が表示される', (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(_buildTestApp());
+      await tester.pump();
+
+      expect(find.byType(HomePage), findsOneWidget);
+    });
+
+    testWidgets('散歩を始めるボタン押下でセッションが walking 状態になる', (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final container = ProviderContainer(
+        overrides: [
+          walkSessionRepositoryProvider
+              .overrideWithValue(_FakeWalkSessionRepository()),
+          routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: HomePage()),
+        ),
+      );
+      // アニメーション完了まで進める
+      await tester.pump(const Duration(milliseconds: 3000));
+
+      await tester.tap(find.byType(ElevatedButton).first);
+      await tester.pump();
+
+      expect(
+        container.read(walkSessionProvider).status,
+        WalkStatus.walking,
+      );
+    });
+
+    testWidgets('walking 状態になったら WalkPage へ遷移する', (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final container = ProviderContainer(
+        overrides: [
+          walkSessionRepositoryProvider
+              .overrideWithValue(_FakeWalkSessionRepository()),
+          routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: HomePage()),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 3000));
+
+      await tester.tap(find.byType(ElevatedButton).first);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WalkPage), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/pages/home/view/home_page_test.dart
+++ b/test/screens/pages/home/view/home_page_test.dart
@@ -9,6 +9,7 @@ import 'package:tekushare/domain/repositories/walk_session_repository.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/clock_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {
@@ -29,20 +30,18 @@ class _FakeRouteRepository implements RouteRepository {
   Future<List<WalkRoute>> getAllRoutes() async => [];
 }
 
-Widget _buildTestApp({List<Override> overrides = const []}) {
-  AppConfig.setFlavor(Flavor.dev);
-  return ProviderScope(
-    overrides: [
+/// 共通のプロバイダーオーバーライド（clockProvider のタイマーを回避）
+List<Override> get _baseOverrides => [
+      // Stream.periodic によるタイマーをテストで残さないよう単発ストリームに差し替え
+      clockProvider.overrideWith((ref) => Stream.value(DateTime.now())),
       walkSessionRepositoryProvider
           .overrideWithValue(_FakeWalkSessionRepository()),
       routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
-      ...overrides,
-    ],
-    child: const MaterialApp(home: HomePage()),
-  );
-}
+    ];
 
 void main() {
+  AppConfig.setFlavor(Flavor.dev);
+
   group('HomePage', () {
     testWidgets('初期状態でホーム画面が表示される', (tester) async {
       tester.view.physicalSize = const Size(1170, 2532);
@@ -50,7 +49,12 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      await tester.pumpWidget(_buildTestApp());
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: _baseOverrides,
+          child: const MaterialApp(home: HomePage()),
+        ),
+      );
       await tester.pump();
 
       expect(find.byType(HomePage), findsOneWidget);
@@ -62,13 +66,7 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      final container = ProviderContainer(
-        overrides: [
-          walkSessionRepositoryProvider
-              .overrideWithValue(_FakeWalkSessionRepository()),
-          routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
-        ],
-      );
+      final container = ProviderContainer(overrides: _baseOverrides);
       addTearDown(container.dispose);
 
       await tester.pumpWidget(
@@ -90,18 +88,13 @@ void main() {
     });
 
     testWidgets('walking 状態になったら WalkPage へ遷移する', (tester) async {
-      tester.view.physicalSize = const Size(1170, 2532);
+      // WalkPage のコンテンツが収まるよう縦に広いサイズを指定
+      tester.view.physicalSize = const Size(1170, 3600);
       tester.view.devicePixelRatio = 3.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      final container = ProviderContainer(
-        overrides: [
-          walkSessionRepositoryProvider
-              .overrideWithValue(_FakeWalkSessionRepository()),
-          routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
-        ],
-      );
+      final container = ProviderContainer(overrides: _baseOverrides);
       addTearDown(container.dispose);
 
       await tester.pumpWidget(


### PR DESCRIPTION
## 概要

ホーム画面を `walkSessionProvider` に接続し、散歩開始フローを実装した。

## 変更内容

- `StatelessWidget` → `ConsumerStatefulWidget` に変更（アニメーションはそのまま維持）
- 「散歩を始める」ボタン押下で `walkSessionProvider.notifier.startWalk()` を呼び出す
- `ref.listen` で `WalkStatus.walking` への遷移を検知し `WalkPage` へ push する

## 動作確認

- `debugPrint` でログ確認 → `startWalk called: status=WalkStatus.walking` を確認
- 実機でボタン押下 → WalkPage への遷移を目視確認

## テスト

- 初期状態でホーム画面が表示される
- 散歩を始めるボタン押下でセッションが `walking` 状態になる
- `walking` 状態になったら `WalkPage` へ遷移する

## 完了条件

- [x] ボタン押下でセッションが開始される
- [x] WalkPage への遷移が正しく動作する

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ホーム画面の開始操作が、状態変化に連動して散歩画面へ進むようになりました。
  * 散歩開始後、画面遷移のタイミングがより安定しました。

* **テスト**
  * ホーム画面の表示、開始ボタンの動作、散歩画面への遷移を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->