### PR TITLE
[Feature] #87 散歩中のGPS記録と距離計算の実装

### DIFF
--- a/lib/core/utils/distance_calculator.dart
+++ b/lib/core/utils/distance_calculator.dart
@@ -1,1 +1,22 @@
-// 距離計算ユーティリティ
+import 'package:latlong2/latlong.dart' as ll;
+import 'package:tekushare/domain/entities/lat_lng.dart';
+
+double calcDistanceKm(List<LatLng> points) {
+  if (points.length < 2) return 0;
+  const d = ll.Distance();
+  var total = 0.0;
+  for (var i = 0; i < points.length - 1; i++) {
+    total += d.as(
+      ll.LengthUnit.Kilometer,
+      ll.LatLng(points[i].latitude, points[i].longitude),
+      ll.LatLng(points[i + 1].latitude, points[i + 1].longitude),
+    );
+  }
+  return total;
+}
+
+String formatDistanceKm(double km) {
+  if (km == 0) return '-';
+  if (km < 1.0) return '${(km * 1000).round()}m';
+  return '${km.toStringAsFixed(1)}km';
+}

--- a/lib/core/utils/distance_calculator.dart
+++ b/lib/core/utils/distance_calculator.dart
@@ -3,7 +3,7 @@ import 'package:tekushare/domain/entities/lat_lng.dart';
 
 double calcDistanceKm(List<LatLng> points) {
   if (points.length < 2) return 0;
-  const d = ll.Distance();
+  const d = ll.Distance(roundResult: false);
   var total = 0.0;
   for (var i = 0; i < points.length - 1; i++) {
     total += d.as(

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -6,7 +6,9 @@ import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/core/utils/distance_calculator.dart';
 import 'package:tekushare/domain/entities/saved_route.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
@@ -14,11 +16,15 @@ import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/saved_routes_provider.dart';
 import 'package:tekushare/screens/providers/walk_history_provider.dart';
+import 'package:tekushare/screens/providers/walk_routes_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
 const _weekdayNames = ['日', '月', '火', '水', '木', '金', '土'];
 
-List<WalkLog> _buildSessionLogs(List<WalkSession> sessions) {
+List<WalkLog> _buildSessionLogs(
+  List<WalkSession> sessions,
+  Map<String, double> distanceBySessionId,
+) {
   final finished = sessions
       .where((s) => s.status == WalkStatus.finished && s.startedAt != null)
       .toList()
@@ -59,12 +65,18 @@ List<WalkLog> _buildSessionLogs(List<WalkSession> sessions) {
               '${m.toString().padLeft(2, '0')}:'
               '${s.toString().padLeft(2, '0')}'
           : '${m.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}',
-      distance: '-',
+      distance: formatDistanceKm(
+        distanceBySessionId[session.id] ?? 0,
+      ),
       spotCount: 0,
       dayLabel: dayLabel,
     );
   });
 }
+
+Map<String, double> _buildDistanceMap(List<WalkRoute> routes) => {
+      for (final r in routes) r.walkSessionId: calcDistanceKm(r.points),
+    };
 
 /// 散歩ルートページ
 class WalkRoutePage extends ConsumerStatefulWidget {
@@ -79,6 +91,7 @@ class WalkRoutePage extends ConsumerStatefulWidget {
 class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
   final _nameController = TextEditingController();
   int _cardSlideDirection = 1;
+  Map<String, double> _distanceBySessionId = {};
 
   void _selectDay(int day) {
     final current = ref.read(walkRouteViewModelProvider).selectedDay;
@@ -92,8 +105,16 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
         sessions.where((s) => s.status == WalkStatus.finished).toList();
     if (finished.isEmpty) return;
     final vm = ref.read(walkRouteViewModelProvider.notifier);
-    vm.setLogs(_buildSessionLogs(sessions));
+    vm.setLogs(_buildSessionLogs(sessions, _distanceBySessionId));
     vm.selectDay(finished.length.clamp(1, 7));
+  }
+
+  void _applyWalkRoutes(List<WalkRoute> routes) {
+    if (!mounted) return;
+    _distanceBySessionId = _buildDistanceMap(routes);
+    // 距離が確定したのでログを再描画する
+    final sessions = ref.read(walkHistoryProvider).valueOrNull;
+    if (sessions != null) _applyHistory(sessions);
   }
 
   @override
@@ -105,8 +126,10 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
         final results = await Future.wait([
           ref.read(walkHistoryProvider.future),
           ref.read(savedRoutesProvider.future),
+          ref.read(walkRoutesProvider.future),
         ]);
         if (!mounted) return;
+        _applyWalkRoutes(results[2] as List<WalkRoute>);
         _applyHistory(results[0] as List<WalkSession>);
         _applySavedRoutes(results[1] as List<SavedRoute>);
       } on Object catch (e) {
@@ -194,6 +217,9 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
     });
     ref.listen(savedRoutesProvider, (_, next) {
       next.whenData(_applySavedRoutes);
+    });
+    ref.listen(walkRoutesProvider, (_, next) {
+      next.whenData(_applyWalkRoutes);
     });
 
     final state = ref.watch(walkRouteViewModelProvider);

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -8,6 +8,7 @@ import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/core/utils/distance_calculator.dart';
 import 'package:tekushare/domain/entities/saved_route.dart';
+import 'package:tekushare/domain/entities/spot.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart';
@@ -15,15 +16,36 @@ import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/saved_routes_provider.dart';
+import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/providers/walk_history_provider.dart';
 import 'package:tekushare/screens/providers/walk_routes_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
 const _weekdayNames = ['日', '月', '火', '水', '木', '金', '土'];
 
+Map<String, int> _buildSpotCountMap(
+  List<WalkSession> sessions,
+  List<Spot> spots,
+) {
+  final result = <String, int>{};
+  for (final s in sessions) {
+    if (s.status != WalkStatus.finished || s.startedAt == null) continue;
+    final end = s.finishedAt ?? DateTime.now();
+    result[s.id] = spots
+        .where(
+          (sp) =>
+              !sp.createdAt.isBefore(s.startedAt!) &&
+              !sp.createdAt.isAfter(end),
+        )
+        .length;
+  }
+  return result;
+}
+
 List<WalkLog> _buildSessionLogs(
   List<WalkSession> sessions,
   Map<String, double> distanceBySessionId,
+  Map<String, int> spotCountBySessionId,
 ) {
   final finished = sessions
       .where((s) => s.status == WalkStatus.finished && s.startedAt != null)
@@ -68,7 +90,7 @@ List<WalkLog> _buildSessionLogs(
       distance: formatDistanceKm(
         distanceBySessionId[session.id] ?? 0,
       ),
-      spotCount: 0,
+      spotCount: spotCountBySessionId[session.id] ?? 0,
       dayLabel: dayLabel,
     );
   });
@@ -92,6 +114,7 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
   final _nameController = TextEditingController();
   int _cardSlideDirection = 1;
   Map<String, double> _distanceBySessionId = {};
+  Map<String, int> _spotCountBySessionId = {};
 
   void _selectDay(int day) {
     final current = ref.read(walkRouteViewModelProvider).selectedDay;
@@ -105,16 +128,25 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
         sessions.where((s) => s.status == WalkStatus.finished).toList();
     if (finished.isEmpty) return;
     final vm = ref.read(walkRouteViewModelProvider.notifier);
-    vm.setLogs(_buildSessionLogs(sessions, _distanceBySessionId));
+    vm.setLogs(
+      _buildSessionLogs(sessions, _distanceBySessionId, _spotCountBySessionId),
+    );
     vm.selectDay(finished.length.clamp(1, 7));
   }
 
   void _applyWalkRoutes(List<WalkRoute> routes) {
     if (!mounted) return;
     _distanceBySessionId = _buildDistanceMap(routes);
-    // 距離が確定したのでログを再描画する
     final sessions = ref.read(walkHistoryProvider).valueOrNull;
     if (sessions != null) _applyHistory(sessions);
+  }
+
+  void _applySpots(List<Spot> spots) {
+    if (!mounted) return;
+    final sessions = ref.read(walkHistoryProvider).valueOrNull;
+    if (sessions == null) return;
+    _spotCountBySessionId = _buildSpotCountMap(sessions, spots);
+    _applyHistory(sessions);
   }
 
   @override
@@ -129,8 +161,11 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
           ref.read(walkRoutesProvider.future),
         ]);
         if (!mounted) return;
+        final sessions = results[0] as List<WalkSession>;
+        final spots = ref.read(spotProvider);
+        _spotCountBySessionId = _buildSpotCountMap(sessions, spots);
         _applyWalkRoutes(results[2] as List<WalkRoute>);
-        _applyHistory(results[0] as List<WalkSession>);
+        _applyHistory(sessions);
         _applySavedRoutes(results[1] as List<SavedRoute>);
       } on Object catch (e) {
         debugPrint('データの読み込みに失敗しました: $e');
@@ -221,6 +256,7 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
     ref.listen(walkRoutesProvider, (_, next) {
       next.whenData(_applyWalkRoutes);
     });
+    ref.listen(spotProvider, (_, spots) => _applySpots(spots));
 
     final state = ref.watch(walkRouteViewModelProvider);
     final vm = ref.read(walkRouteViewModelProvider.notifier);

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -6,10 +6,12 @@ import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart' as domain;
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/providers/walk_history_provider.dart';
+import 'package:tekushare/screens/providers/walk_routes_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/providers/walk_timer_provider.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
@@ -18,7 +20,9 @@ import 'package:tekushare/screens/widgets/common/clock_header.dart';
 
 /// 散歩終了確認ページ
 class EndWalkPage extends ConsumerStatefulWidget {
-  const EndWalkPage({super.key});
+  const EndWalkPage({super.key, this.trackPoints = const []});
+
+  final List<domain.LatLng> trackPoints;
 
   @override
   ConsumerState<EndWalkPage> createState() => _EndWalkPageState();
@@ -77,11 +81,12 @@ class _EndWalkPageState extends ConsumerState<EndWalkPage>
     final route = WalkRoute(
       id: session.id,
       walkSessionId: session.id,
-      points: const [],
+      points: widget.trackPoints,
       createdAt: DateTime.now(),
     );
     await ref.read(walkSessionProvider.notifier).endWalk(route);
     ref.invalidate(walkHistoryProvider);
+    ref.invalidate(walkRoutesProvider);
     ref.read(walkSessionProvider.notifier).resetWalk();
     ref.read(walkTimerProvider.notifier).reset();
     if (!mounted) return;

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:geolocator/geolocator.dart' show Position;
 import 'package:latlong2/latlong.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart' as domain;
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -436,9 +437,14 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                   height: sizing.largeBtnHeight,
                   onPressed: () {
                     ref.read(notificationServiceProvider).cancelAll();
+                    final domainPoints = _trackPoints
+                        .map((p) => domain.LatLng(p.latitude, p.longitude))
+                        .toList();
                     Navigator.push(
                       context,
-                      MaterialPageRoute(builder: (_) => const EndWalkPage()),
+                      MaterialPageRoute(
+                        builder: (_) => EndWalkPage(trackPoints: domainPoints),
+                      ),
                     );
                   },
                 ),

--- a/lib/screens/providers/walk_routes_provider.dart
+++ b/lib/screens/providers/walk_routes_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+
+final walkRoutesProvider = FutureProvider<List<WalkRoute>>((ref) async {
+  return ref.watch(routeRepositoryProvider).getAllRoutes();
+});

--- a/test/core/utils/distance_calculator_test.dart
+++ b/test/core/utils/distance_calculator_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/utils/distance_calculator.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart';
+
+void main() {
+  group('calcDistanceKm', () {
+    test('returns 0 for empty list', () {
+      expect(calcDistanceKm([]), 0);
+    });
+
+    test('returns 0 for single point', () {
+      expect(calcDistanceKm([const LatLng(35.0, 139.0)]), 0);
+    });
+
+    test('calculates distance for two points approximately 1km apart', () {
+      // 35.000→35.009 ≈ 1.0km（緯度1度≈111km）
+      final km = calcDistanceKm([
+        const LatLng(35.000, 139.000),
+        const LatLng(35.009, 139.000),
+      ]);
+      expect(km, closeTo(1.0, 0.05));
+    });
+
+    test('accumulates distances across multiple segments without rounding', () {
+      // 3点を通る経路: 各区間を個別に計算して合計したものと一致する
+      const points = [
+        LatLng(35.000, 139.000),
+        LatLng(35.004, 139.000),
+        LatLng(35.009, 139.000),
+      ];
+      final total = calcDistanceKm(points);
+      final seg1 = calcDistanceKm([points[0], points[1]]);
+      final seg2 = calcDistanceKm([points[1], points[2]]);
+      expect(total, closeTo(seg1 + seg2, 1e-10));
+    });
+  });
+
+  group('formatDistanceKm', () {
+    test('returns - for zero distance', () {
+      expect(formatDistanceKm(0), '-');
+    });
+
+    test('formats as meters when less than 1km', () {
+      expect(formatDistanceKm(0.5), '500m');
+      expect(formatDistanceKm(0.8), '800m');
+    });
+
+    test('formats as km with one decimal when 1km or more', () {
+      expect(formatDistanceKm(1.0), '1.0km');
+      expect(formatDistanceKm(1.234), '1.2km');
+      expect(formatDistanceKm(2.5), '2.5km');
+    });
+  });
+}

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -5,7 +5,9 @@ import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/saved_route.dart';
 import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
+import 'package:tekushare/domain/repositories/route_repository.dart';
 import 'package:tekushare/domain/repositories/saved_route_repository.dart';
 import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
 import 'package:tekushare/domain/usecases/photo/remove_photo_from_spot.dart';
@@ -67,6 +69,19 @@ class _FakeSavedRouteRepository implements SavedRouteRepository {
 
   @override
   Future<List<SavedRoute>> getAll() async => routes;
+}
+
+class _FakeRouteRepository implements RouteRepository {
+  const _FakeRouteRepository();
+
+  @override
+  Future<void> saveRoute(WalkRoute route) async {}
+
+  @override
+  Future<WalkRoute?> getRouteBySessionId(String sessionId) async => null;
+
+  @override
+  Future<List<WalkRoute>> getAllRoutes() async => [];
 }
 
 final _testSavedRoutes = [
@@ -132,6 +147,10 @@ final _historyOverride = walkHistoryProvider.overrideWith(
   (_) async => const <WalkSession>[],
 );
 
+final _walkRoutesOverride = routeRepositoryProvider.overrideWith(
+  (_) => const _FakeRouteRepository(),
+);
+
 final _savedRouteRepoOverride = savedRouteRepositoryProvider.overrideWith(
   (_) => const _FakeSavedRouteRepository(),
 );
@@ -179,7 +198,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoWithDataOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoWithDataOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -218,6 +241,7 @@ void main() {
           overrides: [
             walkHistoryProvider.overrideWith((_) async => [session]),
             _savedRouteRepoOverride,
+            _walkRoutesOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -303,7 +327,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -332,7 +360,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -364,7 +396,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -396,7 +432,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -431,7 +471,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -468,6 +512,7 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
+            _walkRoutesOverride,
             walkRouteViewModelProvider
                 .overrideWith(_NonStandardDateViewModel.new),
           ],
@@ -500,7 +545,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -542,7 +591,12 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride, _spotOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride,
+            _spotOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -584,7 +638,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_historyOverride, _savedRouteRepoOverride],
+          overrides: [
+            _historyOverride,
+            _savedRouteRepoOverride,
+            _walkRoutesOverride
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -43,6 +43,13 @@ class _FakeGetSpots implements GetSpots {
   Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(const []);
 }
 
+class _FakeGetSpotsWithData implements GetSpots {
+  const _FakeGetSpotsWithData(this.spots);
+  final List<Spot> spots;
+  @override
+  Stream<List<Spot>> call({SpotStatus? filter}) => Stream.value(spots);
+}
+
 class _FakeUpdateSpotStatus implements UpdateSpotStatus {
   const _FakeUpdateSpotStatus();
   @override
@@ -220,7 +227,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoWithDataOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -261,6 +269,7 @@ void main() {
             walkHistoryProvider.overrideWith((_) async => [session]),
             _savedRouteRepoOverride,
             _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -305,6 +314,7 @@ void main() {
             walkHistoryProvider.overrideWith((_) async => [session]),
             _savedRouteRepoOverride,
             _walkRoutesWithDataOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -393,7 +403,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -426,7 +437,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -462,7 +474,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -498,7 +511,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -537,7 +551,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -576,6 +591,7 @@ void main() {
             _historyOverride,
             _savedRouteRepoOverride,
             _walkRoutesOverride,
+            _spotOverride,
             walkRouteViewModelProvider
                 .overrideWith(_NonStandardDateViewModel.new),
           ],
@@ -611,7 +627,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -704,7 +721,8 @@ void main() {
           overrides: [
             _historyOverride,
             _savedRouteRepoOverride,
-            _walkRoutesOverride
+            _walkRoutesOverride,
+            _spotOverride,
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -803,6 +821,88 @@ void main() {
       await tester.pump();
 
       expect(find.byType(WalkRoutePage), findsOneWidget);
+    });
+
+    // 散歩セッション中に登録したスポットの件数が反映される
+    testWidgets('shows spot count for spots registered during walk session',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final session = WalkSession(
+        id: 'spot-test-session',
+        status: WalkStatus.finished,
+        startedAt: DateTime(2026, 1, 15, 9, 0),
+        finishedAt: DateTime(2026, 1, 15, 9, 30),
+        elapsedSeconds: 1800,
+      );
+
+      // セッション内(9:15)と外(8:50, 10:00)にスポットを配置
+      final spotsInSession = [
+        Spot(
+          id: 'spot-inside',
+          title: '散歩中スポット',
+          latitude: 35.0,
+          longitude: 139.0,
+          status: SpotStatus.wantToGo,
+          createdAt: DateTime(2026, 1, 15, 9, 15),
+        ),
+        Spot(
+          id: 'spot-before',
+          title: 'セッション前スポット',
+          latitude: 35.001,
+          longitude: 139.001,
+          status: SpotStatus.wantToGo,
+          createdAt: DateTime(2026, 1, 15, 8, 50),
+        ),
+        Spot(
+          id: 'spot-after',
+          title: 'セッション後スポット',
+          latitude: 35.002,
+          longitude: 139.002,
+          status: SpotStatus.wantToGo,
+          createdAt: DateTime(2026, 1, 15, 10, 0),
+        ),
+      ];
+
+      final spotsOverride = spotProvider.overrideWith(
+        (ref) => SpotNotifier(
+          saveSpot: const _FakeSaveSpot(),
+          getSpots: _FakeGetSpotsWithData(spotsInSession),
+          updateSpotStatus: const _FakeUpdateSpotStatus(),
+          attachPhotoToSpot: const _FakeAttachPhotoToSpot(),
+          removePhotoFromSpot: const _FakeRemovePhotoFromSpot(),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            walkHistoryProvider.overrideWith((_) async => [session]),
+            _savedRouteRepoOverride,
+            _walkRoutesOverride,
+            spotsOverride,
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const WalkRoutePage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // セッション内のスポット1件だけが件数に反映される
+      expect(find.text('行きたいスポット：1件'), findsOneWidget);
     });
 
     // カレンダーの日付をタップしてもページが表示されている

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -5,6 +5,7 @@ import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/saved_route.dart';
 import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/entities/lat_lng.dart' as domain;
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/domain/repositories/route_repository.dart';
@@ -72,7 +73,8 @@ class _FakeSavedRouteRepository implements SavedRouteRepository {
 }
 
 class _FakeRouteRepository implements RouteRepository {
-  const _FakeRouteRepository();
+  const _FakeRouteRepository({this.routes = const []});
+  final List<WalkRoute> routes;
 
   @override
   Future<void> saveRoute(WalkRoute route) async {}
@@ -81,8 +83,21 @@ class _FakeRouteRepository implements RouteRepository {
   Future<WalkRoute?> getRouteBySessionId(String sessionId) async => null;
 
   @override
-  Future<List<WalkRoute>> getAllRoutes() async => [];
+  Future<List<WalkRoute>> getAllRoutes() async => routes;
 }
+
+// 約1kmのGPSルート（35.000→35.009 ≈ 1.0km）
+final _testWalkRoutes = [
+  WalkRoute(
+    id: 'test-id',
+    walkSessionId: 'test-id',
+    points: const [
+      domain.LatLng(35.000, 139.000),
+      domain.LatLng(35.009, 139.000),
+    ],
+    createdAt: DateTime(2026, 1, 1),
+  ),
+];
 
 final _testSavedRoutes = [
   SavedRoute(
@@ -149,6 +164,10 @@ final _historyOverride = walkHistoryProvider.overrideWith(
 
 final _walkRoutesOverride = routeRepositoryProvider.overrideWith(
   (_) => const _FakeRouteRepository(),
+);
+
+final _walkRoutesWithDataOverride = routeRepositoryProvider.overrideWith(
+  (_) => _FakeRouteRepository(routes: _testWalkRoutes),
 );
 
 final _savedRouteRepoOverride = savedRouteRepositoryProvider.overrideWith(
@@ -261,6 +280,50 @@ void main() {
 
       expect(find.text('9:00~9:30'), findsOneWidget);
       expect(find.text('30:00'), findsOneWidget);
+    });
+
+    // WalkRouteのGPSポイントがあってもページが正常にレンダリングされる
+    testWidgets('renders without error when walk routes have gps points',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final now = DateTime.now();
+      final session = WalkSession(
+        id: 'test-id',
+        status: WalkStatus.finished,
+        startedAt: DateTime(now.year, now.month, now.day, 9, 0),
+        finishedAt: DateTime(now.year, now.month, now.day, 9, 30),
+        elapsedSeconds: 1800,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            walkHistoryProvider.overrideWith((_) async => [session]),
+            _savedRouteRepoOverride,
+            _walkRoutesWithDataOverride,
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const WalkRoutePage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // セッションの時刻が表示されること（ルートデータあり時もクラッシュしない）
+      expect(find.text('9:00~9:30'), findsOneWidget);
     });
 
     // ページタイトルが表示される


### PR DESCRIPTION
## 概要

- 散歩中に記録した GPS 点列を `WalkRoute.points` に保存する
- 散歩終了時に実際の移動距離を計算し、散歩ルートページに反映する

## 変更内容

- **`lib/core/utils/distance_calculator.dart`** (新規)  
  `latlong2` を使った距離計算ユーティリティ（`calcDistanceKm` / `formatDistanceKm`）

- **`lib/screens/providers/walk_routes_provider.dart`** (新規)  
  `RouteRepository.getAllRoutes()` から `WalkRoute` 一覧を取得する `FutureProvider`

- **`lib/screens/pages/walk/view/walk_page.dart`**  
  「散歩終了」タップ時に `_trackPoints` を domain `LatLng` に変換して `EndWalkPage` に渡す

- **`lib/screens/pages/walk/view/end_walk_page.dart`**  
  `trackPoints` パラメータを追加（デフォルト `const []` で後方互換）。`WalkRoute` に実際の点列を保存し、`walkRoutesProvider` を invalidate

- **`lib/screens/pages/map/view/walk_route_page.dart`**  
  `walkRoutesProvider` を読み込み、sessionId ↔ 距離マップを作成。距離表示を `'-'` から実測値（例：`1.2km`、`800m`）に変更

## テスト

- `walk_route_page_test.dart`：`_FakeRouteRepository` と `_walkRoutesOverride` を追加し全テストパスを確認
- `flutter analyze`：警告・エラーなし

## 関連

- Closes #87
- 残課題（別 issue）：選択ルートカードへのマップ表示・スポット連携

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 散歩ルートの総距離を計算・表示するようになりました。1km未満はm表示、それ以上は小数1桁で見やすく整形されます。
  * 散歩終了時に、移動記録の軌跡情報を保存できるようになりました。

* **改善**
  * ルート確定後に距離を再計算し、記録一覧へ反映するようになりました。
  * ルート一覧の取得に対応し、画面表示が最新状態に更新されやすくなりました。

* **テスト**
  * ルート取得を含む画面テストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->