### PR TITLE
WalkPage UI改善と撮影写真のマップサムネイル表示 (#79)

### DIFF
--- a/lib/core/constants/app_spacing.dart
+++ b/lib/core/constants/app_spacing.dart
@@ -42,6 +42,9 @@ abstract class AppSize {
   static const double avatarSm = 32.0;
   static const double avatarMd = 48.0;
   static const double bottomNavHeight = 60.0;
+  static const double gpsIndicatorHeight = 40.0;
+  static const double gpsSpinnerSize = 14.0;
+  static const double gpsSpinnerStroke = 2.0;
   static const double appBarHeight = 56.0;
   static const double mapPinSize = 36.0;
   static const double cardElevation = 2.0;

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -24,6 +24,7 @@ abstract class AppStrings {
   static const takePhoto = '撮影する';
   static const saveToWantToGo = '現在地を\n行きたいリストに保存する';
   static const wantToGo = '行きたい！';
+  static const recenterMap = '現在地に戻る';
   static const safetyOk = '元気です';
 
   // 行きたい！ページ

--- a/lib/core/constants/map_constants.dart
+++ b/lib/core/constants/map_constants.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 abstract class MapConstants {
   static const double defaultZoom = 15.0;
   static const double polylineStrokeWidth = 3.0;
+  static const double photoThumbnailSize = 40.0;
   static const Color osmAttributionBg = Color(0xCCFFFFFF);
   static const double osmAttributionPaddingH = 6.0;
   static const double osmAttributionPaddingV = 2.0;

--- a/lib/core/constants/map_constants.dart
+++ b/lib/core/constants/map_constants.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 abstract class MapConstants {
-  static const double defaultZoom = 15.0;
+  static const double defaultZoom = 17.0;
   static const double polylineStrokeWidth = 3.0;
   static const double photoThumbnailSize = 40.0;
   static const Color osmAttributionBg = Color(0xCCFFFFFF);

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -172,8 +172,9 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                             alignment: Alignment.bottomLeft,
                             child: Padding(
                               padding: const EdgeInsets.all(AppSpacing.sm),
-                              child: FloatingActionButton.small(
+                              child: FloatingActionButton(
                                 heroTag: 'recenter',
+                                tooltip: AppStrings.recenterMap,
                                 onPressed: () {
                                   if (_currentPosition != null) {
                                     _mapController.move(
@@ -305,16 +306,16 @@ class _GpsStatusIndicator extends StatelessWidget {
     return locationState.when(
       data: (_) => const SizedBox.shrink(),
       loading: () => const SizedBox(
-        height: 40,
+        height: AppSize.gpsIndicatorHeight,
         child: Center(
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               SizedBox(
-                width: 14,
-                height: 14,
+                width: AppSize.gpsSpinnerSize,
+                height: AppSize.gpsSpinnerSize,
                 child: CircularProgressIndicator(
-                  strokeWidth: 2,
+                  strokeWidth: AppSize.gpsSpinnerStroke,
                   color: AppColors.primary,
                 ),
               ),
@@ -328,7 +329,7 @@ class _GpsStatusIndicator extends StatelessWidget {
         ),
       ),
       error: (_, __) => const SizedBox(
-        height: 40,
+        height: AppSize.gpsIndicatorHeight,
         child: Center(
           child: Text(
             AppStrings.gpsUnavailableError,
@@ -363,8 +364,7 @@ class _WalkActionButton extends StatelessWidget {
     final height = compact ? sizing.detailBtnHeight : sizing.actionBtnHeight;
     final fontSize =
         compact ? sizing.detailBtnFontSize : sizing.actionBtnFontSize;
-    final iconSize =
-        compact ? sizing.actionBtnIconSize * 0.7 : sizing.actionBtnIconSize;
+    final iconSize = compact ? AppSize.iconMd : sizing.actionBtnIconSize;
     final radius = compact ? sizing.detailBtnRadius : sizing.actionBtnRadius;
 
     return Container(

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -169,6 +169,27 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                                   .toList(),
                             ),
                           Align(
+                            alignment: Alignment.bottomLeft,
+                            child: Padding(
+                              padding: const EdgeInsets.all(AppSpacing.sm),
+                              child: FloatingActionButton.small(
+                                heroTag: 'recenter',
+                                onPressed: () {
+                                  if (_currentPosition != null) {
+                                    _mapController.move(
+                                      _currentPosition!,
+                                      MapConstants.defaultZoom,
+                                    );
+                                  }
+                                },
+                                backgroundColor: AppColors.surface,
+                                foregroundColor: AppColors.primary,
+                                elevation: 2,
+                                child: const Icon(Icons.my_location),
+                              ),
+                            ),
+                          ),
+                          Align(
                             alignment: Alignment.bottomRight,
                             child: Container(
                               color: MapConstants.osmAttributionBg,

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -22,7 +24,7 @@ import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 import 'package:tekushare/screens/widgets/common/primary_button.dart';
 
-/// 散歩モード画���
+/// 散歩モード画面
 class WalkPage extends ConsumerStatefulWidget {
   const WalkPage({super.key});
 
@@ -33,6 +35,7 @@ class WalkPage extends ConsumerStatefulWidget {
 class _WalkPageState extends ConsumerState<WalkPage> {
   final _mapController = MapController();
   final _trackPoints = <LatLng>[];
+  final _photoMarkers = <({LatLng point, String imagePath})>[];
   LatLng? _currentPosition;
 
   @override
@@ -56,6 +59,11 @@ class _WalkPageState extends ConsumerState<WalkPage> {
     if (imagePath == null || !context.mounted) return;
 
     ref.read(pendingPhotoProvider.notifier).state = imagePath;
+    if (_currentPosition != null) {
+      setState(() {
+        _photoMarkers.add((point: _currentPosition!, imagePath: imagePath));
+      });
+    }
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text(AppStrings.photoTaken)),
     );
@@ -80,6 +88,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
     });
 
     final locationState = ref.watch(locationProvider);
+    final sizing = AppSizingTheme.of(context);
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.dark,
@@ -90,7 +99,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const ClockHeader(),
-              const SizedBox(height: 16),
+              const SizedBox(height: AppSpacing.lg),
               _GpsStatusIndicator(locationState: locationState),
               Expanded(
                 child: _currentPosition != null
@@ -128,6 +137,37 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                               ),
                             ],
                           ),
+                          if (_photoMarkers.isNotEmpty)
+                            MarkerLayer(
+                              markers: _photoMarkers
+                                  .map(
+                                    (m) => Marker(
+                                      point: m.point,
+                                      width: MapConstants.photoThumbnailSize,
+                                      height: MapConstants.photoThumbnailSize,
+                                      child: ClipOval(
+                                        child: Image.file(
+                                          File(m.imagePath),
+                                          width:
+                                              MapConstants.photoThumbnailSize,
+                                          height:
+                                              MapConstants.photoThumbnailSize,
+                                          fit: BoxFit.cover,
+                                          errorBuilder: (_, __, ___) =>
+                                              const ColoredBox(
+                                            color: AppColors.textDisabled,
+                                            child: Icon(
+                                              Icons.photo,
+                                              color: AppColors.textOnPrimary,
+                                              size: AppSize.iconSm,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  )
+                                  .toList(),
+                            ),
                           Align(
                             alignment: Alignment.bottomRight,
                             child: Container(
@@ -149,38 +189,53 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                       )
                     : const SizedBox.shrink(),
               ),
-              const SizedBox(height: 16),
+              const SizedBox(height: AppSpacing.sm),
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x2l),
-                child: _WalkActionButton(
-                  label: AppStrings.takePhoto,
-                  svgAsset: 'assets/SVG/camera.svg',
-                  onPressed: () => _onTakePhotoPressed(context, locationState),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.x2l,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: _WalkActionButton(
+                        label: AppStrings.takePhoto,
+                        svgAsset: 'assets/SVG/camera.svg',
+                        onPressed: () =>
+                            _onTakePhotoPressed(context, locationState),
+                        compact: true,
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: _WalkActionButton(
+                        label: AppStrings.wantToGo,
+                        onPressed: () => Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => const WantToGoPage(),
+                          ),
+                        ),
+                        compact: true,
+                      ),
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(height: 20),
+              const SizedBox(height: AppSpacing.sm),
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x2l),
-                child: _WalkActionButton(
-                  label: AppStrings.saveToWantToGo,
-                  onPressed: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const WantToGoPage()),
-                  ),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.x2l,
                 ),
-              ),
-              const SizedBox(height: 16),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x2l),
                 child: PrimaryButton(
                   label: AppStrings.endWalk,
+                  height: sizing.largeBtnHeight,
                   onPressed: () => Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const EndWalkPage()),
                   ),
                 ),
               ),
-              const SizedBox(height: 16),
+              const SizedBox(height: AppSpacing.lg),
             ],
           ),
         ),
@@ -217,7 +272,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
 
 // ──────────────────────────────────────────
 // GPS 状態インジケーター
-// ────────────────────────��─────────────────
+// ──────────────────────────────────────────
 
 class _GpsStatusIndicator extends StatelessWidget {
   const _GpsStatusIndicator({required this.locationState});
@@ -226,12 +281,12 @@ class _GpsStatusIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 40,
-      child: Center(
-        child: locationState.when(
-          data: (_) => const SizedBox.shrink(),
-          loading: () => const Row(
+    return locationState.when(
+      data: (_) => const SizedBox.shrink(),
+      loading: () => const SizedBox(
+        height: 40,
+        child: Center(
+          child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               SizedBox(
@@ -242,14 +297,19 @@ class _GpsStatusIndicator extends StatelessWidget {
                   color: AppColors.primary,
                 ),
               ),
-              SizedBox(width: 8),
+              SizedBox(width: AppSpacing.sm),
               Text(
                 AppStrings.gpsAcquiring,
                 style: TextStyle(color: AppColors.textDisabled),
               ),
             ],
           ),
-          error: (_, __) => const Text(
+        ),
+      ),
+      error: (_, __) => const SizedBox(
+        height: 40,
+        child: Center(
+          child: Text(
             AppStrings.gpsUnavailableError,
             style: TextStyle(color: AppColors.error),
           ),
@@ -259,28 +319,32 @@ class _GpsStatusIndicator extends StatelessWidget {
   }
 }
 
-// ───────────��──────────────────────────────
+// ──────────────────────────────────────────
 // 散歩アクションボタン（ブラウン）
-// ──���───────────────────────────────────────
+// ──────────────────────────────────────────
 
 class _WalkActionButton extends StatelessWidget {
   const _WalkActionButton({
     required this.label,
     this.svgAsset,
     required this.onPressed,
+    this.compact = false,
   });
 
   final String label;
   final String? svgAsset;
   final VoidCallback onPressed;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     final sizing = AppSizingTheme.of(context);
-    final height = sizing.actionBtnHeight;
-    final fontSize = sizing.actionBtnFontSize;
-    final iconSize = sizing.actionBtnIconSize;
-    final radius = sizing.actionBtnRadius;
+    final height = compact ? sizing.detailBtnHeight : sizing.actionBtnHeight;
+    final fontSize =
+        compact ? sizing.detailBtnFontSize : sizing.actionBtnFontSize;
+    final iconSize =
+        compact ? sizing.actionBtnIconSize * 0.7 : sizing.actionBtnIconSize;
+    final radius = compact ? sizing.detailBtnRadius : sizing.actionBtnRadius;
 
     return Container(
       width: double.infinity,
@@ -322,7 +386,7 @@ class _WalkActionButton extends StatelessWidget {
                       ),
                     ),
                   ),
-                  const SizedBox(width: 12),
+                  const SizedBox(width: AppSpacing.sm),
                   Text(
                     label,
                     style: TextStyle(

--- a/lib/screens/widgets/common/primary_button.dart
+++ b/lib/screens/widgets/common/primary_button.dart
@@ -11,10 +11,12 @@ class PrimaryButton extends StatelessWidget {
     super.key,
     required this.label,
     required this.onPressed,
+    this.height,
   });
 
   final String label;
   final VoidCallback onPressed;
+  final double? height;
 
   @override
   Widget build(BuildContext context) {
@@ -22,7 +24,7 @@ class PrimaryButton extends StatelessWidget {
 
     return Container(
       width: double.infinity,
-      height: sizing.primaryBtnHeight,
+      height: height ?? sizing.primaryBtnHeight,
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(sizing.primaryBtnRadius),

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -139,7 +139,7 @@ void main() {
       await pumpWalkPage(tester);
 
       expect(find.text(AppStrings.takePhoto), findsOneWidget);
-      expect(find.text(AppStrings.saveToWantToGo), findsOneWidget);
+      expect(find.text(AppStrings.wantToGo), findsOneWidget);
       expect(find.text(AppStrings.endWalk), findsOneWidget);
     });
 
@@ -242,9 +242,8 @@ void main() {
       expect(container.read(pendingPhotoProvider), isNull);
     });
 
-    // 行きたいリストに保存ボタンをタップすると WantToGoPage へ遷移する
-    testWidgets(
-        'navigates to WantToGoPage when save to want-to-go button is tapped',
+    // 行きたいボタンをタップすると WantToGoPage へ遷移する
+    testWidgets('navigates to WantToGoPage when want-to-go button is tapped',
         (tester) async {
       setDisplaySize(tester);
 
@@ -282,7 +281,7 @@ void main() {
       await tester.tap(find.text('start'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text(AppStrings.saveToWantToGo));
+      await tester.tap(find.text(AppStrings.wantToGo));
       await tester.pumpAndSettle();
 
       expect(find.byType(WantToGoPage), findsOneWidget);
@@ -506,6 +505,44 @@ void main() {
       await pumpWalkPage(tester, locationStream: const Stream.empty());
 
       expect(find.byType(FlutterMap), findsNothing);
+    });
+
+    // 撮影すると地図上に ClipOval サムネイルが追加される
+    testWidgets('adds photo marker on map after taking photo', (tester) async {
+      const imagePath = '/fake/photo.jpg';
+      final position = _makePosition(35.6895, 139.6917);
+
+      await pumpWalkPage(
+        tester,
+        locationStream: Stream.value(position),
+        camera: _FakeCameraService(imagePath),
+      );
+      await tester.pump();
+
+      expect(find.byType(ClipOval), findsNothing);
+
+      await tester.tap(find.text(AppStrings.takePhoto));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ClipOval), findsOneWidget);
+    });
+
+    // 撮影をキャンセルした場合は地図上にサムネイルが追加されない
+    testWidgets('does not add photo marker when camera is cancelled',
+        (tester) async {
+      final position = _makePosition(35.0, 139.0);
+
+      await pumpWalkPage(
+        tester,
+        locationStream: Stream.value(position),
+        camera: _FakeCameraService(null),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text(AppStrings.takePhoto));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ClipOval), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## 概要

- 地図を最大化し1画面に収まるレイアウトに改善
- 撮影した写真を GPS 座標に紐づけてマップ上にサムネイル表示
- ズームアップ後に現在地へ戻るボタンを追加

## 変更内容

### WalkPage レイアウト刷新
- 「撮影する」「行きたい！」ボタンを横並びのコンパクトボタンに変更
- 「散歩を終了する」を `largeBtnHeight` でやや小さく
- GPS 取得済み時に GPS インジケーターが完全に折りたたまれるよう修正（地図エリアを最大化）

### マップ改善
- 初期ズームを 15 → 17 に変更（歩行中の近め表示）
- 歩いた軌跡を青色ポリラインで描画（実装済み、今回ズーム調整）
- マップ左下に「現在地に戻る」ボタンを追加

### 写真サムネイル
- 撮影時の GPS 座標を `_photoMarkers` に保持
- `ClipOval` + `Image.file()` で 40×40px のサムネイルをマップ上に表示
- ファイル不在時のフォールバック表示あり（`errorBuilder`）

### その他
- `PrimaryButton` に optional `height` パラメータを追加
- `_WalkActionButton` に `compact` モードを追加
- `MapConstants.photoThumbnailSize` を追加

## テスト

- 写真サムネイル追加のテストを 2 件追加
- ボタンラベル変更（`saveToWantToGo` → `wantToGo`）に追従

## 関連 Issue

closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 散歩画面で撮影した写真を地図上のサムネイルとして表示できるようになりました。
  * 位置をすばやく現在地へ戻す再センターボタンを追加しました。
  * 散歩画面下部の操作ボタンを見やすく整理しました。

* **改善**
  * 地図の初期ズームを調整しました。
  * 写真サムネイル表示用のサイズを追加しました。
  * GPS取得中の表示をわかりやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->