### PR TITLE
[Logic] タイマー通知とロジックの繋ぎ込み (#80)

### DIFF
--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -14,6 +14,7 @@ abstract class AppColors {
   static const navActive = primary;
   static const navInactive = Color(0xFFB0B0B0);
   static const error = Color(0xFFE53935);
+  static const warning = Color(0xFFF57C00);
   static const shareLinkBg = Color(0xFF3A3A3A);
   static const shareLinkLabel = Color(0x80FFFFFF);
   static const shareLinkButton = Color(0x3DFFFFFF);

--- a/lib/core/constants/app_spacing.dart
+++ b/lib/core/constants/app_spacing.dart
@@ -45,6 +45,8 @@ abstract class AppSize {
   static const double gpsIndicatorHeight = 40.0;
   static const double gpsSpinnerSize = 14.0;
   static const double gpsSpinnerStroke = 2.0;
+  static const double timerChipLabelFontSize = 11.0;
+  static const double timerChipCountFontSize = 13.0;
   static const double appBarHeight = 56.0;
   static const double mapPinSize = 36.0;
   static const double cardElevation = 2.0;

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -25,6 +25,8 @@ abstract class AppStrings {
   static const saveToWantToGo = '現在地を\n行きたいリストに保存する';
   static const wantToGo = '行きたい！';
   static const recenterMap = '現在地に戻る';
+  static const timerTurnaround = '折り返し';
+  static const timerInactivity = '不活動';
   static const safetyOk = '元気です';
 
   // 行きたい！ページ

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -154,10 +154,10 @@ class _WalkPageState extends ConsumerState<WalkPage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              const ClockHeader(),
+              ClockHeader(countdownSeconds: _turnSecondsLeft),
               const SizedBox(height: AppSpacing.lg),
               _GpsStatusIndicator(locationState: locationState),
-              if (_turnSecondsLeft != null || _inactSecondsLeft != null)
+              if (_inactSecondsLeft != null)
                 Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: AppSpacing.x2l,
@@ -166,133 +166,138 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      if (_turnSecondsLeft != null) ...[
-                        _WalkTimerChip(
-                          label: AppStrings.timerTurnaround,
-                          icon: Icons.notifications_outlined,
-                          seconds: _turnSecondsLeft!,
-                        ),
-                        if (_inactSecondsLeft != null)
-                          const SizedBox(width: AppSpacing.sm),
-                      ],
-                      if (_inactSecondsLeft != null)
-                        _WalkTimerChip(
-                          label: AppStrings.timerInactivity,
-                          icon: Icons.directions_walk,
-                          seconds: _inactSecondsLeft!,
-                        ),
+                      _WalkTimerChip(
+                        label: AppStrings.timerInactivity,
+                        icon: Icons.directions_walk,
+                        seconds: _inactSecondsLeft!,
+                      ),
                     ],
                   ),
                 ),
               Expanded(
-                child: _currentPosition != null
-                    ? FlutterMap(
-                        mapController: _mapController,
-                        options: MapOptions(
-                          initialCenter: _currentPosition!,
-                          initialZoom: MapConstants.defaultZoom,
-                        ),
-                        children: [
-                          TileLayer(
-                            urlTemplate:
-                                'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                            userAgentPackageName: 'com.example.tekushare',
-                          ),
-                          if (_trackPoints.length >= 2)
-                            PolylineLayer(
-                              polylines: [
-                                Polyline(
-                                  points: _trackPoints,
-                                  color: AppColors.primary,
-                                  strokeWidth: MapConstants.polylineStrokeWidth,
-                                ),
-                              ],
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.lg,
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(AppRadius.lg),
+                    child: _currentPosition != null
+                        ? FlutterMap(
+                            mapController: _mapController,
+                            options: MapOptions(
+                              initialCenter: _currentPosition!,
+                              initialZoom: MapConstants.defaultZoom,
                             ),
-                          MarkerLayer(
-                            markers: [
-                              Marker(
-                                point: _currentPosition!,
-                                child: const Icon(
-                                  Icons.location_on,
-                                  color: Colors.red,
-                                  size: AppSize.iconMd,
-                                ),
+                            children: [
+                              TileLayer(
+                                urlTemplate:
+                                    'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                                userAgentPackageName: 'com.example.tekushare',
                               ),
-                            ],
-                          ),
-                          if (_photoMarkers.isNotEmpty)
-                            MarkerLayer(
-                              markers: _photoMarkers
-                                  .map(
-                                    (m) => Marker(
-                                      point: m.point,
-                                      width: MapConstants.photoThumbnailSize,
-                                      height: MapConstants.photoThumbnailSize,
-                                      child: ClipOval(
-                                        child: Image.file(
-                                          File(m.imagePath),
+                              if (_trackPoints.length >= 2)
+                                PolylineLayer(
+                                  polylines: [
+                                    Polyline(
+                                      points: _trackPoints,
+                                      color: AppColors.primary,
+                                      strokeWidth:
+                                          MapConstants.polylineStrokeWidth,
+                                    ),
+                                  ],
+                                ),
+                              MarkerLayer(
+                                markers: [
+                                  Marker(
+                                    point: _currentPosition!,
+                                    child: const Icon(
+                                      Icons.location_on,
+                                      color: Colors.red,
+                                      size: AppSize.iconMd,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              if (_photoMarkers.isNotEmpty)
+                                MarkerLayer(
+                                  markers: _photoMarkers
+                                      .map(
+                                        (m) => Marker(
+                                          point: m.point,
                                           width:
                                               MapConstants.photoThumbnailSize,
                                           height:
                                               MapConstants.photoThumbnailSize,
-                                          fit: BoxFit.cover,
-                                          errorBuilder: (_, __, ___) =>
-                                              const ColoredBox(
-                                            color: AppColors.textDisabled,
-                                            child: Icon(
-                                              Icons.photo,
-                                              color: AppColors.textOnPrimary,
-                                              size: AppSize.iconSm,
+                                          child: ClipOval(
+                                            child: Image.file(
+                                              File(m.imagePath),
+                                              width: MapConstants
+                                                  .photoThumbnailSize,
+                                              height: MapConstants
+                                                  .photoThumbnailSize,
+                                              fit: BoxFit.cover,
+                                              errorBuilder: (_, __, ___) =>
+                                                  const ColoredBox(
+                                                color: AppColors.textDisabled,
+                                                child: Icon(
+                                                  Icons.photo,
+                                                  color:
+                                                      AppColors.textOnPrimary,
+                                                  size: AppSize.iconSm,
+                                                ),
+                                              ),
                                             ),
                                           ),
                                         ),
-                                      ),
-                                    ),
-                                  )
-                                  .toList(),
-                            ),
-                          Align(
-                            alignment: Alignment.bottomLeft,
-                            child: Padding(
-                              padding: const EdgeInsets.all(AppSpacing.sm),
-                              child: FloatingActionButton(
-                                heroTag: 'recenter',
-                                tooltip: AppStrings.recenterMap,
-                                onPressed: () {
-                                  if (_currentPosition != null) {
-                                    _mapController.move(
-                                      _currentPosition!,
-                                      MapConstants.defaultZoom,
-                                    );
-                                  }
-                                },
-                                backgroundColor: AppColors.surface,
-                                foregroundColor: AppColors.primary,
-                                elevation: 2,
-                                child: const Icon(Icons.my_location),
-                              ),
-                            ),
-                          ),
-                          Align(
-                            alignment: Alignment.bottomRight,
-                            child: Container(
-                              color: MapConstants.osmAttributionBg,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: MapConstants.osmAttributionPaddingH,
-                                vertical: MapConstants.osmAttributionPaddingV,
-                              ),
-                              child: const Text(
-                                '© OpenStreetMap contributors',
-                                style: TextStyle(
-                                  fontSize: MapConstants.osmAttributionFontSize,
-                                  color: Colors.black87,
+                                      )
+                                      .toList(),
+                                ),
+                              Align(
+                                alignment: Alignment.bottomLeft,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(AppSpacing.sm),
+                                  child: FloatingActionButton(
+                                    heroTag: 'recenter',
+                                    tooltip: AppStrings.recenterMap,
+                                    onPressed: () {
+                                      if (_currentPosition != null) {
+                                        _mapController.move(
+                                          _currentPosition!,
+                                          MapConstants.defaultZoom,
+                                        );
+                                      }
+                                    },
+                                    backgroundColor: AppColors.surface,
+                                    foregroundColor: AppColors.primary,
+                                    elevation: 2,
+                                    child: const Icon(Icons.my_location),
+                                  ),
                                 ),
                               ),
-                            ),
-                          ),
-                        ],
-                      )
-                    : const SizedBox.shrink(),
+                              Align(
+                                alignment: Alignment.bottomRight,
+                                child: Container(
+                                  color: MapConstants.osmAttributionBg,
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal:
+                                        MapConstants.osmAttributionPaddingH,
+                                    vertical:
+                                        MapConstants.osmAttributionPaddingV,
+                                  ),
+                                  child: const Text(
+                                    '© OpenStreetMap contributors',
+                                    style: TextStyle(
+                                      fontSize:
+                                          MapConstants.osmAttributionFontSize,
+                                      color: Colors.black87,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ),
               ),
               const SizedBox(height: AppSpacing.sm),
               Padding(

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -14,6 +15,7 @@ import 'package:tekushare/core/constants/map_constants.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
+import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
@@ -38,8 +40,53 @@ class _WalkPageState extends ConsumerState<WalkPage> {
   final _photoMarkers = <({LatLng point, String imagePath})>[];
   LatLng? _currentPosition;
 
+  Timer? _tickTimer;
+  int? _turnSecondsLeft;
+  int? _inactSecondsLeft;
+  bool _turnFired = false;
+  bool _inactFired = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final settings = ref.read(settingsViewModelProvider);
+    if (settings.timerEnabled) {
+      _turnSecondsLeft = settings.timerMinutes * 60;
+    }
+    if (settings.inactivityEnabled) {
+      _inactSecondsLeft = settings.inactivityMinutes * 60;
+    }
+    _tickTimer = Timer.periodic(const Duration(seconds: 1), _onTick);
+  }
+
+  void _onTick(Timer _) {
+    if (!mounted) return;
+    setState(() {
+      if (_turnSecondsLeft != null && _turnSecondsLeft! > 0) {
+        _turnSecondsLeft = _turnSecondsLeft! - 1;
+      }
+      if (_inactSecondsLeft != null && _inactSecondsLeft! > 0) {
+        _inactSecondsLeft = _inactSecondsLeft! - 1;
+      }
+    });
+    _fireNotificationsIfNeeded();
+  }
+
+  Future<void> _fireNotificationsIfNeeded() async {
+    final svc = ref.read(notificationServiceProvider);
+    if (_turnSecondsLeft == 0 && !_turnFired) {
+      _turnFired = true;
+      await svc.showTurnaroundNotification();
+    }
+    if (_inactSecondsLeft == 0 && !_inactFired) {
+      _inactFired = true;
+      await svc.showInactivityNotification();
+    }
+  }
+
   @override
   void dispose() {
+    _tickTimer?.cancel();
     _mapController.dispose();
     super.dispose();
   }
@@ -76,9 +123,15 @@ class _WalkPageState extends ConsumerState<WalkPage> {
       next.whenData((pos) {
         final point = LatLng(pos.latitude, pos.longitude);
         final isFirstFix = _currentPosition == null;
+        final settings = ref.read(settingsViewModelProvider);
         setState(() {
           _currentPosition = point;
           _trackPoints.add(point);
+          // GPS 移動で不活動タイマーをリセット
+          if (_inactSecondsLeft != null) {
+            _inactSecondsLeft = settings.inactivityMinutes * 60;
+            _inactFired = false;
+          }
         });
         // 初回はマップ未生成のため move() をスキップ
         if (!isFirstFix) {
@@ -101,6 +154,33 @@ class _WalkPageState extends ConsumerState<WalkPage> {
               const ClockHeader(),
               const SizedBox(height: AppSpacing.lg),
               _GpsStatusIndicator(locationState: locationState),
+              if (_turnSecondsLeft != null || _inactSecondsLeft != null)
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.x2l,
+                    vertical: AppSpacing.xs,
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      if (_turnSecondsLeft != null) ...[
+                        _WalkTimerChip(
+                          label: AppStrings.timerTurnaround,
+                          icon: Icons.notifications_outlined,
+                          seconds: _turnSecondsLeft!,
+                        ),
+                        if (_inactSecondsLeft != null)
+                          const SizedBox(width: AppSpacing.sm),
+                      ],
+                      if (_inactSecondsLeft != null)
+                        _WalkTimerChip(
+                          label: AppStrings.timerInactivity,
+                          icon: Icons.directions_walk,
+                          seconds: _inactSecondsLeft!,
+                        ),
+                    ],
+                  ),
+                ),
               Expanded(
                 child: _currentPosition != null
                     ? FlutterMap(
@@ -251,10 +331,13 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                 child: PrimaryButton(
                   label: AppStrings.endWalk,
                   height: sizing.largeBtnHeight,
-                  onPressed: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const EndWalkPage()),
-                  ),
+                  onPressed: () {
+                    ref.read(notificationServiceProvider).cancelAll();
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => const EndWalkPage()),
+                    );
+                  },
                 ),
               ),
               const SizedBox(height: AppSpacing.lg),
@@ -336,6 +419,74 @@ class _GpsStatusIndicator extends StatelessWidget {
             style: TextStyle(color: AppColors.error),
           ),
         ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// タイマーチップ
+// ──────────────────────────────────────────
+
+class _WalkTimerChip extends StatelessWidget {
+  const _WalkTimerChip({
+    required this.label,
+    required this.icon,
+    required this.seconds,
+  });
+
+  final String label;
+  final IconData icon;
+  final int seconds;
+
+  Color _color() {
+    if (seconds < 60) return AppColors.error;
+    if (seconds < 120) return AppColors.warning;
+    return AppColors.primary;
+  }
+
+  String _formatted() {
+    final m = seconds ~/ 60;
+    final s = seconds % 60;
+    return '${m.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color();
+    return Container(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+        borderRadius: BorderRadius.circular(AppRadius.full),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.xs,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: AppSize.iconXs, color: color),
+          const SizedBox(width: AppSpacing.xs),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: AppSize.timerChipLabelFontSize,
+              color: color,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          Text(
+            _formatted(),
+            style: TextStyle(
+              fontSize: AppSize.timerChipCountFontSize,
+              fontWeight: FontWeight.w600,
+              color: color,
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -51,7 +51,10 @@ class _WalkPageState extends ConsumerState<WalkPage> {
     super.initState();
     final settings = ref.read(settingsViewModelProvider);
     if (settings.timerEnabled) {
-      _turnSecondsLeft = settings.timerMinutes * 60;
+      final oneWayMinutes = settings.timerRoundTrip
+          ? settings.timerMinutes ~/ 2
+          : settings.timerMinutes;
+      _turnSecondsLeft = oneWayMinutes * 60;
     }
     if (settings.inactivityEnabled) {
       _inactSecondsLeft = settings.inactivityMinutes * 60;

--- a/lib/screens/widgets/common/clock_header.dart
+++ b/lib/screens/widgets/common/clock_header.dart
@@ -1,22 +1,39 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
-import 'package:tekushare/core/constants/app_defaults.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.dart';
 import 'package:tekushare/screens/providers/clock_provider.dart';
 
 /// 時刻・片道設定を表示する共通ヘッダー
 class ClockHeader extends ConsumerWidget {
-  const ClockHeader({super.key});
+  const ClockHeader({super.key, this.countdownSeconds});
+
+  /// 指定するとリアルタイムカウントダウン（MM:SS）を表示する
+  final int? countdownSeconds;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final now = ref.watch(clockProvider).valueOrNull ?? DateTime.now();
     final h = now.hour.toString().padLeft(2, '0');
     final m = now.minute.toString().padLeft(2, '0');
-    final minutes = AppDefaults.timerMinutes.toString().padLeft(2, '0');
+
+    final settings = ref.watch(settingsViewModelProvider);
+    final oneWayMinutes = settings.timerRoundTrip
+        ? settings.timerMinutes ~/ 2
+        : settings.timerMinutes;
+
+    final String timeLabel;
+    if (countdownSeconds != null) {
+      final mm = (countdownSeconds! ~/ 60).toString().padLeft(2, '0');
+      final ss = (countdownSeconds! % 60).toString().padLeft(2, '0');
+      timeLabel = '片道  $mm:$ss';
+    } else {
+      final mm = oneWayMinutes.toString().padLeft(2, '0');
+      timeLabel = '片道  00:$mm';
+    }
 
     // 99px はスクリーン最上端からの距離のため SafeArea 分を差し引く
     final topPadding =
@@ -39,7 +56,7 @@ class ClockHeader extends ConsumerWidget {
           ),
           const SizedBox(height: 10),
           Text(
-            '片道  00:$minutes',
+            timeLabel,
             style: AppTextStyle.bodyMedium.copyWith(
               color: AppColors.primary,
               fontSize: sizing.clockLabelFontSize,

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
 import 'package:tekushare/domain/usecases/spot/get_spots.dart';
 import 'package:tekushare/domain/usecases/spot/save_spot.dart';
 import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/infrastructure/camera_service.dart';
+import 'package:tekushare/infrastructure/notification_service.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
+import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
@@ -19,7 +23,6 @@ import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
-import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
 // ──────────────────────────────────────────
@@ -74,6 +77,51 @@ class _FakeCameraService extends Fake implements CameraService {
   Future<String?> takePhoto() async => _returnPath;
 }
 
+class _FakeNotificationsPlugin extends Fake
+    implements FlutterLocalNotificationsPlugin {
+  @override
+  Future<void> show({
+    required int id,
+    String? title,
+    String? body,
+    NotificationDetails? notificationDetails,
+    String? payload,
+  }) async {}
+
+  @override
+  Future<void> cancelAll() async {}
+}
+
+final _notificationOverride = notificationServiceProvider.overrideWithValue(
+  NotificationService.forTest(_FakeNotificationsPlugin()),
+);
+
+class _TimerEnabledSettingsViewModel extends SettingsViewModel {
+  @override
+  SettingsState build() => const SettingsState(
+        timerEnabled: true,
+        timerMinutes: 30,
+        inactivityEnabled: true,
+        inactivityMinutes: 15,
+      );
+}
+
+class _TimerDisabledSettingsViewModel extends SettingsViewModel {
+  @override
+  SettingsState build() => const SettingsState(
+        timerEnabled: false,
+        inactivityEnabled: false,
+      );
+}
+
+final _timerEnabledOverride = settingsViewModelProvider.overrideWith(
+  _TimerEnabledSettingsViewModel.new,
+);
+
+final _timerDisabledOverride = settingsViewModelProvider.overrideWith(
+  _TimerDisabledSettingsViewModel.new,
+);
+
 Position _makePosition(double lat, double lng) => Position(
       latitude: lat,
       longitude: lng,
@@ -111,6 +159,7 @@ void main() {
         locationProvider.overrideWith(
           (ref) => locationStream ?? const Stream.empty(),
         ),
+        _notificationOverride,
         if (camera != null) cameraServiceProvider.overrideWith((ref) => camera),
       ];
 
@@ -254,6 +303,7 @@ void main() {
         ProviderScope(
           overrides: [
             locationProvider.overrideWith((ref) => locationStream),
+            _notificationOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -299,6 +349,7 @@ void main() {
         ProviderScope(
           overrides: [
             locationProvider.overrideWith((ref) => locationStream),
+            _notificationOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -543,6 +594,68 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(ClipOval), findsNothing);
+    });
+
+    // タイマー有効時はチップが表示される
+    testWidgets('shows timer chips when timers are enabled', (tester) async {
+      setDisplaySize(tester);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            locationProvider.overrideWith((ref) => const Stream.empty()),
+            _timerEnabledOverride,
+            _notificationOverride,
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const WalkPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(AppStrings.timerTurnaround), findsOneWidget);
+      expect(find.text(AppStrings.timerInactivity), findsOneWidget);
+    });
+
+    // タイマー無効時はチップが表示されない
+    testWidgets('hides timer chips when timers are disabled', (tester) async {
+      setDisplaySize(tester);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            locationProvider.overrideWith((ref) => const Stream.empty()),
+            _timerDisabledOverride,
+            _notificationOverride,
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const WalkPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(AppStrings.timerTurnaround), findsNothing);
+      expect(find.text(AppStrings.timerInactivity), findsNothing);
     });
   });
 }

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -623,7 +623,6 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text(AppStrings.timerTurnaround), findsOneWidget);
       expect(find.text(AppStrings.timerInactivity), findsOneWidget);
     });
 


### PR DESCRIPTION
## 概要

- 散歩開始時に設定値（timerMinutes・timerRoundTrip・inactivityMinutes）からカウントダウンを初期化
- 1秒ごとのTickタイマーで折り返し・不活動カウントダウンを更新
- カウントが0になったとき通知サービス（折り返し・不活動）を呼び出す
- GPS移動検知で不活動タイマーをリセット
- 散歩終了ボタン押下時に全通知をキャンセル
- ClockHeaderの「片道 MM:SS」をリアルタイムカウントダウン表示に変更（設定値連携）
- FlutterMapに左右余白（AppSpacing.lg）と角丸（AppRadius.lg）を追加

## テスト計画

- [ ] タイマー有効時に不活動チップが表示されることを確認
- [ ] タイマー無効時にチップが表示されないことを確認
- [ ] 散歩終了ボタンタップで EndWalkPage へ遷移することを確認
- [ ] ClockHeaderの片道カウントダウンが設定の往復/片道に応じて正しい時間から始まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)