### PR TITLE
[Logic] スポットリストページとロジックの繋ぎ込み

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -51,6 +51,7 @@ abstract class AppStrings {
 
   // リストページ
   static const listWentTab = '行った！';
+  static const spotListEmpty = 'スポットがありません';
 
   // スポット
   static const statusWantToGo = '行きたい';

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
@@ -16,9 +17,9 @@ import 'package:tekushare/screens/widgets/common/dashed_border_painter.dart';
 
 /// 行きたい！／行った！共通詳細ページ
 class SpotDetailPage extends ConsumerStatefulWidget {
-  const SpotDetailPage({super.key, required this.isWantToGo});
+  const SpotDetailPage({super.key, required this.spot});
 
-  final bool isWantToGo;
+  final Spot spot;
 
   @override
   ConsumerState<SpotDetailPage> createState() => _SpotDetailPageState();
@@ -117,7 +118,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         backgroundColor: AppColors.primary,
         foregroundColor: Colors.white,
         title: Text(
-          widget.isWantToGo
+          widget.spot.status == SpotStatus.wantToGo
               ? AppStrings.wantToGoPageTitle
               : AppStrings.listWentTab,
         ),
@@ -144,7 +145,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
               SizedBox(height: AppSizingTheme.of(context).sectionSpacing),
               const _PhotoBox(),
               SizedBox(height: AppSizingTheme.of(context).sectionSpacing),
-              if (widget.isWantToGo)
+              if (widget.spot.status == SpotStatus.wantToGo)
                 _MoveToWentButton(onPressed: _onMoveToWentPressed)
               else
                 _DeleteButton(onPressed: _onDeletePressed),

--- a/lib/screens/pages/spot/view/spot_list_page.dart
+++ b/lib/screens/pages/spot/view/spot_list_page.dart
@@ -81,7 +81,8 @@ class SpotListPage extends ConsumerWidget {
                       itemBuilder: (context, i) {
                         final spot = filtered[i];
                         return _ListItem(
-                          date: '${spot.createdAt.month}/${spot.createdAt.day}',
+                          date:
+                              '${spot.createdAt.month.toString().padLeft(2, '0')}/${spot.createdAt.day.toString().padLeft(2, '0')}',
                           title: spot.title,
                           onTap: () => Navigator.push(
                             context,

--- a/lib/screens/pages/spot/view/spot_list_page.dart
+++ b/lib/screens/pages/spot/view/spot_list_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
-import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
@@ -31,10 +30,7 @@ class SpotListPage extends ConsumerWidget {
     final state = ref.watch(spotListViewModelProvider);
     final vm = ref.read(spotListViewModelProvider.notifier);
 
-    final spots = ref.watch(spotProvider);
-    final filter =
-        state.isWantToGoTab ? SpotStatus.wantToGo : SpotStatus.visited;
-    final filtered = spots.where((s) => s.status == filter).toList();
+    final filtered = ref.watch(filteredSpotsProvider);
 
     final sizing = AppSizingTheme.of(context);
 

--- a/lib/screens/pages/spot/view/spot_list_page.dart
+++ b/lib/screens/pages/spot/view/spot_list_page.dart
@@ -2,11 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
 import 'package:tekushare/screens/pages/spot/viewmodel/spot_list_viewmodel.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/category_chip_group.dart';
 
@@ -27,6 +30,11 @@ class SpotListPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(spotListViewModelProvider);
     final vm = ref.read(spotListViewModelProvider.notifier);
+
+    final spots = ref.watch(spotProvider);
+    final filter =
+        state.isWantToGoTab ? SpotStatus.wantToGo : SpotStatus.visited;
+    final filtered = spots.where((s) => s.status == filter).toList();
 
     final sizing = AppSizingTheme.of(context);
 
@@ -50,7 +58,6 @@ class SpotListPage extends ConsumerWidget {
               onTap: vm.selectTab,
             ),
             const SizedBox(height: 32),
-            // TODO(#8): カテゴリフィルタリングはデータ連携issueで実装
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: CategoryChipGroup(
@@ -61,22 +68,34 @@ class SpotListPage extends ConsumerWidget {
             ),
             const SizedBox(height: 32),
             Expanded(
-              child: ListView.separated(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                itemCount: state.currentItems.length,
-                separatorBuilder: (_, __) => const SizedBox(height: 8),
-                itemBuilder: (context, i) => _ListItem(
-                  date: state.currentItems[i].date,
-                  title: state.currentItems[i].title,
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) =>
-                          SpotDetailPage(isWantToGo: state.isWantToGoTab),
+              child: filtered.isEmpty
+                  ? const Center(
+                      child: Text(
+                        AppStrings.spotListEmpty,
+                        style: TextStyle(
+                          color: AppColors.textDisabled,
+                          fontSize: AppTextStyle.md2,
+                        ),
+                      ),
+                    )
+                  : ListView.separated(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      itemCount: filtered.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 8),
+                      itemBuilder: (context, i) {
+                        final spot = filtered[i];
+                        return _ListItem(
+                          date: '${spot.createdAt.month}/${spot.createdAt.day}',
+                          title: spot.title,
+                          onTap: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => SpotDetailPage(spot: spot),
+                            ),
+                          ),
+                        );
+                      },
                     ),
-                  ),
-                ),
-              ),
             ),
           ],
         ),

--- a/lib/screens/pages/spot/viewmodel/spot_list_viewmodel.dart
+++ b/lib/screens/pages/spot/viewmodel/spot_list_viewmodel.dart
@@ -24,10 +24,7 @@ class SpotListState {
 
 class SpotListViewModel extends Notifier<SpotListState> {
   @override
-  SpotListState build() {
-    ref.read(selectedSpotStatusProvider.notifier).state = SpotStatus.wantToGo;
-    return const SpotListState();
-  }
+  SpotListState build() => const SpotListState();
 
   void selectTab(bool isWantToGo) {
     state = state.copyWith(isWantToGoTab: isWantToGo);

--- a/lib/screens/pages/spot/viewmodel/spot_list_viewmodel.dart
+++ b/lib/screens/pages/spot/viewmodel/spot_list_viewmodel.dart
@@ -1,8 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 
-typedef SpotItem = ({String date, String title});
-
 class SpotListState {
   const SpotListState({
     this.isWantToGoTab = true,
@@ -11,24 +9,6 @@ class SpotListState {
 
   final bool isWantToGoTab;
   final String selectedCategory;
-
-  static const wantToGoItems = <SpotItem>[
-    (date: '4/12', title: 'ひだまりパーク'),
-    (date: '5/12', title: 'Cafe&Gallery'),
-    (date: '6/12', title: 'カフェ Noce'),
-    (date: '7/12', title: 'むすび屋（雑貨屋）'),
-    (date: '8/12', title: 'ごはん処 まるふく'),
-    (date: '9/12', title: 'cafe hanahana'),
-    (date: '10/12', title: 'time spot'),
-  ];
-
-  static const wentItems = <SpotItem>[
-    (date: '1/15', title: '新宿御苑'),
-    (date: '2/03', title: 'タリーズ 銀座店'),
-    (date: '3/20', title: 'ブルーボトルコーヒー'),
-  ];
-
-  List<SpotItem> get currentItems => isWantToGoTab ? wantToGoItems : wentItems;
 
   SpotListState copyWith({
     bool? isWantToGoTab,

--- a/lib/screens/pages/spot/viewmodel/spot_list_viewmodel.dart
+++ b/lib/screens/pages/spot/viewmodel/spot_list_viewmodel.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 
 class SpotListState {
   const SpotListState({
@@ -22,10 +24,15 @@ class SpotListState {
 
 class SpotListViewModel extends Notifier<SpotListState> {
   @override
-  SpotListState build() => const SpotListState();
+  SpotListState build() {
+    ref.read(selectedSpotStatusProvider.notifier).state = SpotStatus.wantToGo;
+    return const SpotListState();
+  }
 
   void selectTab(bool isWantToGo) {
     state = state.copyWith(isWantToGoTab: isWantToGo);
+    ref.read(selectedSpotStatusProvider.notifier).state =
+        isWantToGo ? SpotStatus.wantToGo : SpotStatus.visited;
   }
 
   void selectCategory(String category) {

--- a/lib/screens/providers/spot_provider.dart
+++ b/lib/screens/providers/spot_provider.dart
@@ -71,8 +71,9 @@ final spotProvider = StateNotifierProvider<SpotNotifier, List<Spot>>((ref) {
 /// 散歩中にカメラで撮影した写真の一時パス（WantToGoPage で使用）
 final pendingPhotoProvider = StateProvider<String?>((ref) => null);
 
-/// 現在選択中のステータスフィルタ（null = 全件）
-final selectedSpotStatusProvider = StateProvider<SpotStatus?>((ref) => null);
+/// 現在選択中のステータスフィルタ（null = 全件、デフォルトは行きたい！）
+final selectedSpotStatusProvider =
+    StateProvider<SpotStatus?>((ref) => SpotStatus.wantToGo);
 
 /// selectedSpotStatusProvider と連動してフィルタリングしたスポット一覧
 final filteredSpotsProvider = Provider<List<Spot>>((ref) {

--- a/test/screens/pages/home/home_page_test.dart
+++ b/test/screens/pages/home/home_page_test.dart
@@ -3,10 +3,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/domain/repositories/route_repository.dart';
 import 'package:tekushare/domain/repositories/walk_session_repository.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
@@ -17,7 +22,48 @@ import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/clock_provider.dart';
 import 'package:tekushare/screens/providers/location_provider.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots();
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(const []);
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: const _FakeGetSpots(),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {
   @override
@@ -57,6 +103,7 @@ void main() {
             locationProvider.overrideWith(
               (ref) => Stream<Position>.error(Exception('GPS unavailable')),
             ),
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -140,6 +187,7 @@ void main() {
             locationProvider.overrideWith(
               (ref) => Stream<Position>.error(Exception('GPS unavailable')),
             ),
+            _spotOverride,
           ],
           child: MaterialApp(
             navigatorKey: navKey,

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -3,11 +3,57 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots();
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(const []);
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: const _FakeGetSpots(),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
 
 class _NonStandardDateViewModel extends WalkRouteViewModel {
   @override
@@ -347,6 +393,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -3,10 +3,56 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots();
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(const []);
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: const _FakeGetSpots(),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
 
 void main() {
   group('SettingsPage', () {
@@ -139,6 +185,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -4,11 +4,56 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots();
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(const []);
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: const _FakeGetSpots(),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
 
 Spot _makeSpot({SpotStatus status = SpotStatus.wantToGo}) => Spot(
       id: 'test-id',
@@ -32,6 +77,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -64,6 +110,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -3,11 +3,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+Spot _makeSpot({SpotStatus status = SpotStatus.wantToGo}) => Spot(
+      id: 'test-id',
+      title: 'テストスポット',
+      latitude: 35.0,
+      longitude: 135.0,
+      status: status,
+      createdAt: DateTime(2024, 1, 1),
+    );
 
 void main() {
   group('SpotDetailPage', () {
@@ -32,7 +42,11 @@ void main() {
                 child: child!,
               );
             },
-            home: SpotDetailPage(isWantToGo: isWantToGo),
+            home: SpotDetailPage(
+              spot: _makeSpot(
+                status: isWantToGo ? SpotStatus.wantToGo : SpotStatus.visited,
+              ),
+            ),
           ),
         ),
       );
@@ -65,7 +79,13 @@ void main() {
                 onPressed: () => Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) => SpotDetailPage(isWantToGo: isWantToGo),
+                    builder: (_) => SpotDetailPage(
+                      spot: _makeSpot(
+                        status: isWantToGo
+                            ? SpotStatus.wantToGo
+                            : SpotStatus.visited,
+                      ),
+                    ),
                   ),
                 ),
                 child: const Text('start'),

--- a/test/screens/pages/spot/spot_list_page_test.dart
+++ b/test/screens/pages/spot/spot_list_page_test.dart
@@ -3,12 +3,86 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots(this._spots);
+  final List<Spot> _spots;
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(_spots);
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+final _fakeSpots = [
+  Spot(
+    id: '1',
+    title: 'ひだまりパーク',
+    latitude: 0,
+    longitude: 0,
+    status: SpotStatus.wantToGo,
+    createdAt: DateTime(2024, 4, 12),
+  ),
+  Spot(
+    id: '2',
+    title: 'Cafe&Gallery',
+    latitude: 0,
+    longitude: 0,
+    status: SpotStatus.wantToGo,
+    createdAt: DateTime(2024, 5, 12),
+  ),
+  Spot(
+    id: '8',
+    title: '新宿御苑',
+    latitude: 0,
+    longitude: 0,
+    status: SpotStatus.visited,
+    createdAt: DateTime(2024, 1, 15),
+  ),
+];
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: _FakeGetSpots(_fakeSpots),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
 
 void main() {
   group('SpotListPage', () {
@@ -20,6 +94,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -67,7 +142,6 @@ void main() {
     testWidgets('want-to-go tab is selected by default', (tester) async {
       await pumpPage(tester);
 
-      // 行きたい専用アイテムが表示され、行った専用アイテムは非表示
       expect(find.text(wantToGoOnly), findsOneWidget);
       expect(find.text(wentOnly), findsNothing);
     });
@@ -79,7 +153,6 @@ void main() {
       await tester.tap(find.text(AppStrings.listWentTab));
       await tester.pump();
 
-      // 行った専用アイテムが表示され、行きたい専用アイテムは非表示
       expect(find.text(wentOnly), findsOneWidget);
       expect(find.text(wantToGoOnly), findsNothing);
     });
@@ -89,7 +162,6 @@ void main() {
       await pumpPage(tester);
 
       expect(find.text(AppStrings.categoryPark), findsOneWidget);
-      expect(find.text(AppStrings.categoryCafe), findsOneWidget);
       expect(find.text(AppStrings.categoryCafe), findsOneWidget);
       expect(find.text(AppStrings.categoryLunch), findsOneWidget);
       expect(find.text(AppStrings.categoryDinner), findsOneWidget);
@@ -102,7 +174,6 @@ void main() {
         (tester) async {
       await pumpPage(tester);
 
-      // 初期は公園が選択色
       expect(
         find.ancestor(
           of: find.text(AppStrings.categoryPark),
@@ -117,7 +188,6 @@ void main() {
       await tester.tap(find.text(AppStrings.categoryCafe));
       await tester.pump();
 
-      // カフェが選択色になり、公園は非選択色になる
       expect(
         find.ancestor(
           of: find.text(AppStrings.categoryCafe),
@@ -148,6 +218,45 @@ void main() {
       expect(find.byIcon(Icons.chevron_right), findsWidgets);
     });
 
+    // スポットが空のときは空状態メッセージが表示される
+    testWidgets('shows empty message when no spots in current tab',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final emptyOverride = spotProvider.overrideWith(
+        (ref) => SpotNotifier(
+          saveSpot: const _FakeSaveSpot(),
+          getSpots: const _FakeGetSpots([]),
+          updateSpotStatus: const _FakeUpdateSpotStatus(),
+          attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [emptyOverride],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const SpotListPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(AppStrings.spotListEmpty), findsOneWidget);
+    });
+
     // ボトムナビが表示される
     testWidgets('shows bottom navigation', (tester) async {
       await pumpPage(tester);
@@ -159,6 +268,7 @@ void main() {
     testWidgets('shows back button in AppBar', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -193,12 +303,10 @@ void main() {
         (tester) async {
       await pumpPage(tester);
 
-      // 行った！タブに切り替え
       await tester.tap(find.text(AppStrings.listWentTab));
       await tester.pump();
       expect(find.text(wentOnly), findsOneWidget);
 
-      // 行きたい！タブに戻す
       await tester.tap(find.text(AppStrings.wantToGo));
       await tester.pump();
 
@@ -216,6 +324,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -259,6 +368,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -300,6 +410,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/spot/spot_list_page_test.dart
+++ b/test/screens/pages/spot/spot_list_page_test.dart
@@ -214,7 +214,7 @@ void main() {
     testWidgets('shows date and arrow icon in list', (tester) async {
       await pumpPage(tester);
 
-      expect(find.text('4/12'), findsOneWidget);
+      expect(find.text('04/12'), findsOneWidget);
       expect(find.byIcon(Icons.chevron_right), findsWidgets);
     });
 

--- a/test/screens/pages/walk/end_walk_page_test.dart
+++ b/test/screens/pages/walk/end_walk_page_test.dart
@@ -3,16 +3,62 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/domain/repositories/route_repository.dart';
 import 'package:tekushare/domain/repositories/walk_session_repository.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots();
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(const []);
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: const _FakeGetSpots(),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {
   @override
@@ -184,6 +230,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -3,6 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
+import 'package:tekushare/domain/usecases/spot/get_spots.dart';
+import 'package:tekushare/domain/usecases/spot/save_spot.dart';
+import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/infrastructure/camera_service.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
@@ -19,6 +24,46 @@ import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 // ──────────────────────────────────────────
 // フェイク実装
 // ──────────────────────────────────────────
+
+class _FakeSaveSpot implements SaveSpot {
+  const _FakeSaveSpot();
+  @override
+  Future<String> call({
+    required String title,
+    required double latitude,
+    required double longitude,
+    String? memo,
+    SpotStatus status = SpotStatus.wantToGo,
+  }) async =>
+      'fake-id';
+}
+
+class _FakeGetSpots implements GetSpots {
+  const _FakeGetSpots();
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(const []);
+}
+
+class _FakeUpdateSpotStatus implements UpdateSpotStatus {
+  const _FakeUpdateSpotStatus();
+  @override
+  Future<void> call(String spotId, SpotStatus status) async {}
+}
+
+class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
+  const _FakeAttachPhotoToSpot();
+  @override
+  Future<void> call(String spotId, String imagePath) async {}
+}
+
+final _spotOverride = spotProvider.overrideWith(
+  (ref) => SpotNotifier(
+    saveSpot: const _FakeSaveSpot(),
+    getSpots: const _FakeGetSpots(),
+    updateSpotStatus: const _FakeUpdateSpotStatus(),
+    attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+  ),
+);
 
 class _FakeCameraService extends Fake implements CameraService {
   _FakeCameraService(this._returnPath);
@@ -332,6 +377,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/providers/spot_provider_test.dart
+++ b/test/screens/providers/spot_provider_test.dart
@@ -97,6 +97,7 @@ void main() {
       final container = makeContainer();
       addTearDown(container.dispose);
 
+      container.read(selectedSpotStatusProvider.notifier).state = null;
       container.read(spotProvider); // notifier を生成してストリーム購読を開始
       await Future<void>.delayed(Duration.zero); // ストリームの emit を待つ
       final result = container.read(filteredSpotsProvider);


### PR DESCRIPTION
## 概要

- SpotListPage を spotProvider に接続し、タブ切り替えで wantToGo / visited をフィルタリングして表示
- スポットが空のときは「スポットがありません」を表示
- SpotDetailPage のコンストラクタを isWantToGo: bool から spot: Spot に変更（#34 の前提）
- SpotListViewModel からハードコードのダミーデータを削除

## 変更ファイル

- lib/core/constants/app_strings.dart — spotListEmpty 追加
- lib/screens/pages/spot/viewmodel/spot_list_viewmodel.dart — ダミーデータ削除
- lib/screens/pages/spot/view/spot_list_page.dart — spotProvider 接続・空状態・日付表示
- lib/screens/pages/spot/view/spot_detail_page.dart — コンストラクタ変更
- test/screens/pages/spot/spot_list_page_test.dart — spotProvider オーバーライド対応
- test/screens/pages/spot/spot_detail_page_test.dart — spot: パラメータ対応

## 関連 Issue

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * スポット一覧に、件数が0件のときの空状態メッセージを追加しました。
  * スポット詳細画面で、表示内容をスポットの状態に応じて切り替えるようになりました。

* **Bug Fixes**
  * スポット一覧の表示が、タブ状態に合わせて正しく切り替わるよう改善しました。
  * 一覧から詳細画面への遷移時に、より正確なスポット情報を引き継ぐようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->