### PR TITLE
[Logic] 散歩終了確認画面とロジックの繋ぎ込み

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -15,6 +15,18 @@ migration:
     - platform: root
       create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
       base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+    - platform: android
+      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+    - platform: ios
+      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+    - platform: macos
+      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+    - platform: web
+      create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
+      base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
     - platform: windows
       create_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159
       base_revision: 48c32af0345e9ad5747f78ddce828c7f795f7159

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,5 @@
     "editor.suggestSelection": "first",
     "editor.tabCompletion": "onlySnippets"
   },
-  "cmake.sourceDirectory": "C:/programming/tekushare-app/linux"
+  "cmake.configureOnOpen": false
 }

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -6,9 +6,11 @@ import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
+import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 
@@ -68,6 +70,20 @@ class _EndWalkPageState extends ConsumerState<EndWalkPage>
     super.dispose();
   }
 
+  Future<void> _onConfirm() async {
+    final session = ref.read(walkSessionProvider);
+    final now = DateTime.now();
+    final route = WalkRoute(
+      id: now.microsecondsSinceEpoch.toString(),
+      walkSessionId: session.id,
+      points: const [],
+      createdAt: now,
+    );
+    await ref.read(walkSessionProvider.notifier).endWalk(route);
+    if (!mounted) return;
+    Navigator.popUntil(context, (r) => r.isFirst);
+  }
+
   @override
   Widget build(BuildContext context) {
     final sizing = AppSizingTheme.of(context);
@@ -89,17 +105,7 @@ class _EndWalkPageState extends ConsumerState<EndWalkPage>
                       opacity: _cardFade,
                       child: _ConfirmCard(
                         onCancel: () => Navigator.pop(context),
-                        onConfirm: () {
-                          Navigator.pushAndRemoveUntil(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => const WalkRoutePage(
-                                showSaveDialogOnLoad: true,
-                              ),
-                            ),
-                            (route) => route.isFirst,
-                          );
-                        },
+                        onConfirm: () => _onConfirm(),
                       ),
                     ),
                     const Spacer(flex: 3),

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -9,7 +9,6 @@ import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
-import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 
@@ -91,7 +90,6 @@ class _EndWalkPageState extends ConsumerState<EndWalkPage>
                       child: _ConfirmCard(
                         onCancel: () => Navigator.pop(context),
                         onConfirm: () {
-                          ref.read(walkSessionProvider.notifier).resetWalk();
                           Navigator.pushAndRemoveUntil(
                             context,
                             MaterialPageRoute(


### PR DESCRIPTION
## 概要

- `EndWalkPage` の確認ボタンから `resetWalk()` 呼び出しを削除
- 散歩終了前にセッションデータ（経過時間など）が消えてしまうバグを修正

## 変更内容

- `resetWalk()` 削除：確認ボタン押下時にセッションを即リセットしていたため、`WalkRoutePage` でルートを保存する前にデータが失われていた
- `endWalk()` の呼び出しは GPS ルート収集を実装する #35 で `WalkRoutePage` から行う設計
- 不要になった `walk_session_provider` の import を削除

## 関連 Issue

Closes #31

## テスト

- [ ] 散歩終了確認 → WalkRoutePage への遷移が正常に動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * ウォーク終了後の確定操作で、確認後にそのまま保存ダイアログ付きの画面へ移動するようになりました。
  * 画面遷移時の流れがシンプルになり、終了後の操作がよりスムーズになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->