### PR TITLE
[Logic] 散歩ルートページとロジックの繋ぎ込み

### DIFF
--- a/lib/core/constants/map_constants.dart
+++ b/lib/core/constants/map_constants.dart
@@ -1,1 +1,10 @@
-// 地図関連の定数
+import 'package:flutter/material.dart';
+
+abstract class MapConstants {
+  static const double defaultZoom = 15.0;
+  static const double polylineStrokeWidth = 3.0;
+  static const Color osmAttributionBg = Color(0xCCFFFFFF);
+  static const double osmAttributionPaddingH = 6.0;
+  static const double osmAttributionPaddingV = 2.0;
+  static const double osmAttributionFontSize = 10.0;
+}

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -9,6 +12,7 @@ import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/dashed_border_painter.dart';
 
@@ -24,6 +28,9 @@ class WalkRoutePage extends ConsumerStatefulWidget {
 
 class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
   final _nameController = TextEditingController();
+  final _mapController = MapController();
+  final _trackPoints = <LatLng>[];
+  LatLng? _currentPosition;
   int _cardSlideDirection = 1;
 
   void _selectDay(int day) {
@@ -45,6 +52,7 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
   @override
   void dispose() {
     _nameController.dispose();
+    _mapController.dispose();
     super.dispose();
   }
 
@@ -87,6 +95,17 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AsyncValue<Position>>(locationProvider, (_, next) {
+      next.whenData((pos) {
+        final point = LatLng(pos.latitude, pos.longitude);
+        setState(() {
+          _currentPosition = point;
+          _trackPoints.add(point);
+        });
+        _mapController.move(point, _mapController.camera.zoom);
+      });
+    });
+
     final state = ref.watch(walkRouteViewModelProvider);
     final vm = ref.read(walkRouteViewModelProvider.notifier);
 
@@ -110,7 +129,12 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   const SizedBox(height: AppSpacing.lg),
-                  _SelectedRouteCard(route: state.selectedRoute),
+                  _SelectedRouteCard(
+                    route: state.selectedRoute,
+                    mapController: _mapController,
+                    trackPoints: _trackPoints,
+                    currentPosition: _currentPosition,
+                  ),
                   const SizedBox(height: AppSpacing.lg),
                   _RouteListCard(
                     routes: state.routes,
@@ -517,12 +541,23 @@ class _RouteItem extends StatelessWidget {
 // ──────────────────────────────────────────
 
 class _SelectedRouteCard extends StatelessWidget {
-  const _SelectedRouteCard({required this.route});
+  const _SelectedRouteCard({
+    required this.route,
+    required this.mapController,
+    required this.trackPoints,
+    this.currentPosition,
+  });
 
   final WalkRoute route;
+  final MapController mapController;
+  final List<LatLng> trackPoints;
+  final LatLng? currentPosition;
 
   @override
   Widget build(BuildContext context) {
+    final mapHeight = AppSizingTheme.of(context).mapPlaceholderHeight;
+    final hasTrack = trackPoints.isNotEmpty || currentPosition != null;
+
     return Container(
       clipBehavior: Clip.antiAlias,
       padding: const EdgeInsets.symmetric(horizontal: 25),
@@ -557,20 +592,57 @@ class _SelectedRouteCard extends StatelessWidget {
               ),
             ),
           ),
-          // 地図プレースホルダー
-          Builder(
-            builder: (context) => Container(
-              width: double.infinity,
-              height: AppSizingTheme.of(context).mapPlaceholderHeight,
-              color: AppColors.chipUnselected,
-              child: const Center(
-                child: Icon(
-                  Icons.map_outlined,
-                  size: 48,
-                  color: AppColors.textDisabled,
-                ),
-              ),
-            ),
+          SizedBox(
+            width: double.infinity,
+            height: mapHeight,
+            child: hasTrack
+                ? FlutterMap(
+                    mapController: mapController,
+                    options: MapOptions(
+                      initialCenter: currentPosition ?? trackPoints.last,
+                      initialZoom: 15,
+                    ),
+                    children: [
+                      TileLayer(
+                        urlTemplate:
+                            'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                        userAgentPackageName: 'com.example.tekushare',
+                      ),
+                      if (trackPoints.length >= 2)
+                        PolylineLayer(
+                          polylines: [
+                            Polyline(
+                              points: trackPoints,
+                              color: AppColors.primary,
+                              strokeWidth: 3,
+                            ),
+                          ],
+                        ),
+                      if (currentPosition != null)
+                        MarkerLayer(
+                          markers: [
+                            Marker(
+                              point: currentPosition!,
+                              child: const Icon(
+                                Icons.location_on,
+                                color: Colors.red,
+                                size: 24,
+                              ),
+                            ),
+                          ],
+                        ),
+                    ],
+                  )
+                : Container(
+                    color: AppColors.chipUnselected,
+                    child: const Center(
+                      child: Icon(
+                        Icons.map_outlined,
+                        size: 48,
+                        color: AppColors.textDisabled,
+                      ),
+                    ),
+                  ),
           ),
           Padding(
             padding: const EdgeInsets.all(AppSpacing.lg),

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:geolocator/geolocator.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -12,7 +9,6 @@ import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
-import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/dashed_border_painter.dart';
 
@@ -28,9 +24,6 @@ class WalkRoutePage extends ConsumerStatefulWidget {
 
 class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
   final _nameController = TextEditingController();
-  final _mapController = MapController();
-  final _trackPoints = <LatLng>[];
-  LatLng? _currentPosition;
   int _cardSlideDirection = 1;
 
   void _selectDay(int day) {
@@ -52,7 +45,6 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
   @override
   void dispose() {
     _nameController.dispose();
-    _mapController.dispose();
     super.dispose();
   }
 
@@ -95,17 +87,6 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<AsyncValue<Position>>(locationProvider, (_, next) {
-      next.whenData((pos) {
-        final point = LatLng(pos.latitude, pos.longitude);
-        setState(() {
-          _currentPosition = point;
-          _trackPoints.add(point);
-        });
-        _mapController.move(point, _mapController.camera.zoom);
-      });
-    });
-
     final state = ref.watch(walkRouteViewModelProvider);
     final vm = ref.read(walkRouteViewModelProvider.notifier);
 
@@ -129,12 +110,7 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   const SizedBox(height: AppSpacing.lg),
-                  _SelectedRouteCard(
-                    route: state.selectedRoute,
-                    mapController: _mapController,
-                    trackPoints: _trackPoints,
-                    currentPosition: _currentPosition,
-                  ),
+                  _SelectedRouteCard(route: state.selectedRoute),
                   const SizedBox(height: AppSpacing.lg),
                   _RouteListCard(
                     routes: state.routes,
@@ -541,23 +517,12 @@ class _RouteItem extends StatelessWidget {
 // ──────────────────────────────────────────
 
 class _SelectedRouteCard extends StatelessWidget {
-  const _SelectedRouteCard({
-    required this.route,
-    required this.mapController,
-    required this.trackPoints,
-    this.currentPosition,
-  });
+  const _SelectedRouteCard({required this.route});
 
   final WalkRoute route;
-  final MapController mapController;
-  final List<LatLng> trackPoints;
-  final LatLng? currentPosition;
 
   @override
   Widget build(BuildContext context) {
-    final mapHeight = AppSizingTheme.of(context).mapPlaceholderHeight;
-    final hasTrack = trackPoints.isNotEmpty || currentPosition != null;
-
     return Container(
       clipBehavior: Clip.antiAlias,
       padding: const EdgeInsets.symmetric(horizontal: 25),
@@ -592,57 +557,19 @@ class _SelectedRouteCard extends StatelessWidget {
               ),
             ),
           ),
-          SizedBox(
-            width: double.infinity,
-            height: mapHeight,
-            child: hasTrack
-                ? FlutterMap(
-                    mapController: mapController,
-                    options: MapOptions(
-                      initialCenter: currentPosition ?? trackPoints.last,
-                      initialZoom: 15,
-                    ),
-                    children: [
-                      TileLayer(
-                        urlTemplate:
-                            'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                        userAgentPackageName: 'com.example.tekushare',
-                      ),
-                      if (trackPoints.length >= 2)
-                        PolylineLayer(
-                          polylines: [
-                            Polyline(
-                              points: trackPoints,
-                              color: AppColors.primary,
-                              strokeWidth: 3,
-                            ),
-                          ],
-                        ),
-                      if (currentPosition != null)
-                        MarkerLayer(
-                          markers: [
-                            Marker(
-                              point: currentPosition!,
-                              child: const Icon(
-                                Icons.location_on,
-                                color: Colors.red,
-                                size: 24,
-                              ),
-                            ),
-                          ],
-                        ),
-                    ],
-                  )
-                : Container(
-                    color: AppColors.chipUnselected,
-                    child: const Center(
-                      child: Icon(
-                        Icons.map_outlined,
-                        size: 48,
-                        color: AppColors.textDisabled,
-                      ),
-                    ),
-                  ),
+          Builder(
+            builder: (context) => Container(
+              width: double.infinity,
+              height: AppSizingTheme.of(context).mapPlaceholderHeight,
+              color: AppColors.chipUnselected,
+              child: const Center(
+                child: Icon(
+                  Icons.map_outlined,
+                  size: 48,
+                  color: AppColors.textDisabled,
+                ),
+              ),
+            ),
           ),
           Padding(
             padding: const EdgeInsets.all(AppSpacing.lg),

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -7,8 +7,9 @@ import 'package:geolocator/geolocator.dart' show Position;
 import 'package:latlong2/latlong.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
-import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/map_constants.dart';
+import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
@@ -62,14 +63,19 @@ class _WalkPageState extends ConsumerState<WalkPage> {
 
   @override
   Widget build(BuildContext context) {
+    // エラー時は _GpsStatusIndicator（ref.watch 側）がフィードバックを担う
     ref.listen<AsyncValue<Position>>(locationProvider, (_, next) {
       next.whenData((pos) {
         final point = LatLng(pos.latitude, pos.longitude);
+        final isFirstFix = _currentPosition == null;
         setState(() {
           _currentPosition = point;
           _trackPoints.add(point);
         });
-        _mapController.move(point, _mapController.camera.zoom);
+        // 初回はマップ未生成のため move() をスキップ
+        if (!isFirstFix) {
+          _mapController.move(point, _mapController.camera.zoom);
+        }
       });
     });
 
@@ -92,7 +98,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                         mapController: _mapController,
                         options: MapOptions(
                           initialCenter: _currentPosition!,
-                          initialZoom: 15,
+                          initialZoom: MapConstants.defaultZoom,
                         ),
                         children: [
                           TileLayer(
@@ -106,7 +112,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                                 Polyline(
                                   points: _trackPoints,
                                   color: AppColors.primary,
-                                  strokeWidth: 3,
+                                  strokeWidth: MapConstants.polylineStrokeWidth,
                                 ),
                               ],
                             ),
@@ -117,10 +123,27 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                                 child: const Icon(
                                   Icons.location_on,
                                   color: Colors.red,
-                                  size: 24,
+                                  size: AppSize.iconMd,
                                 ),
                               ),
                             ],
+                          ),
+                          Align(
+                            alignment: Alignment.bottomRight,
+                            child: Container(
+                              color: MapConstants.osmAttributionBg,
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: MapConstants.osmAttributionPaddingH,
+                                vertical: MapConstants.osmAttributionPaddingV,
+                              ),
+                              child: const Text(
+                                '© OpenStreetMap contributors',
+                                style: TextStyle(
+                                  fontSize: MapConstants.osmAttributionFontSize,
+                                  color: Colors.black87,
+                                ),
+                              ),
+                            ),
                           ),
                         ],
                       )

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:geolocator/geolocator.dart' show Position;
+import 'package:latlong2/latlong.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
@@ -19,13 +21,27 @@ import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 import 'package:tekushare/screens/widgets/common/primary_button.dart';
 
-/// 散歩モード画面
-class WalkPage extends ConsumerWidget {
+/// 散歩モード画���
+class WalkPage extends ConsumerStatefulWidget {
   const WalkPage({super.key});
+
+  @override
+  ConsumerState<WalkPage> createState() => _WalkPageState();
+}
+
+class _WalkPageState extends ConsumerState<WalkPage> {
+  final _mapController = MapController();
+  final _trackPoints = <LatLng>[];
+  LatLng? _currentPosition;
+
+  @override
+  void dispose() {
+    _mapController.dispose();
+    super.dispose();
+  }
 
   Future<void> _onTakePhotoPressed(
     BuildContext context,
-    WidgetRef ref,
     AsyncValue<Position> locationState,
   ) async {
     if (!locationState.hasValue) {
@@ -45,7 +61,18 @@ class WalkPage extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<Position>>(locationProvider, (_, next) {
+      next.whenData((pos) {
+        final point = LatLng(pos.latitude, pos.longitude);
+        setState(() {
+          _currentPosition = point;
+          _trackPoints.add(point);
+        });
+        _mapController.move(point, _mapController.camera.zoom);
+      });
+    });
+
     final locationState = ref.watch(locationProvider);
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
@@ -59,14 +86,53 @@ class WalkPage extends ConsumerWidget {
               const ClockHeader(),
               const SizedBox(height: 16),
               _GpsStatusIndicator(locationState: locationState),
-              const Spacer(flex: 2),
+              Expanded(
+                child: _currentPosition != null
+                    ? FlutterMap(
+                        mapController: _mapController,
+                        options: MapOptions(
+                          initialCenter: _currentPosition!,
+                          initialZoom: 15,
+                        ),
+                        children: [
+                          TileLayer(
+                            urlTemplate:
+                                'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                            userAgentPackageName: 'com.example.tekushare',
+                          ),
+                          if (_trackPoints.length >= 2)
+                            PolylineLayer(
+                              polylines: [
+                                Polyline(
+                                  points: _trackPoints,
+                                  color: AppColors.primary,
+                                  strokeWidth: 3,
+                                ),
+                              ],
+                            ),
+                          MarkerLayer(
+                            markers: [
+                              Marker(
+                                point: _currentPosition!,
+                                child: const Icon(
+                                  Icons.location_on,
+                                  color: Colors.red,
+                                  size: 24,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      )
+                    : const SizedBox.shrink(),
+              ),
+              const SizedBox(height: 16),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x2l),
                 child: _WalkActionButton(
                   label: AppStrings.takePhoto,
                   svgAsset: 'assets/SVG/camera.svg',
-                  onPressed: () =>
-                      _onTakePhotoPressed(context, ref, locationState),
+                  onPressed: () => _onTakePhotoPressed(context, locationState),
                 ),
               ),
               const SizedBox(height: 20),
@@ -80,7 +146,7 @@ class WalkPage extends ConsumerWidget {
                   ),
                 ),
               ),
-              const Spacer(flex: 3),
+              const SizedBox(height: 16),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x2l),
                 child: PrimaryButton(
@@ -128,7 +194,7 @@ class WalkPage extends ConsumerWidget {
 
 // ──────────────────────────────────────────
 // GPS 状態インジケーター
-// ──────────────────────────────────────────
+// ────────────────────────��─────────────────
 
 class _GpsStatusIndicator extends StatelessWidget {
   const _GpsStatusIndicator({required this.locationState});
@@ -170,9 +236,9 @@ class _GpsStatusIndicator extends StatelessWidget {
   }
 }
 
-// ──────────────────────────────────────────
+// ───────────��──────────────────────────────
 // 散歩アクションボタン（ブラウン）
-// ──────────────────────────────────────────
+// ──���───────────────────────────────────────
 
 class _WalkActionButton extends StatelessWidget {
   const _WalkActionButton({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   firebase_core: ^4.11.0
   firebase_auth: ^6.5.4
   cloud_firestore: ^6.6.0
+  flutter_map: ^8.3.1
+  latlong2: ^0.10.1
 
 dev_dependencies:
   flutter_test:

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/spot.dart';
@@ -14,7 +12,6 @@ import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
-import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
@@ -545,63 +542,6 @@ void main() {
       await tester.pump();
 
       expect(find.text('3'), findsWidgets);
-    });
-
-    // 散歩外のときはマッププレースホルダーが表示される
-    testWidgets('shows map placeholder when not walking', (tester) async {
-      await pumpPage(tester);
-
-      expect(find.byIcon(Icons.map_outlined), findsOneWidget);
-      expect(find.byType(FlutterMap), findsNothing);
-    });
-
-    // 散歩中は FlutterMap が表示される
-    testWidgets('shows FlutterMap when walking with GPS position',
-        (tester) async {
-      tester.view.physicalSize = const Size(1170, 3000);
-      tester.view.devicePixelRatio = 3.0;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
-
-      final positionStream = Stream.fromIterable([
-        Position(
-          latitude: 35.6895,
-          longitude: 139.6917,
-          timestamp: DateTime(2024),
-          accuracy: 0,
-          altitude: 0,
-          altitudeAccuracy: 0,
-          heading: 0,
-          headingAccuracy: 0,
-          speed: 0,
-          speedAccuracy: 0,
-        ),
-      ]);
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            locationProvider.overrideWith((ref) => positionStream),
-          ],
-          child: MaterialApp(
-            builder: (context, child) {
-              final sw = MediaQuery.sizeOf(context).width;
-              return Theme(
-                data: Theme.of(context).copyWith(
-                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
-                ),
-                child: child!,
-              );
-            },
-            home: const WalkRoutePage(),
-          ),
-        ),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
-
-      expect(find.byType(FlutterMap), findsOneWidget);
-      expect(find.byIcon(Icons.map_outlined), findsNothing);
     });
   });
 }

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/spot.dart';
@@ -12,6 +14,7 @@ import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
@@ -542,6 +545,63 @@ void main() {
       await tester.pump();
 
       expect(find.text('3'), findsWidgets);
+    });
+
+    // 散歩外のときはマッププレースホルダーが表示される
+    testWidgets('shows map placeholder when not walking', (tester) async {
+      await pumpPage(tester);
+
+      expect(find.byIcon(Icons.map_outlined), findsOneWidget);
+      expect(find.byType(FlutterMap), findsNothing);
+    });
+
+    // 散歩中は FlutterMap が表示される
+    testWidgets('shows FlutterMap when walking with GPS position',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final positionStream = Stream.fromIterable([
+        Position(
+          latitude: 35.6895,
+          longitude: 139.6917,
+          timestamp: DateTime(2024),
+          accuracy: 0,
+          altitude: 0,
+          altitudeAccuracy: 0,
+          heading: 0,
+          headingAccuracy: 0,
+          speed: 0,
+          speedAccuracy: 0,
+        ),
+      ]);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            locationProvider.overrideWith((ref) => positionStream),
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const WalkRoutePage(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(FlutterMap), findsOneWidget);
+      expect(find.byIcon(Icons.map_outlined), findsNothing);
     });
   });
 }

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
@@ -483,6 +484,28 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(SettingsPage), findsOneWidget);
+    });
+
+    // GPS 取得済みのとき FlutterMap が表示される
+    testWidgets('shows FlutterMap when GPS position is available',
+        (tester) async {
+      final position = _makePosition(35.6895, 139.6917);
+
+      await pumpWalkPage(
+        tester,
+        locationStream: Stream.value(position),
+      );
+      await tester.pump();
+
+      expect(find.byType(FlutterMap), findsOneWidget);
+    });
+
+    // GPS 未取得のとき FlutterMap は表示されない
+    testWidgets('does not show FlutterMap when GPS is not yet available',
+        (tester) async {
+      await pumpWalkPage(tester, locationStream: const Stream.empty());
+
+      expect(find.byType(FlutterMap), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## 概要

- `flutter_map` / `latlong2` パッケージを追加
- `locationProvider` の `Stream<Position>` を購読して GPS 軌跡をポリラインとして蓄積
- 散歩中は `FlutterMap` + `PolylineLayer` + 現在地マーカーをリアルタイム描画
- 散歩外（idle / finished）は既存のプレースホルダーを維持
- 現在地更新のたびに `MapController.move()` でカメラを追従

## 変更ファイル

- `pubspec.yaml` — `flutter_map: ^8.3.1`, `latlong2: ^0.10.1` 追加
- `lib/screens/pages/map/view/walk_route_page.dart` — GPS 軌跡・地図描画の実装
- `test/screens/pages/map/walk_route_page_test.dart` — 散歩中/散歩外のテストを追加

## 関連 Issue

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GPS 取得時に地図を表示し、現在地をピンで示すようになりました。
  * 取得した位置情報に応じて移動軌跡のラインを地図上に表示します。
  * 地図表示エリアにプレースホルダーを追加し、未取得時の見た目を整えました。

* **バグ修正**
  * 位置情報がない場合は地図を表示しないようになり、不要な表示崩れを防ぎました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->