### PR TITLE
[Feature/Fix] #85 ログアウト・アカウント削除、ナビゲーション修正、散歩ルートマップ改善

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -35,6 +35,8 @@ class _FakeAuthService implements AuthService {
   Future<void> setDisplayName(String name) async {}
   @override
   Future<void> signOut() async {}
+  @override
+  Future<void> deleteUser() async {}
 }
 
 void main() {

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -74,6 +74,7 @@ abstract class AppStrings {
   static const saveRouteButton = 'このルートを保存する';
   static const routeDeleteConfirmMessage = '本当に消去しますか？';
   static const routeDeleteButton = '消去';
+  static const fullscreenMapTooltip = 'マップを全画面表示';
   static const walkStartEndTime = '開始終了時間';
   static const walkDuration = '散歩時間';
   static const walkDistanceLabel = '距離';

--- a/lib/core/constants/map_constants.dart
+++ b/lib/core/constants/map_constants.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 
 abstract class MapConstants {
   static const double defaultZoom = 17.0;
   static const double polylineStrokeWidth = 6.0;
+  // 保存済みルート表示用（小さいカードに埋め込まれるため細め）
+  static const double savedRoutePolylineStrokeWidth = 3.0;
+  // 保存済みルートカードのマップ操作フラグ（ピンチズーム・ダブルタップズームのみ）
+  static const int savedRouteMapFlags =
+      InteractiveFlag.pinchZoom | InteractiveFlag.doubleTapZoom;
   static const double photoThumbnailSize = 40.0;
   static const double photoDeleteBadgeSize = 16.0;
   static const double photoDeleteIconSize = 10.0;

--- a/lib/core/constants/map_constants.dart
+++ b/lib/core/constants/map_constants.dart
@@ -4,11 +4,19 @@ import 'package:flutter_map/flutter_map.dart';
 abstract class MapConstants {
   static const double defaultZoom = 17.0;
   static const double polylineStrokeWidth = 6.0;
-  // 保存済みルート表示用（小さいカードに埋め込まれるため細め）
+  // 保存済みルート表示用（defaultZoom 時の基準太さ）
   static const double savedRoutePolylineStrokeWidth = 3.0;
+  static const double savedRoutePolylineMinStrokeWidth = 1.5;
+  static const double savedRoutePolylineMaxStrokeWidth = 8.0;
   // 保存済みルートカードのマップ操作フラグ（ピンチズーム・ダブルタップズームのみ）
   static const int savedRouteMapFlags =
       InteractiveFlag.pinchZoom | InteractiveFlag.doubleTapZoom;
+
+  static double savedRouteStrokeWidthAtZoom(double zoom) =>
+      (zoom / defaultZoom * savedRoutePolylineStrokeWidth).clamp(
+        savedRoutePolylineMinStrokeWidth,
+        savedRoutePolylineMaxStrokeWidth,
+      );
   static const double photoThumbnailSize = 40.0;
   static const double photoDeleteBadgeSize = 16.0;
   static const double photoDeleteIconSize = 10.0;

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -869,28 +869,59 @@ class _SelectedRouteCardState extends ConsumerState<_SelectedRouteCard> {
                         }
                       },
                     );
-              return SizedBox(
-                width: double.infinity,
-                height: height,
-                child: FlutterMap(
-                  options: mapOptions,
-                  children: [
-                    TileLayer(
-                      urlTemplate:
-                          'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      userAgentPackageName: 'com.example.tekushare',
-                    ),
-                    PolylineLayer(
-                      polylines: [
-                        Polyline(
-                          points: points,
-                          strokeWidth: _strokeWidth,
-                          color: AppColors.primary,
+              return Stack(
+                children: [
+                  SizedBox(
+                    width: double.infinity,
+                    height: height,
+                    child: FlutterMap(
+                      options: mapOptions,
+                      children: [
+                        TileLayer(
+                          urlTemplate:
+                              'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                          userAgentPackageName: 'com.example.tekushare',
+                        ),
+                        PolylineLayer(
+                          polylines: [
+                            Polyline(
+                              points: points,
+                              strokeWidth: _strokeWidth,
+                              color: AppColors.primary,
+                            ),
+                          ],
                         ),
                       ],
                     ),
-                  ],
-                ),
+                  ),
+                  Positioned(
+                    top: AppSpacing.xs,
+                    right: AppSpacing.xs,
+                    child: GestureDetector(
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => _FullScreenRouteMapPage(
+                            points: points,
+                            name: widget.route.name,
+                          ),
+                        ),
+                      ),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: 0.85),
+                          borderRadius: BorderRadius.circular(AppRadius.xs),
+                        ),
+                        padding: const EdgeInsets.all(AppSpacing.xs),
+                        child: const Icon(
+                          Icons.fullscreen,
+                          color: AppColors.primary,
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
               );
             },
           ),
@@ -1435,6 +1466,82 @@ class _SavedDialog extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 全画面ルートマップページ
+// ──────────────────────────────────────────
+
+class _FullScreenRouteMapPage extends StatefulWidget {
+  const _FullScreenRouteMapPage({
+    required this.points,
+    required this.name,
+  });
+
+  final List<latlong2.LatLng> points;
+  final String name;
+
+  @override
+  State<_FullScreenRouteMapPage> createState() =>
+      _FullScreenRouteMapPageState();
+}
+
+class _FullScreenRouteMapPageState extends State<_FullScreenRouteMapPage> {
+  double _strokeWidth = MapConstants.savedRoutePolylineStrokeWidth;
+
+  void _onMapEvent(MapEvent event) {
+    if (event is MapEventMove) {
+      final w = MapConstants.savedRouteStrokeWidthAtZoom(event.camera.zoom);
+      if ((w - _strokeWidth).abs() > 0.1) {
+        setState(() => _strokeWidth = w);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mapOptions = widget.points.length >= 2
+        ? MapOptions(
+            initialCameraFit: CameraFit.coordinates(
+              coordinates: widget.points,
+              padding: const EdgeInsets.all(AppSpacing.x2l),
+            ),
+            onMapEvent: _onMapEvent,
+          )
+        : MapOptions(
+            initialCenter: widget.points.first,
+            initialZoom: MapConstants.defaultZoom,
+            onMapEvent: _onMapEvent,
+          );
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: Text(widget.name),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: FlutterMap(
+        options: mapOptions,
+        children: [
+          TileLayer(
+            urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+            userAgentPackageName: 'com.example.tekushare',
+          ),
+          PolylineLayer(
+            polylines: [
+              Polyline(
+                points: widget.points,
+                strokeWidth: _strokeWidth,
+                color: AppColors.primary,
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:latlong2/latlong.dart' as latlong2;
+import 'package:tekushare/screens/widgets/common/app_confirm_dialog.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -727,8 +728,11 @@ class _RouteItem extends StatelessWidget {
                 builder: (ctx) => GestureDetector(
                   onTap: () => showDialog<void>(
                     context: ctx,
-                    builder: (_) => _RouteDeleteConfirmDialog(
-                      routeName: route.name,
+                    builder: (_) => AppConfirmDialog(
+                      title: route.name,
+                      message: AppStrings.routeDeleteConfirmMessage,
+                      confirmLabel: AppStrings.routeDeleteButton,
+                      isDestructive: true,
                       onConfirm: () {
                         Navigator.pop(ctx);
                         onDelete!();
@@ -1308,102 +1312,6 @@ class _SaveConfirmDialog extends StatelessWidget {
                         ),
                       ),
                       child: const Text(AppStrings.cancelButton),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// ルート削除確認ダイアログ
-// ──────────────────────────────────────────
-
-class _RouteDeleteConfirmDialog extends StatelessWidget {
-  const _RouteDeleteConfirmDialog({
-    required this.routeName,
-    required this.onConfirm,
-    required this.onCancel,
-  });
-
-  final String routeName;
-  final VoidCallback onConfirm;
-  final VoidCallback onCancel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.x2l,
-          AppSpacing.x3l,
-          AppSpacing.x2l,
-          AppSpacing.x2l,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              routeName,
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: AppTextStyle.lg2,
-                fontWeight: AppTextStyle.semiBold,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSpacing.md),
-            const Text(
-              AppStrings.routeDeleteConfirmMessage,
-              style: TextStyle(fontSize: AppTextStyle.md),
-            ),
-            const SizedBox(height: AppSpacing.x2l),
-            Row(
-              children: [
-                Expanded(
-                  child: SizedBox(
-                    height: AppSpacing.x5l,
-                    child: OutlinedButton(
-                      onPressed: onCancel,
-                      style: OutlinedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppSpacing.sm,
-                        ),
-                        side: const BorderSide(color: AppColors.primary),
-                        foregroundColor: AppColors.primary,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(AppRadius.sm),
-                        ),
-                      ),
-                      child: const Text(AppStrings.cancelButton),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.md),
-                Expanded(
-                  child: SizedBox(
-                    height: AppSpacing.x5l,
-                    child: ElevatedButton(
-                      onPressed: onConfirm,
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppSpacing.sm,
-                        ),
-                        backgroundColor: Colors.red.shade400,
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(AppRadius.sm),
-                        ),
-                      ),
-                      child: const Text(AppStrings.routeDeleteButton),
                     ),
                   ),
                 ),

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -899,10 +899,11 @@ class _SelectedRouteCardState extends ConsumerState<_SelectedRouteCard> {
                     ),
                   ),
                   Positioned(
-                    top: AppSpacing.xs,
-                    right: AppSpacing.xs,
-                    child: GestureDetector(
-                      onTap: () => Navigator.push(
+                    top: 0,
+                    right: 0,
+                    child: IconButton(
+                      tooltip: AppStrings.fullscreenMapTooltip,
+                      onPressed: () => Navigator.push(
                         context,
                         MaterialPageRoute(
                           builder: (_) => _FullScreenRouteMapPage(
@@ -911,17 +912,14 @@ class _SelectedRouteCardState extends ConsumerState<_SelectedRouteCard> {
                           ),
                         ),
                       ),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.85),
+                      icon: const Icon(Icons.fullscreen, size: 20),
+                      color: AppColors.primary,
+                      style: IconButton.styleFrom(
+                        backgroundColor: Colors.white.withValues(alpha: 0.85),
+                        shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(AppRadius.xs),
                         ),
-                        padding: const EdgeInsets.all(AppSpacing.xs),
-                        child: const Icon(
-                          Icons.fullscreen,
-                          color: AppColors.primary,
-                          size: 20,
-                        ),
+                        tapTargetSize: MaterialTapTargetSize.padded,
                       ),
                     ),
                   ),

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -398,16 +398,18 @@ class _WalkRoutePageState extends ConsumerState<WalkRoutePage> {
         currentIndex: 2,
         onTap: (index) {
           if (index == 0) {
-            Navigator.pop(context);
+            Navigator.popUntil(context, (route) => route.isFirst);
           } else if (index == 1) {
-            Navigator.pushReplacement(
+            Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (_) => const SpotListPage()),
+              (route) => route.isFirst,
             );
           } else if (index == 3) {
-            Navigator.pushReplacement(
+            Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (_) => const SettingsPage()),
+              (route) => route.isFirst,
             );
           }
         },

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -756,18 +756,25 @@ class _RouteItem extends StatelessWidget {
 // 選択中ルートカード
 // ──────────────────────────────────────────
 
-class _SelectedRouteCard extends ConsumerWidget {
+class _SelectedRouteCard extends ConsumerStatefulWidget {
   const _SelectedRouteCard({required this.route});
 
   final SavedRouteItem route;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_SelectedRouteCard> createState() => _SelectedRouteCardState();
+}
+
+class _SelectedRouteCardState extends ConsumerState<_SelectedRouteCard> {
+  double _strokeWidth = MapConstants.savedRoutePolylineStrokeWidth;
+
+  @override
+  Widget build(BuildContext context) {
     final walkRoutes = ref.watch(walkRoutesProvider).valueOrNull ?? [];
-    final walkRoute = route.walkSessionId == null
+    final walkRoute = widget.route.walkSessionId == null
         ? null
         : walkRoutes
-            .where((r) => r.walkSessionId == route.walkSessionId)
+            .where((r) => r.walkSessionId == widget.route.walkSessionId)
             .firstOrNull;
 
     return Container(
@@ -836,11 +843,31 @@ class _SelectedRouteCard extends ConsumerWidget {
                         padding: const EdgeInsets.all(AppSpacing.x2l),
                       ),
                       interactionOptions: interactionOptions,
+                      onMapEvent: (event) {
+                        if (event is MapEventMove) {
+                          final w = MapConstants.savedRouteStrokeWidthAtZoom(
+                            event.camera.zoom,
+                          );
+                          if ((w - _strokeWidth).abs() > 0.1) {
+                            setState(() => _strokeWidth = w);
+                          }
+                        }
+                      },
                     )
                   : MapOptions(
                       initialCenter: points.first,
                       initialZoom: MapConstants.defaultZoom,
                       interactionOptions: interactionOptions,
+                      onMapEvent: (event) {
+                        if (event is MapEventMove) {
+                          final w = MapConstants.savedRouteStrokeWidthAtZoom(
+                            event.camera.zoom,
+                          );
+                          if ((w - _strokeWidth).abs() > 0.1) {
+                            setState(() => _strokeWidth = w);
+                          }
+                        }
+                      },
                     );
               return SizedBox(
                 width: double.infinity,
@@ -857,8 +884,7 @@ class _SelectedRouteCard extends ConsumerWidget {
                       polylines: [
                         Polyline(
                           points: points,
-                          strokeWidth:
-                              MapConstants.savedRoutePolylineStrokeWidth,
+                          strokeWidth: _strokeWidth,
                           color: AppColors.primary,
                         ),
                       ],
@@ -875,9 +901,9 @@ class _SelectedRouteCard extends ConsumerWidget {
               runSpacing: AppSpacing.xs,
               alignment: WrapAlignment.start,
               children: [
-                _RouteTag(label: route.name),
-                _RouteTag(label: route.distance),
-                _RouteTag(label: route.time),
+                _RouteTag(label: widget.route.name),
+                _RouteTag(label: widget.route.distance),
+                _RouteTag(label: widget.route.time),
               ],
             ),
           ),

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -826,22 +826,21 @@ class _SelectedRouteCard extends ConsumerWidget {
               final points = walkRoute.points
                   .map((p) => latlong2.LatLng(p.latitude, p.longitude))
                   .toList();
+              const interactionOptions = InteractionOptions(
+                flags: MapConstants.savedRouteMapFlags,
+              );
               final mapOptions = points.length >= 2
                   ? MapOptions(
                       initialCameraFit: CameraFit.coordinates(
                         coordinates: points,
                         padding: const EdgeInsets.all(AppSpacing.x2l),
                       ),
-                      interactionOptions: const InteractionOptions(
-                        flags: InteractiveFlag.none,
-                      ),
+                      interactionOptions: interactionOptions,
                     )
                   : MapOptions(
                       initialCenter: points.first,
                       initialZoom: MapConstants.defaultZoom,
-                      interactionOptions: const InteractionOptions(
-                        flags: InteractiveFlag.none,
-                      ),
+                      interactionOptions: interactionOptions,
                     );
               return SizedBox(
                 width: double.infinity,
@@ -858,7 +857,8 @@ class _SelectedRouteCard extends ConsumerWidget {
                       polylines: [
                         Polyline(
                           points: points,
-                          strokeWidth: MapConstants.polylineStrokeWidth,
+                          strokeWidth:
+                              MapConstants.savedRoutePolylineStrokeWidth,
                           color: AppColors.primary,
                         ),
                       ],

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -81,7 +81,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   }
 
   void _showDeleteAccountConfirmDialog() {
-    final vm = ref.read(settingsViewModelProvider.notifier);
     showDialog<void>(
       context: context,
       builder: (_) => _ConfirmActionDialog(
@@ -89,8 +88,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         confirmLabel: AppStrings.settingsDeleteAccountConfirmButton,
         isDestructive: true,
         onConfirm: () {
-          vm.deleteAccount();
-          Navigator.pop(context);
+          ref.read(walkSessionProvider.notifier).resetWalk();
+          ref.read(authServiceProvider).deleteUser();
+          Navigator.popUntil(context, (route) => route.isFirst);
         },
         onCancel: () => Navigator.pop(context),
       ),

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -142,16 +142,18 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         currentIndex: 3,
         onTap: (index) {
           if (index == 0) {
-            Navigator.pop(context);
+            Navigator.popUntil(context, (route) => route.isFirst);
           } else if (index == 1) {
-            Navigator.push(
+            Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (_) => const SpotListPage()),
+              (route) => route.isFirst,
             );
           } else if (index == 2) {
-            Navigator.push(
+            Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (_) => const WalkRoutePage()),
+              (route) => route.isFirst,
             );
           }
         },

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -14,6 +14,7 @@ import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+import 'package:tekushare/screens/widgets/common/app_confirm_dialog.dart';
 
 /// 設定画面
 class SettingsPage extends ConsumerStatefulWidget {
@@ -66,7 +67,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   void _showLogoutConfirmDialog() {
     showDialog<void>(
       context: context,
-      builder: (_) => _ConfirmActionDialog(
+      builder: (_) => AppConfirmDialog(
         message: AppStrings.settingsLogoutConfirmMessage,
         confirmLabel: AppStrings.settingsLogoutConfirmButton,
         isDestructive: false,
@@ -83,7 +84,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   void _showDeleteAccountConfirmDialog() {
     showDialog<void>(
       context: context,
-      builder: (_) => _ConfirmActionDialog(
+      builder: (_) => AppConfirmDialog(
         message: AppStrings.settingsDeleteAccountConfirmMessage,
         confirmLabel: AppStrings.settingsDeleteAccountConfirmButton,
         isDestructive: true,
@@ -1514,93 +1515,6 @@ class _AccountCard extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 汎用確認ダイアログ（ログアウト・アカウント消去）
-// ──────────────────────────────────────────
-
-class _ConfirmActionDialog extends StatelessWidget {
-  const _ConfirmActionDialog({
-    required this.message,
-    required this.confirmLabel,
-    required this.isDestructive,
-    required this.onConfirm,
-    required this.onCancel,
-  });
-
-  final String message;
-  final String confirmLabel;
-  final bool isDestructive;
-  final VoidCallback onConfirm;
-  final VoidCallback onCancel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.x2l,
-          AppSpacing.x3l,
-          AppSpacing.x2l,
-          AppSpacing.x2l,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              message,
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: AppTextStyle.sm2),
-            ),
-            const SizedBox(height: AppSpacing.x2l),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: onCancel,
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      side: const BorderSide(color: AppColors.primary),
-                      foregroundColor: AppColors.primary,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.sm),
-                      ),
-                    ),
-                    child: const Text(AppStrings.cancelButton),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.md),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: onConfirm,
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      backgroundColor:
-                          isDestructive ? Colors.red : AppColors.primary,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.sm),
-                      ),
-                    ),
-                    child: Text(confirmLabel),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -88,9 +88,10 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         message: AppStrings.settingsDeleteAccountConfirmMessage,
         confirmLabel: AppStrings.settingsDeleteAccountConfirmButton,
         isDestructive: true,
-        onConfirm: () {
+        onConfirm: () async {
           ref.read(walkSessionProvider.notifier).resetWalk();
-          ref.read(authServiceProvider).deleteUser();
+          await ref.read(authServiceProvider).deleteUser();
+          if (!mounted) return;
           Navigator.popUntil(context, (route) => route.isFirst);
         },
         onCancel: () => Navigator.pop(context),

--- a/lib/screens/pages/settings/viewmodel/settings_viewmodel.dart
+++ b/lib/screens/pages/settings/viewmodel/settings_viewmodel.dart
@@ -69,10 +69,6 @@ class SettingsViewModel extends Notifier<SettingsState> {
     final updated = List<String>.from(state.sharedAccounts)..remove(name);
     state = state.copyWith(sharedAccounts: updated);
   }
-
-  void logout() {}
-
-  void deleteAccount() {}
 }
 
 final settingsViewModelProvider =

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -20,6 +20,7 @@ import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+import 'package:tekushare/screens/widgets/common/app_confirm_dialog.dart';
 import 'package:tekushare/screens/widgets/common/category_chip_group.dart';
 import 'package:tekushare/screens/widgets/common/dashed_border_painter.dart';
 import 'package:tekushare/screens/widgets/common/photo_viewer_dialog.dart';
@@ -93,8 +94,10 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
     final category = ref.read(spotDetailViewModelProvider).selectedCategory;
     showDialog<void>(
       context: context,
-      builder: (_) => _SaveConfirmDialog(
+      builder: (_) => AppConfirmDialog(
         title: title,
+        message: AppStrings.spotDetailSaveConfirmMessage,
+        confirmLabel: AppStrings.saveButton,
         onConfirm: () async {
           Navigator.pop(context);
           await ref.read(spotProvider.notifier).updateSpot(
@@ -111,10 +114,13 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
   void _onDeletePressed() {
     showDialog<void>(
       context: context,
-      builder: (_) => _DeleteConfirmDialog(
+      builder: (_) => AppConfirmDialog(
         title: _titleController.text.isEmpty
             ? AppStrings.noTitle
             : _titleController.text,
+        message: AppStrings.spotDetailDeleteConfirmMessage,
+        confirmLabel: AppStrings.spotDetailDeleteButton,
+        isDestructive: true,
         onConfirm: () async {
           Navigator.pop(context);
           await ref.read(spotProvider.notifier).deleteSpot(widget.spot.id);
@@ -133,8 +139,11 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
     final category = ref.read(spotDetailViewModelProvider).selectedCategory;
     showDialog<void>(
       context: context,
-      builder: (_) => _MoveToWentConfirmDialog(
+      builder: (_) => AppConfirmDialog(
         title: title,
+        message: AppStrings.spotDetailMoveToWentConfirmMessage,
+        confirmLabel: AppStrings.spotDetailMoveToWentButton,
+        confirmColor: AppColors.listSelected,
         onConfirm: () async {
           Navigator.pop(context);
           await ref.read(spotProvider.notifier).updateSpot(
@@ -596,255 +605,6 @@ class _SaveButton extends StatelessWidget {
             fontSize: sizing.detailBtnFontSize,
             fontWeight: FontWeight.w500,
           ),
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 上書き保存確認ダイアログ
-// ──────────────────────────────────────────
-
-class _SaveConfirmDialog extends StatelessWidget {
-  const _SaveConfirmDialog({
-    required this.title,
-    required this.onConfirm,
-    required this.onCancel,
-  });
-
-  final String title;
-  final VoidCallback onConfirm;
-  final VoidCallback onCancel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: AppTextStyle.lg2,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 12),
-            const Text(
-              AppStrings.spotDetailSaveConfirmMessage,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: onCancel,
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                    child: const Text(AppStrings.cancelButton),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: onConfirm,
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      backgroundColor: AppColors.primary,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                    child: const Text(AppStrings.saveButton),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 削除確認ダイアログ
-// ──────────────────────────────────────────
-
-class _DeleteConfirmDialog extends StatelessWidget {
-  const _DeleteConfirmDialog({
-    required this.title,
-    required this.onConfirm,
-    required this.onCancel,
-  });
-
-  final String title;
-  final VoidCallback onConfirm;
-  final VoidCallback onCancel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: AppTextStyle.lg2,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 12),
-            const Text(
-              AppStrings.spotDetailDeleteConfirmMessage,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: onCancel,
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                    child: const Text(AppStrings.cancelButton),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: onConfirm,
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      backgroundColor: AppColors.primary,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                    child: const Text(AppStrings.spotDetailDeleteButton),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 行った！に保存確認ダイアログ
-// ──────────────────────────────────────────
-
-class _MoveToWentConfirmDialog extends StatelessWidget {
-  const _MoveToWentConfirmDialog({
-    required this.title,
-    required this.onConfirm,
-    required this.onCancel,
-  });
-
-  final String title;
-  final VoidCallback onConfirm;
-  final VoidCallback onCancel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      insetPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.x2l,
-        vertical: AppSpacing.x2l,
-      ),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.lg,
-          28,
-          AppSpacing.lg,
-          AppSpacing.xl,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: AppTextStyle.lg2,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 12),
-            const Text(
-              AppStrings.spotDetailMoveToWentConfirmMessage,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: onCancel,
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                    child: const Text(AppStrings.cancelButton),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: onConfirm,
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm,
-                      ),
-                      backgroundColor: AppColors.listSelected,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                    child: const Text(AppStrings.listWentTab),
-                  ),
-                ),
-              ],
-            ),
-          ],
         ),
       ),
     );

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -212,14 +212,13 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
                 onExpand: _onPhotoExpand,
               ),
               SizedBox(height: AppSizingTheme.of(context).sectionSpacing),
-              if (widget.spot.status == SpotStatus.wantToGo) ...[
-                _MoveToWentButton(onPressed: _onMoveToWentPressed),
-                const SizedBox(height: 12),
-                _DeleteButton(onPressed: _onDeletePressed),
-              ] else
-                _DeleteButton(onPressed: _onDeletePressed),
-              const SizedBox(height: 16),
+              _DeleteButton(onPressed: _onDeletePressed),
+              const SizedBox(height: 12),
               _SaveButton(onPressed: _onSavePressed),
+              if (widget.spot.status == SpotStatus.wantToGo) ...[
+                const SizedBox(height: 12),
+                _MoveToWentButton(onPressed: _onMoveToWentPressed),
+              ],
               SizedBox(height: AppSizingTheme.of(context).sectionSpacing),
             ],
           ),

--- a/lib/screens/pages/spot/view/spot_list_page.dart
+++ b/lib/screens/pages/spot/view/spot_list_page.dart
@@ -101,16 +101,18 @@ class SpotListPage extends ConsumerWidget {
         currentIndex: 1,
         onTap: (index) {
           if (index == 0) {
-            Navigator.pop(context);
+            Navigator.popUntil(context, (route) => route.isFirst);
           } else if (index == 2) {
-            Navigator.push(
+            Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (_) => const WalkRoutePage()),
+              (route) => route.isFirst,
             );
           } else if (index == 3) {
-            Navigator.push(
+            Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(builder: (_) => const SettingsPage()),
+              (route) => route.isFirst,
             );
           }
         },

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -37,6 +37,7 @@ abstract interface class AuthService {
   Future<void> signInWithEmail(String email, String password);
   Future<void> setDisplayName(String name);
   Future<void> signOut();
+  Future<void> deleteUser();
 }
 
 // ── Firebase Auth 実装 ────────────────────────────────────────────────────────
@@ -72,6 +73,9 @@ class FirebaseAuthServiceImpl implements AuthService {
 
   @override
   Future<void> signOut() => _auth.signOut();
+
+  @override
+  Future<void> deleteUser() => _auth.currentUser!.delete();
 }
 
 String _mapErrorCode(String code) {

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -75,7 +75,11 @@ class FirebaseAuthServiceImpl implements AuthService {
   Future<void> signOut() => _auth.signOut();
 
   @override
-  Future<void> deleteUser() => _auth.currentUser!.delete();
+  Future<void> deleteUser() async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+    await user.delete();
+  }
 }
 
 String _mapErrorCode(String code) {

--- a/lib/screens/widgets/common/app_confirm_dialog.dart
+++ b/lib/screens/widgets/common/app_confirm_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
@@ -9,7 +11,9 @@ import 'package:tekushare/core/constants/app_text_style.dart';
 /// - [title] を渡すと本文上部に primary 色の見出しを表示する。
 /// - [isDestructive] が true のとき確認ボタンを赤色にする。
 /// - [confirmColor] を渡すと [isDestructive] より優先してその色を使う。
-class AppConfirmDialog extends StatelessWidget {
+/// - [onConfirm] は同期・非同期どちらでも可。非同期の場合は完了まで
+///   確認ボタンを無効化する。
+class AppConfirmDialog extends StatefulWidget {
   const AppConfirmDialog({
     super.key,
     required this.message,
@@ -26,12 +30,19 @@ class AppConfirmDialog extends StatelessWidget {
   final String confirmLabel;
   final bool isDestructive;
   final Color? confirmColor;
-  final VoidCallback onConfirm;
+  final FutureOr<void> Function() onConfirm;
   final VoidCallback onCancel;
 
+  @override
+  State<AppConfirmDialog> createState() => _AppConfirmDialogState();
+}
+
+class _AppConfirmDialogState extends State<AppConfirmDialog> {
+  bool _processing = false;
+
   Color get _confirmColor {
-    if (confirmColor != null) return confirmColor!;
-    return isDestructive ? Colors.red.shade400 : AppColors.primary;
+    if (widget.confirmColor != null) return widget.confirmColor!;
+    return widget.isDestructive ? Colors.red.shade400 : AppColors.primary;
   }
 
   @override
@@ -50,9 +61,9 @@ class AppConfirmDialog extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (title != null) ...[
+            if (widget.title != null) ...[
               Text(
-                title!,
+                widget.title!,
                 textAlign: TextAlign.center,
                 style: const TextStyle(
                   color: AppColors.primary,
@@ -63,7 +74,7 @@ class AppConfirmDialog extends StatelessWidget {
               const SizedBox(height: AppSpacing.sm),
             ],
             Text(
-              message,
+              widget.message,
               textAlign: TextAlign.center,
               style: const TextStyle(fontSize: AppTextStyle.md),
             ),
@@ -74,7 +85,7 @@ class AppConfirmDialog extends StatelessWidget {
                   child: SizedBox(
                     height: AppSpacing.x5l,
                     child: OutlinedButton(
-                      onPressed: onCancel,
+                      onPressed: _processing ? null : widget.onCancel,
                       style: OutlinedButton.styleFrom(
                         padding: const EdgeInsets.symmetric(
                           horizontal: AppSpacing.sm,
@@ -94,7 +105,13 @@ class AppConfirmDialog extends StatelessWidget {
                   child: SizedBox(
                     height: AppSpacing.x5l,
                     child: ElevatedButton(
-                      onPressed: onConfirm,
+                      onPressed: _processing
+                          ? null
+                          : () async {
+                              setState(() => _processing = true);
+                              await widget.onConfirm();
+                              if (mounted) setState(() => _processing = false);
+                            },
                       style: ElevatedButton.styleFrom(
                         padding: const EdgeInsets.symmetric(
                           horizontal: AppSpacing.sm,
@@ -106,7 +123,7 @@ class AppConfirmDialog extends StatelessWidget {
                           borderRadius: BorderRadius.circular(AppRadius.sm),
                         ),
                       ),
-                      child: Text(confirmLabel),
+                      child: Text(widget.confirmLabel),
                     ),
                   ),
                 ),

--- a/lib/screens/widgets/common/app_confirm_dialog.dart
+++ b/lib/screens/widgets/common/app_confirm_dialog.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_spacing.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+
+/// キャンセル＋確認ボタンを持つ汎用ダイアログ。
+///
+/// - [title] を渡すと本文上部に primary 色の見出しを表示する。
+/// - [isDestructive] が true のとき確認ボタンを赤色にする。
+/// - [confirmColor] を渡すと [isDestructive] より優先してその色を使う。
+class AppConfirmDialog extends StatelessWidget {
+  const AppConfirmDialog({
+    super.key,
+    required this.message,
+    required this.confirmLabel,
+    required this.onConfirm,
+    required this.onCancel,
+    this.title,
+    this.isDestructive = false,
+    this.confirmColor,
+  });
+
+  final String? title;
+  final String message;
+  final String confirmLabel;
+  final bool isDestructive;
+  final Color? confirmColor;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  Color get _confirmColor {
+    if (confirmColor != null) return confirmColor!;
+    return isDestructive ? Colors.red.shade400 : AppColors.primary;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.x2l,
+          AppSpacing.x3l,
+          AppSpacing.x2l,
+          AppSpacing.x2l,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (title != null) ...[
+              Text(
+                title!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: AppColors.primary,
+                  fontSize: AppTextStyle.lg2,
+                  fontWeight: AppTextStyle.semiBold,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+            ],
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: AppTextStyle.md),
+            ),
+            const SizedBox(height: AppSpacing.x2l),
+            Row(
+              children: [
+                Expanded(
+                  child: SizedBox(
+                    height: AppSpacing.x5l,
+                    child: OutlinedButton(
+                      onPressed: onCancel,
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppSpacing.sm,
+                        ),
+                        side: const BorderSide(color: AppColors.primary),
+                        foregroundColor: AppColors.primary,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(AppRadius.sm),
+                        ),
+                      ),
+                      child: const Text(AppStrings.cancelButton),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: SizedBox(
+                    height: AppSpacing.x5l,
+                    child: ElevatedButton(
+                      onPressed: onConfirm,
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppSpacing.sm,
+                        ),
+                        backgroundColor: _confirmColor,
+                        foregroundColor: Colors.white,
+                        elevation: 0,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(AppRadius.sm),
+                        ),
+                      ),
+                      child: Text(confirmLabel),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -899,7 +899,7 @@ void main() {
       await tester.tap(find.text(AppStrings.settingsDeleteAccount));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('アカウントを消去しますか'), findsOneWidget);
+      expect(find.text(AppStrings.settingsDeleteAccountConfirmMessage), findsOneWidget);
     });
 
     // アカウント削除キャンセルでダイアログが閉じる
@@ -946,7 +946,7 @@ void main() {
       await tester.tap(find.text(AppStrings.cancelButton));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('アカウントを消去しますか'), findsNothing);
+      expect(find.text(AppStrings.settingsDeleteAccountConfirmMessage), findsNothing);
     });
 
     // アカウント削除確認で deleteUser が呼ばれる

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -899,7 +899,8 @@ void main() {
       await tester.tap(find.text(AppStrings.settingsDeleteAccount));
       await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.settingsDeleteAccountConfirmMessage), findsOneWidget);
+      expect(find.text(AppStrings.settingsDeleteAccountConfirmMessage),
+          findsOneWidget);
     });
 
     // アカウント削除キャンセルでダイアログが閉じる
@@ -946,7 +947,8 @@ void main() {
       await tester.tap(find.text(AppStrings.cancelButton));
       await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.settingsDeleteAccountConfirmMessage), findsNothing);
+      expect(find.text(AppStrings.settingsDeleteAccountConfirmMessage),
+          findsNothing);
     });
 
     // アカウント削除確認で deleteUser が呼ばれる

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -1,9 +1,14 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
+import 'package:tekushare/domain/repositories/route_repository.dart';
+import 'package:tekushare/domain/repositories/walk_session_repository.dart';
 import 'package:tekushare/domain/usecases/photo/attach_photo_to_spot.dart';
 import 'package:tekushare/domain/usecases/photo/remove_photo_from_spot.dart';
 import 'package:tekushare/domain/usecases/spot/delete_spot.dart';
@@ -11,11 +16,65 @@ import 'package:tekushare/domain/usecases/spot/update_spot.dart';
 import 'package:tekushare/domain/usecases/spot/get_spots.dart';
 import 'package:tekushare/domain/usecases/spot/save_spot.dart';
 import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
+import 'package:tekushare/domain/usecases/walk/end_walk.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
+import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
+
+class _FakeAuthService implements AuthService {
+  bool signedOut = false;
+  bool deletedUser = false;
+
+  @override
+  Stream<User?> watchAuthState() => const Stream.empty();
+
+  @override
+  Future<void> registerWithEmail(
+          String email, String password, String displayName) async =>
+      {};
+
+  @override
+  Future<void> signInWithEmail(String email, String password) async {}
+
+  @override
+  Future<void> setDisplayName(String name) async {}
+
+  @override
+  Future<void> signOut() async => signedOut = true;
+
+  @override
+  Future<void> deleteUser() async => deletedUser = true;
+}
+
+class _FakeWalkSessionRepository implements WalkSessionRepository {
+  const _FakeWalkSessionRepository();
+
+  @override
+  Future<void> saveSession(WalkSession session) async {}
+
+  @override
+  Future<List<WalkSession>> getAllSessions() async => [];
+
+  @override
+  Future<WalkSession?> getSessionById(String id) async => null;
+}
+
+class _FakeWalkRouteRepository implements RouteRepository {
+  const _FakeWalkRouteRepository();
+
+  @override
+  Future<void> saveRoute(WalkRoute route) async {}
+
+  @override
+  Future<WalkRoute?> getRouteBySessionId(String sessionId) async => null;
+
+  @override
+  Future<List<WalkRoute>> getAllRoutes() async => [];
+}
 
 class _FakeSaveSpot implements SaveSpot {
   const _FakeSaveSpot();
@@ -654,6 +713,287 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(SettingsPage), findsOneWidget);
+    });
+
+    // ── ログアウト ──
+
+    // ログアウトボタンをタップすると確認ダイアログが表示される
+    testWidgets('tapping logout button shows logout confirm dialog',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final fakeAuth = _FakeAuthService();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(fakeAuth),
+            walkSessionProvider.overrideWith(
+              (ref) => WalkSessionNotifier(
+                endWalk: const EndWalk(
+                  _FakeWalkSessionRepository(),
+                  _FakeWalkRouteRepository(),
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const SettingsPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.text(AppStrings.settingsLogout));
+      await tester.tap(find.text(AppStrings.settingsLogout));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.text(AppStrings.settingsLogoutConfirmMessage), findsOneWidget);
+    });
+
+    // ログアウトキャンセルでダイアログが閉じる
+    testWidgets('canceling logout dialog closes dialog', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final fakeAuth = _FakeAuthService();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(fakeAuth),
+            walkSessionProvider.overrideWith(
+              (ref) => WalkSessionNotifier(
+                endWalk: const EndWalk(
+                  _FakeWalkSessionRepository(),
+                  _FakeWalkRouteRepository(),
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const SettingsPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.text(AppStrings.settingsLogout));
+      await tester.tap(find.text(AppStrings.settingsLogout));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.settingsLogoutConfirmMessage), findsNothing);
+    });
+
+    // ログアウト確認で signOut が呼ばれる
+    testWidgets('confirming logout calls signOut', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final fakeAuth = _FakeAuthService();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(fakeAuth),
+            walkSessionProvider.overrideWith(
+              (ref) => WalkSessionNotifier(
+                endWalk: const EndWalk(
+                  _FakeWalkSessionRepository(),
+                  _FakeWalkRouteRepository(),
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const SettingsPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.text(AppStrings.settingsLogout));
+      await tester.tap(find.text(AppStrings.settingsLogout));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.settingsLogoutConfirmButton).last);
+      await tester.pumpAndSettle();
+
+      expect(fakeAuth.signedOut, isTrue);
+    });
+
+    // ── アカウント削除 ──
+
+    // アカウント削除ボタンをタップすると確認ダイアログが表示される
+    testWidgets('tapping delete account button shows confirm dialog',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final fakeAuth = _FakeAuthService();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(fakeAuth),
+            walkSessionProvider.overrideWith(
+              (ref) => WalkSessionNotifier(
+                endWalk: const EndWalk(
+                  _FakeWalkSessionRepository(),
+                  _FakeWalkRouteRepository(),
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const SettingsPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.text(AppStrings.settingsDeleteAccount));
+      await tester.tap(find.text(AppStrings.settingsDeleteAccount));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('アカウントを消去しますか'), findsOneWidget);
+    });
+
+    // アカウント削除キャンセルでダイアログが閉じる
+    testWidgets('canceling delete account dialog closes dialog',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final fakeAuth = _FakeAuthService();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(fakeAuth),
+            walkSessionProvider.overrideWith(
+              (ref) => WalkSessionNotifier(
+                endWalk: const EndWalk(
+                  _FakeWalkSessionRepository(),
+                  _FakeWalkRouteRepository(),
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const SettingsPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.text(AppStrings.settingsDeleteAccount));
+      await tester.tap(find.text(AppStrings.settingsDeleteAccount));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('アカウントを消去しますか'), findsNothing);
+    });
+
+    // アカウント削除確認で deleteUser が呼ばれる
+    testWidgets('confirming delete account calls deleteUser', (tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final fakeAuth = _FakeAuthService();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(fakeAuth),
+            walkSessionProvider.overrideWith(
+              (ref) => WalkSessionNotifier(
+                endWalk: const EndWalk(
+                  _FakeWalkSessionRepository(),
+                  _FakeWalkRouteRepository(),
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            builder: (context, child) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: child!,
+              );
+            },
+            home: const SettingsPage(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.text(AppStrings.settingsDeleteAccount));
+      await tester.tap(find.text(AppStrings.settingsDeleteAccount));
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.text(AppStrings.settingsDeleteAccountConfirmButton));
+      await tester.pumpAndSettle();
+
+      expect(fakeAuth.deletedUser, isTrue);
     });
   });
 }

--- a/test/screens/pages/settings/settings_viewmodel_test.dart
+++ b/test/screens/pages/settings/settings_viewmodel_test.dart
@@ -93,16 +93,6 @@ void main() {
       expect(state().sharedAccounts, ['あかり', 'たかし', 'ゆか', 'けんじ']);
     });
 
-    // ログアウト（スタブ：状態変化なし）
-    test('logout does not throw', () {
-      expect(() => vm().logout(), returnsNormally);
-    });
-
-    // アカウント消去（スタブ：状態変化なし）
-    test('deleteAccount does not throw', () {
-      expect(() => vm().deleteAccount(), returnsNormally);
-    });
-
     // 他フィールドに影響しない
     test('updating one field does not affect others', () {
       vm().setTimerEnabled(false);

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -372,7 +372,7 @@ void main() {
       await tester.tap(
         find.descendant(
           of: find.byType(Dialog),
-          matching: find.text(AppStrings.listWentTab),
+          matching: find.text(AppStrings.spotDetailMoveToWentButton),
         ),
       );
       await tester.pumpAndSettle();
@@ -390,7 +390,7 @@ void main() {
       await tester.tap(
         find.descendant(
           of: find.byType(Dialog),
-          matching: find.text(AppStrings.listWentTab),
+          matching: find.text(AppStrings.spotDetailMoveToWentButton),
         ),
       );
       await tester.pumpAndSettle();

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -42,6 +42,8 @@ class _FakeAuthService implements AuthService {
   Future<void> setDisplayName(String name) async {}
   @override
   Future<void> signOut() async {}
+  @override
+  Future<void> deleteUser() async {}
 }
 
 class _FakePhotoRepository implements PhotoRepository {


### PR DESCRIPTION
## 概要

- #85 ログアウト・アカウント削除の実装
- ボトムナビゲーションのバグ修正
- 散歩ルートマップの表示改善

## 変更内容

### #85 ログアウト・アカウント削除
- `AuthService` に `deleteUser()` を追加
- 設定ページのログアウト・アカウント削除ボタンで実際に Firebase Auth を呼び出すよう実装
- 操作前に確認ダイアログを表示
- アカウント削除時は散歩セッションもリセット

### ボトムナビゲーション修正
- リスト → 散歩ルート → ホーム の順で押下するとホームではなくリストへ遷移してしまうバグを修正
- 各ページのナビゲーションを `popUntil(isFirst)` / `pushAndRemoveUntil(isFirst)` で統一し、常に正しいページへ遷移するよう変更

### 散歩ルートマップ改善
- ポリライン太さを 6px → 3px に変更（全体表示時に見やすく）
- ピンチズーム・ダブルタップズームを有効化
- ズームレベルに連動してポリライン太さを動的に変更
- マップ右上のフルスクリーンボタンで全画面マップページへ遷移（自由にパン・ズーム可能）

## テスト

- `settings_page_test.dart`: ログアウト・アカウント削除ダイアログのテスト追加
- `walk_route_page_test.dart`: ルート削除確認ダイアログのテスト更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 保存済みルートの表示が改善され、ズームに応じて線の太さが見やすく調整されるようになりました。
  * ルート画面に全画面表示を追加し、より大きく地図を確認できます。

* **改善**
  * 画面下部のメニュー遷移を整理し、不要な画面が残りにくくなりました。
  * アカウント削除時に、関連データのリセットとアカウント削除がより確実に行われるようになりました。

* **バグ修正**
  * ログアウト・アカウント削除の確認ダイアログ動作を見直しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->