### PR TITLE
[Logic] 行きたい！ページとロジックの繋ぎ込み

### DIFF
--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -8,6 +8,7 @@ import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/screens/pages/spot/viewmodel/want_to_go_viewmodel.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
@@ -44,14 +45,32 @@ class _WantToGoPageState extends ConsumerState<WantToGoPage> {
   }
 
   void _onSavePressed() {
+    final title = _titleController.text.isEmpty
+        ? AppStrings.noTitle
+        : _titleController.text;
+    final location = ref.read(locationProvider).valueOrNull;
+    if (location == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(AppStrings.gpsUnavailableError)),
+      );
+      return;
+    }
     showDialog<void>(
       context: context,
       builder: (_) => _ConfirmDialog(
-        title: _titleController.text.isEmpty
-            ? AppStrings.noTitle
-            : _titleController.text,
-        onConfirm: () {
+        title: title,
+        onConfirm: () async {
           Navigator.pop(context);
+          final spotId = await ref.read(spotProvider.notifier).saveSpot(
+                title: title,
+                latitude: location.latitude,
+                longitude: location.longitude,
+              );
+          final photo = ref.read(pendingPhotoProvider);
+          if (photo != null) {
+            await ref.read(spotProvider.notifier).attachPhoto(spotId, photo);
+            ref.read(pendingPhotoProvider.notifier).state = null;
+          }
           if (!mounted) return;
           _showSavedDialog();
         },

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -6,11 +6,9 @@ import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
-import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
-import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 
@@ -70,18 +68,14 @@ class _EndWalkPageState extends ConsumerState<EndWalkPage>
     super.dispose();
   }
 
-  Future<void> _onConfirm() async {
-    final session = ref.read(walkSessionProvider);
-    final now = DateTime.now();
-    final route = WalkRoute(
-      id: now.microsecondsSinceEpoch.toString(),
-      walkSessionId: session.id,
-      points: const [],
-      createdAt: now,
+  void _onConfirm() {
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(
+        builder: (_) => const WalkRoutePage(showSaveDialogOnLoad: true),
+      ),
+      (route) => route.isFirst,
     );
-    await ref.read(walkSessionProvider.notifier).endWalk(route);
-    if (!mounted) return;
-    Navigator.popUntil(context, (r) => r.isFirst);
   }
 
   @override

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -8,6 +8,7 @@ import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
+import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
@@ -69,6 +70,7 @@ class _EndWalkPageState extends ConsumerState<EndWalkPage>
   }
 
   void _onConfirm() {
+    ref.read(walkSessionProvider.notifier).resetWalk();
     Navigator.pushAndRemoveUntil(
       context,
       MaterialPageRoute(

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -18,10 +18,6 @@ import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
-// ──────────────────────────────────────────
-// フェイク実装
-// ──────────────────────────────────────────
-
 class _FakeSaveSpot implements SaveSpot {
   const _FakeSaveSpot();
   @override
@@ -78,10 +74,6 @@ final _spotOverride = spotProvider.overrideWith(
     attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
   ),
 );
-
-// ──────────────────────────────────────────
-// テスト
-// ──────────────────────────────────────────
 
 void main() {
   group('WantToGoPage', () {

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -96,11 +96,17 @@ void main() {
                 child: child!,
               );
             },
-            home: const WantToGoPage(),
+            home: Consumer(
+              builder: (_, ref, child) {
+                ref.watch(locationProvider); // autoDisposeを防いでStreamを定着させる
+                return child!;
+              },
+              child: const WantToGoPage(),
+            ),
           ),
         ),
       );
-      await tester.pump();
+      await tester.pumpAndSettle();
     }
 
     // ページタイトルが表示される
@@ -303,7 +309,15 @@ void main() {
               builder: (context) => ElevatedButton(
                 onPressed: () => Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => const WantToGoPage()),
+                  MaterialPageRoute(
+                    builder: (_) => Consumer(
+                      builder: (_, ref, child) {
+                        ref.watch(locationProvider);
+                        return child!;
+                      },
+                      child: const WantToGoPage(),
+                    ),
+                  ),
                 ),
                 child: const Text('start'),
               ),

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -1,14 +1,87 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+// ──────────────────────────────────────────
+// フェイク実装
+// ──────────────────────────────────────────
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-spot-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots();
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => const Stream.empty();
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+Position _makePosition(double lat, double lng) => Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime.now(),
+      accuracy: 0,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: 0,
+      speedAccuracy: 0,
+    );
+
+final _locationOverride = locationProvider.overrideWith(
+  (ref) => Stream.value(_makePosition(35.0, 135.0)),
+);
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: const _FakeGetSpots(),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
+
+// ──────────────────────────────────────────
+// テスト
+// ──────────────────────────────────────────
 
 void main() {
   group('WantToGoPage', () {
@@ -20,6 +93,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_locationOverride, _spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -110,10 +184,44 @@ void main() {
       );
     });
 
+    // GPS未取得時に保存ボタンを押すとスナックバーが表示される
+    testWidgets('pressing save button without GPS shows snackbar',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [_spotOverride],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const WantToGoPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text(AppStrings.wantToGoSave));
+      await tester.pump();
+
+      expect(find.text(AppStrings.gpsUnavailableError), findsOneWidget);
+    });
+
     // 保存ボタンを押すと確認ダイアログが表示される
     testWidgets('pressing save button shows confirmation dialog',
         (tester) async {
       await pumpPage(tester);
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
@@ -126,6 +234,7 @@ void main() {
         'confirmation dialog shows no-title placeholder when title is empty',
         (tester) async {
       await pumpPage(tester);
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
@@ -136,6 +245,7 @@ void main() {
     // タイトル入力時の確認ダイアログに入力値が表示される
     testWidgets('confirmation dialog shows entered title', (tester) async {
       await pumpPage(tester);
+      await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField), 'テストスポット');
       await tester.tap(find.text(AppStrings.wantToGoSave));
@@ -153,6 +263,7 @@ void main() {
     // 確認ダイアログのキャンセルでダイアログが閉じる
     testWidgets('canceling confirmation dialog closes dialog', (tester) async {
       await pumpPage(tester);
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
@@ -162,9 +273,11 @@ void main() {
       expect(find.text(AppStrings.wantToGoConfirmMessage), findsNothing);
     });
 
-    // 確認ダイアログの保存で保存完了ダイアログが表示される
-    testWidgets('confirming save shows save complete dialog', (tester) async {
+    // 確認ダイアログの保存でスポットが保存されて完了ダイアログが表示される
+    testWidgets('confirming save stores spot and shows save complete dialog',
+        (tester) async {
       await pumpPage(tester);
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
@@ -183,6 +296,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_locationOverride, _spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -229,6 +343,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_locationOverride, _spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -270,6 +385,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_locationOverride, _spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -311,6 +427,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_locationOverride, _spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -352,6 +469,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_locationOverride, _spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;


### PR DESCRIPTION
## 概要

- 保存ボタン押下時に `locationProvider` から現在地を取得し、`spotProvider.saveSpot()` で Isar に保存
- GPS 未取得の場合はスナックバーでエラー表示して処理を中断
- 写真がある場合は `attachPhoto()` で紐づけて `pendingPhotoProvider` をリセット

## 変更内容

### `want_to_go_page.dart`
- `_onSavePressed()` に GPS チェックを追加
- 確認ダイアログの `onConfirm` で `saveSpot()` → `attachPhoto()` の非同期処理を実装

### `want_to_go_page_test.dart`
- `locationProvider` / `spotProvider` のフェイクを追加（テストの Isar 非依存化）
- GPS 未取得時にスナックバーが表示されるテストを追加
- 既存の保存フローテストを GPS モック対応に更新

## 関連 Issue

Closes #32