### PR TITLE
[logic]散歩モード画面とロジックの繋ぎ込み (#30)

### DIFF
--- a/.github/workflows/move-to-done-on-merge.yml
+++ b/.github/workflows/move-to-done-on-merge.yml
@@ -66,4 +66,4 @@ jobs:
             -F projectId="$PROJECT_ID" \
             -F itemId="$ITEM_ID" \
             -F fieldId="$FIELD_ID" \
-            -F optionId="$DONE_OPTION_ID"
+            -f optionId="$DONE_OPTION_ID"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -13,4 +13,5 @@ abstract class AppColors {
   static const listSelected = Color(0xFF17A6C8);
   static const navActive = primary;
   static const navInactive = Color(0xFFB0B0B0);
+  static const error = Color(0xFFE53935);
 }

--- a/lib/core/constants/app_spacing.dart
+++ b/lib/core/constants/app_spacing.dart
@@ -24,6 +24,8 @@ abstract class AppSize {
   static const double mapPinSize = 36.0;
   static const double cardElevation = 2.0;
   static const double photoGridItem = 80.0;
+  static const double photoBoxWidth = 176.0;
+  static const double photoBoxHeight = 100.0;
   static const double timerFontSize = 56.0;
   static const double maxContentWidth = 480.0;
   static const double borderThin = 0.5;

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -11,6 +11,10 @@ abstract class AppStrings {
 
   // 散歩モード
   static const endWalk = '散歩を終了する';
+  static const gpsAcquiring = 'GPS取得中...';
+  static const gpsUnavailableError = 'GPS信号を取得できません';
+  static const photoSpotTitle = '散歩スポット';
+  static const photoTaken = '写真を撮影しました！行きたいリストに保存してください';
   static const endWalkConfirmMessage = '散歩を終了しますか？';
   static const endWalkConfirmButton = '終了する';
   static const takePhoto = '撮影する';

--- a/lib/domain/usecases/spot/save_spot.dart
+++ b/lib/domain/usecases/spot/save_spot.dart
@@ -6,7 +6,7 @@ class SaveSpot {
 
   final SpotRepository _repository;
 
-  Future<void> call({
+  Future<String> call({
     required String title,
     required double latitude,
     required double longitude,
@@ -14,8 +14,9 @@ class SaveSpot {
     SpotStatus status = SpotStatus.wantToGo,
   }) async {
     final now = DateTime.now();
+    final id = now.microsecondsSinceEpoch.toString();
     final spot = Spot(
-      id: now.microsecondsSinceEpoch.toString(),
+      id: id,
       title: title,
       latitude: latitude,
       longitude: longitude,
@@ -24,5 +25,6 @@ class SaveSpot {
       memo: memo,
     );
     await _repository.saveSpot(spot);
+    return id;
   }
 }

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/screens/pages/spot/viewmodel/want_to_go_viewmodel.dart';
@@ -208,10 +209,10 @@ class _PhotoBox extends ConsumerWidget {
 
     if (photoPath != null) {
       return SizedBox(
-        width: 176,
-        height: 100,
+        width: AppSize.photoBoxWidth,
+        height: AppSize.photoBoxHeight,
         child: ClipRRect(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(AppRadius.sm),
           child: Image.file(
             File(photoPath),
             fit: BoxFit.cover,
@@ -222,8 +223,8 @@ class _PhotoBox extends ConsumerWidget {
     }
 
     return SizedBox(
-      width: 176,
-      height: 100,
+      width: AppSize.photoBoxWidth,
+      height: AppSize.photoBoxHeight,
       child: CustomPaint(
         painter: const DashedBorderPainter(),
         child: _placeholder(),
@@ -237,14 +238,14 @@ class _PhotoBox extends ConsumerWidget {
       children: [
         SvgPicture.asset(
           'assets/SVG/camera.svg',
-          width: 24,
-          height: 24,
+          width: AppSize.iconMd,
+          height: AppSize.iconMd,
           colorFilter: const ColorFilter.mode(
             AppColors.textAccent,
             BlendMode.srcIn,
           ),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: AppSpacing.sm),
         const Text(
           AppStrings.addPhoto,
           style: TextStyle(

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -5,6 +7,7 @@ import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/screens/pages/spot/viewmodel/want_to_go_viewmodel.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
@@ -196,39 +199,60 @@ class _TitleInput extends StatelessWidget {
 // 写真エリア
 // ──────────────────────────────────────────
 
-class _PhotoBox extends StatelessWidget {
+class _PhotoBox extends ConsumerWidget {
   const _PhotoBox();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final photoPath = ref.watch(pendingPhotoProvider);
+
+    if (photoPath != null) {
+      return SizedBox(
+        width: 176,
+        height: 100,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: Image.file(
+            File(photoPath),
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) => _placeholder(),
+          ),
+        ),
+      );
+    }
+
     return SizedBox(
       width: 176,
       height: 100,
       child: CustomPaint(
         painter: const DashedBorderPainter(),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            SvgPicture.asset(
-              'assets/SVG/camera.svg',
-              width: 24,
-              height: 24,
-              colorFilter: const ColorFilter.mode(
-                AppColors.textAccent,
-                BlendMode.srcIn,
-              ),
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              AppStrings.addPhoto,
-              style: TextStyle(
-                color: AppColors.textAccent,
-                fontSize: AppTextStyle.sm,
-              ),
-            ),
-          ],
-        ),
+        child: _placeholder(),
       ),
+    );
+  }
+
+  Widget _placeholder() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        SvgPicture.asset(
+          'assets/SVG/camera.svg',
+          width: 24,
+          height: 24,
+          colorFilter: const ColorFilter.mode(
+            AppColors.textAccent,
+            BlendMode.srcIn,
+          ),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          AppStrings.addPhoto,
+          style: TextStyle(
+            color: AppColors.textAccent,
+            fontSize: AppTextStyle.sm,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -33,11 +33,9 @@ class WalkPage extends ConsumerWidget {
     }
 
     final imagePath = await ref.read(cameraServiceProvider).takePhoto();
-    if (imagePath == null) return;
+    if (imagePath == null || !context.mounted) return;
 
     ref.read(pendingPhotoProvider.notifier).state = imagePath;
-
-    if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text(AppStrings.photoTaken)),
     );

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -144,7 +144,7 @@ class _GpsStatusIndicator extends StatelessWidget {
           ),
           error: (_, __) => const Text(
             AppStrings.gpsUnavailableError,
-            style: TextStyle(color: Colors.red),
+            style: TextStyle(color: AppColors.error),
           ),
         ),
       ),

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:geolocator/geolocator.dart' show Position;
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
@@ -7,16 +9,44 @@ import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 import 'package:tekushare/screens/widgets/common/primary_button.dart';
 
 /// 散歩モード画面
-class WalkPage extends StatelessWidget {
+class WalkPage extends ConsumerWidget {
   const WalkPage({super.key});
 
+  Future<void> _onTakePhotoPressed(
+    BuildContext context,
+    WidgetRef ref,
+    AsyncValue<Position> locationState,
+  ) async {
+    if (!locationState.hasValue) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(AppStrings.gpsUnavailableError)),
+      );
+      return;
+    }
+
+    final imagePath = await ref.read(cameraServiceProvider).takePhoto();
+    if (imagePath == null) return;
+
+    ref.read(pendingPhotoProvider.notifier).state = imagePath;
+
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text(AppStrings.photoTaken)),
+    );
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locationState = ref.watch(locationProvider);
+
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
@@ -24,15 +54,16 @@ class WalkPage extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             const ClockHeader(),
-            const SizedBox(height: 60),
+            const SizedBox(height: 16),
+            _GpsStatusIndicator(locationState: locationState),
+            const Spacer(flex: 2),
             Center(
               child: _WalkActionButton(
                 label: AppStrings.takePhoto,
                 svgAsset: 'assets/SVG/camera.svg',
                 fontSize: AppTextStyle.x1l,
-                onPressed: () {
-                  // TODO: 撮影処理
-                },
+                onPressed: () =>
+                    _onTakePhotoPressed(context, ref, locationState),
               ),
             ),
             const SizedBox(height: 20),
@@ -45,7 +76,7 @@ class WalkPage extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(height: 70),
+            const Spacer(flex: 3),
             Center(
               child: PrimaryButton(
                 label: AppStrings.endWalk,
@@ -55,7 +86,7 @@ class WalkPage extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(height: 24),
+            const SizedBox(height: 16),
           ],
         ),
       ),
@@ -74,6 +105,50 @@ class WalkPage extends StatelessWidget {
             );
           }
         },
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// GPS 状態インジケーター
+// ──────────────────────────────────────────
+
+class _GpsStatusIndicator extends StatelessWidget {
+  const _GpsStatusIndicator({required this.locationState});
+
+  final AsyncValue<Position> locationState;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 40,
+      child: Center(
+        child: locationState.when(
+          data: (_) => const SizedBox.shrink(),
+          loading: () => const Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: AppColors.primary,
+                ),
+              ),
+              SizedBox(width: 8),
+              Text(
+                AppStrings.gpsAcquiring,
+                style: TextStyle(color: AppColors.textDisabled),
+              ),
+            ],
+          ),
+          error: (_, __) => const Text(
+            AppStrings.gpsUnavailableError,
+            style: TextStyle(color: Colors.red),
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/providers/app_providers.dart
+++ b/lib/screens/providers/app_providers.dart
@@ -12,6 +12,7 @@ import 'package:tekushare/domain/repositories/photo_repository.dart';
 import 'package:tekushare/domain/repositories/route_repository.dart';
 import 'package:tekushare/domain/repositories/spot_repository.dart';
 import 'package:tekushare/domain/repositories/walk_session_repository.dart';
+import 'package:tekushare/infrastructure/camera_service.dart';
 import 'package:tekushare/infrastructure/notification_service.dart';
 
 /// Isar インスタンスを非同期で提供する。
@@ -44,6 +45,10 @@ final photoRepositoryProvider = Provider<PhotoRepository>((ref) {
 
 final notificationServiceProvider = Provider<NotificationService>((ref) {
   return NotificationService.instance;
+});
+
+final cameraServiceProvider = Provider<CameraService>((ref) {
+  return CameraService();
 });
 
 /// DB 初期化完了を表すプロバイダー。

--- a/lib/screens/providers/spot_provider.dart
+++ b/lib/screens/providers/spot_provider.dart
@@ -26,7 +26,7 @@ class SpotNotifier extends StateNotifier<List<Spot>> {
   final AttachPhotoToSpot _attachPhotoToSpot;
   late final StreamSubscription<List<Spot>> _subscription;
 
-  Future<void> saveSpot({
+  Future<String> saveSpot({
     required String title,
     required double latitude,
     required double longitude,
@@ -67,6 +67,9 @@ final spotProvider = StateNotifierProvider<SpotNotifier, List<Spot>>((ref) {
     attachPhotoToSpot: AttachPhotoToSpot(photoRepo),
   );
 });
+
+/// 散歩中にカメラで撮影した写真の一時パス（WantToGoPage で使用）
+final pendingPhotoProvider = StateProvider<String?>((ref) => null);
 
 /// 現在選択中のステータスフィルタ（null = 全件）
 final selectedSpotStatusProvider = StateProvider<SpotStatus?>((ref) => null);

--- a/test/domain/usecases/spot/save_spot_test.dart
+++ b/test/domain/usecases/spot/save_spot_test.dart
@@ -77,5 +77,18 @@ void main() {
 
       expect(captured?.status, SpotStatus.visited);
     });
+
+    test('生成したスポットIDを返す', () async {
+      Spot? captured;
+      when(mockRepo.saveSpot(any)).thenAnswer((inv) {
+        captured = inv.positionalArguments[0] as Spot;
+        return Future<void>.value();
+      });
+
+      final id = await usecase.call(title: 'テスト', latitude: 0, longitude: 0);
+
+      expect(id, isNotEmpty);
+      expect(id, captured?.id);
+    });
   });
 }

--- a/test/screens/pages/home/home_page_test.dart
+++ b/test/screens/pages/home/home_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
@@ -11,6 +12,7 @@ import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/clock_provider.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {
   @override
@@ -46,6 +48,10 @@ void main() {
             walkSessionRepositoryProvider
                 .overrideWithValue(_FakeWalkSessionRepository()),
             routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+            // WalkPage の CircularProgressIndicator で pumpAndSettle がタイムアウトしないよう静的ストリームに差し替え
+            locationProvider.overrideWith(
+              (ref) => Stream<Position>.error(Exception('GPS unavailable')),
+            ),
           ],
           child: const MaterialApp(home: HomePage()),
         ),

--- a/test/screens/pages/home/view/home_page_test.dart
+++ b/test/screens/pages/home/view/home_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/config/flavor.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
@@ -10,6 +11,7 @@ import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/clock_provider.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {
@@ -37,6 +39,10 @@ List<Override> get _baseOverrides => [
       walkSessionRepositoryProvider
           .overrideWithValue(_FakeWalkSessionRepository()),
       routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+      // WalkPage の CircularProgressIndicator で pumpAndSettle がタイムアウトしないよう静的ストリームに差し替え
+      locationProvider.overrideWith(
+        (ref) => Stream<Position>.error(Exception('GPS unavailable')),
+      ),
     ];
 
 void main() {

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -1,25 +1,73 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/infrastructure/camera_service.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+// ──────────────────────────────────────────
+// フェイク実装
+// ──────────────────────────────────────────
+
+class _FakeCameraService extends Fake implements CameraService {
+  _FakeCameraService(this._returnPath);
+  final String? _returnPath;
+
+  @override
+  Future<String?> takePhoto() async => _returnPath;
+}
+
+Position _makePosition(double lat, double lng) => Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime.now(),
+      accuracy: 0,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: 0,
+      speedAccuracy: 0,
+    );
+
+// ──────────────────────────────────────────
+// テスト
+// ──────────────────────────────────────────
 
 void main() {
   group('WalkPage', () {
-    setUp(() {});
-
-    Future<void> pumpWalkPage(WidgetTester tester) async {
+    void setDisplaySize(WidgetTester tester) {
       tester.view.physicalSize = const Size(1170, 3000);
       tester.view.devicePixelRatio = 3.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
+    }
+
+    Future<void> pumpWalkPage(
+      WidgetTester tester, {
+      Stream<Position>? locationStream,
+      CameraService? camera,
+    }) async {
+      setDisplaySize(tester);
+
+      final overrides = <Override>[
+        locationProvider.overrideWith(
+          (ref) => locationStream ?? const Stream.empty(),
+        ),
+        if (camera != null) cameraServiceProvider.overrideWith((ref) => camera),
+      ];
 
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(home: WalkPage()),
+        ProviderScope(
+          overrides: overrides,
+          child: const MaterialApp(home: WalkPage()),
         ),
       );
       await tester.pump();
@@ -41,27 +89,94 @@ void main() {
       expect(find.byType(AppBottomNav), findsOneWidget);
     });
 
-    // 撮影するボタンをタップしても何も起きない
-    testWidgets('tapping take photo button does nothing', (tester) async {
-      await pumpWalkPage(tester);
+    // GPS 取得中は loading インジケーターが表示される
+    testWidgets('shows loading indicator while GPS is acquiring',
+        (tester) async {
+      await pumpWalkPage(tester, locationStream: const Stream.empty());
+
+      expect(find.text(AppStrings.gpsAcquiring), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    // GPS 取得失敗時はエラーテキストが表示される
+    testWidgets('shows error text when GPS is unavailable', (tester) async {
+      final errorStream = Stream<Position>.error(Exception('GPS error'));
+
+      await pumpWalkPage(tester, locationStream: errorStream);
+      await tester.pump();
+
+      expect(find.text(AppStrings.gpsUnavailableError), findsOneWidget);
+    });
+
+    // GPS 未取得でカメラボタンをタップするとエラー SnackBar が表示される
+    testWidgets('shows snackbar when camera tapped without GPS',
+        (tester) async {
+      await pumpWalkPage(tester, locationStream: const Stream.empty());
 
       await tester.tap(find.text(AppStrings.takePhoto));
       await tester.pump();
 
-      expect(find.byType(WalkPage), findsOneWidget);
+      expect(find.text(AppStrings.gpsUnavailableError), findsWidgets);
+    });
+
+    // GPS 取得済みで撮影すると pendingPhotoProvider に保存される
+    testWidgets('stores photo path in pendingPhotoProvider when photo taken',
+        (tester) async {
+      const imagePath = '/fake/photo.jpg';
+      final position = _makePosition(35.6895, 139.6917);
+
+      await pumpWalkPage(
+        tester,
+        locationStream: Stream.value(position),
+        camera: _FakeCameraService(imagePath),
+      );
+      await tester.pump(); // stream 受信
+
+      await tester.tap(find.text(AppStrings.takePhoto));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(WalkPage)),
+      );
+      expect(container.read(pendingPhotoProvider), imagePath);
+      expect(find.text(AppStrings.photoTaken), findsOneWidget);
+    });
+
+    // カメラをキャンセルした場合は pendingPhotoProvider に保存しない
+    testWidgets('does not store photo when camera is cancelled',
+        (tester) async {
+      final position = _makePosition(35.0, 139.0);
+
+      await pumpWalkPage(
+        tester,
+        locationStream: Stream.value(position),
+        camera: _FakeCameraService(null),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text(AppStrings.takePhoto));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(WalkPage)),
+      );
+      expect(container.read(pendingPhotoProvider), isNull);
     });
 
     // 行きたいリストに保存ボタンをタップすると WantToGoPage へ遷移する
     testWidgets(
         'navigates to WantToGoPage when save to want-to-go button is tapped',
         (tester) async {
-      tester.view.physicalSize = const Size(1170, 3000);
-      tester.view.devicePixelRatio = 3.0;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
+      setDisplaySize(tester);
+
+      final locationStream =
+          Stream<Position>.error(Exception('GPS unavailable'));
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [
+            locationProvider.overrideWith((ref) => locationStream),
+          ],
           child: MaterialApp(
             home: Builder(
               builder: (context) => ElevatedButton(
@@ -88,13 +203,16 @@ void main() {
     // 散歩を終了するボタンをタップすると EndWalkPage へ遷移する
     testWidgets('navigates to EndWalkPage when end walk button is tapped',
         (tester) async {
-      tester.view.physicalSize = const Size(1170, 3000);
-      tester.view.devicePixelRatio = 3.0;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
+      setDisplaySize(tester);
+
+      final locationStream =
+          Stream<Position>.error(Exception('GPS unavailable'));
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [
+            locationProvider.overrideWith((ref) => locationStream),
+          ],
           child: MaterialApp(
             home: Builder(
               builder: (context) => ElevatedButton(

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -130,7 +130,7 @@ void main() {
         locationStream: Stream.value(position),
         camera: _FakeCameraService(imagePath),
       );
-      await tester.pump(); // stream 受信
+      await tester.pump();
 
       await tester.tap(find.text(AppStrings.takePhoto));
       await tester.pumpAndSettle();
@@ -139,6 +139,24 @@ void main() {
         tester.element(find.byType(WalkPage)),
       );
       expect(container.read(pendingPhotoProvider), imagePath);
+    });
+
+    // GPS 取得済みで撮影すると photoTaken SnackBar が表示される
+    testWidgets('shows photoTaken snackbar after photo is taken',
+        (tester) async {
+      const imagePath = '/fake/photo.jpg';
+      final position = _makePosition(35.6895, 139.6917);
+
+      await pumpWalkPage(
+        tester,
+        locationStream: Stream.value(position),
+        camera: _FakeCameraService(imagePath),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text(AppStrings.takePhoto));
+      await tester.pumpAndSettle();
+
       expect(find.text(AppStrings.photoTaken), findsOneWidget);
     });
 


### PR DESCRIPTION
## 概要

- `WalkPage` を `ConsumerWidget` に変更し、`locationProvider` / `CameraService` / `spotProvider` に接続
- Closes #30

## 変更内容

- **WalkPage**: `locationProvider` を購読し、GPS 取得中・エラー状態をインジケーターとして画面に表示
- **カメラボタン**: `CameraService.takePhoto()` で撮影 → パスを `pendingPhotoProvider` に一時保存（スポットはまだ作成しない）
- **WantToGoPage**: `pendingPhotoProvider` を読み取り、撮影済み写真を写真エリアに表示
- **SaveSpot**: スポット ID を戻り値として返すよう変更（`Future<void>` → `Future<String>`）
- **cameraServiceProvider**: `app_providers.dart` に追加
- **AndroidManifest.xml**: 位置情報パーミッション（`ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`）を追加
- **レイアウト**: `Spacer` による可変スペーサーを採用し、全端末サイズでオーバーフローしないよう対応
- **home_page_test**: `locationProvider` オーバーライドを追加（WalkPage 遷移テストの pumpAndSettle タイムアウト対策）
- **Move to Done on PR Merge**: `optionId` を `-f` で文字列として渡すよう修正

## 撮影フロー

```
撮影するボタン → カメラ起動 → 写真を pendingPhotoProvider に保存
現在地を行きたいリストに保存 → WantToGoPage（撮影写真が表示される）
```

## テスト

- GPS 取得中・エラー状態の表示
- GPS 未取得時のカメラタップ → エラー SnackBar
- 撮影成功時に `pendingPhotoProvider` へ保存されること
- カメラキャンセル時は保存しないこと
- `SaveSpot` がスポット ID を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 位置情報を使った散歩中の写真撮影ができるようになりました。
  * 撮影した写真を一時的に保持し、「行きたいリスト」保存後に写真付きスポットとして確認できます。
* **改善**
  * GPS取得中・取得失敗時の案内（進捗表示／エラー表示）や、撮影時のエラースナックバーを追加しました。
  * 写真表示の見た目を安定化し、読み込み失敗時はプレースホルダー表示に切り替わります。
* **対応**
  * 位置情報の権限（精密／おおまか）を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->