### PR TITLE
[Feature] #52 #55 Firestoreスポット・連絡先登録機能の実装

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -5,13 +5,18 @@ import 'package:integration_test/integration_test.dart';
 import 'package:tekushare/app.dart';
 import 'package:tekushare/core/config/flavor.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/domain/entities/contact.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/repositories/contact_repository.dart';
+import 'package:tekushare/domain/repositories/photo_repository.dart';
+import 'package:tekushare/domain/repositories/spot_repository.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
 /// Firebase を初期化せずに使えるフェイク User。
-/// app.dart が参照するのは displayName のみ。
 class _FakeUser implements User {
   @override
   String? get displayName => 'テストユーザー';
@@ -42,6 +47,33 @@ class _FakeAuthService implements AuthService {
   Future<void> deleteUser() async {}
 }
 
+class _FakeSpotRepository implements SpotRepository {
+  @override
+  Future<void> saveSpot(Spot spot) async {}
+  @override
+  Stream<List<Spot>> getSpots() => Stream.value([]);
+  @override
+  Future<void> updateSpotStatus(String id, SpotStatus status) async {}
+  @override
+  Future<void> deleteSpot(String id) async {}
+}
+
+class _FakePhotoRepository implements PhotoRepository {
+  @override
+  Future<void> attachPhoto(String spotId, String imagePath) async {}
+  @override
+  Future<void> removePhoto(String spotId, String imagePath) async {}
+}
+
+class _FakeContactRepository implements ContactRepository {
+  @override
+  Stream<List<Contact>> watchContacts() => Stream.value([]);
+  @override
+  Future<void> saveContact(Contact contact) async {}
+  @override
+  Future<void> deleteContact(String id) async {}
+}
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -54,8 +86,10 @@ void main() {
       ProviderScope(
         overrides: [
           authServiceProvider.overrideWithValue(_FakeAuthService()),
-          // ログイン済みユーザーを即時提供し Firebase アクセスを回避
           authStateProvider.overrideWith((ref) => Stream.value(_FakeUser())),
+          spotRepositoryProvider.overrideWithValue(_FakeSpotRepository()),
+          photoRepositoryProvider.overrideWithValue(_FakePhotoRepository()),
+          contactRepositoryProvider.overrideWithValue(_FakeContactRepository()),
         ],
         child: const TekuShareApp(),
       ),

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -17,6 +17,9 @@ class _FakeUser implements User {
   String? get displayName => 'テストユーザー';
 
   @override
+  String get uid => '';
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -129,6 +129,16 @@ abstract class AppStrings {
   static const settingsPhoneConfirmMessage = '安否確認先の電話番号に\n登録しますか？';
   static const settingsPhoneRegisterConfirm = '登録する';
   static const settingsPhoneRegisteredMessage = '登録しました！';
+  static const settingsPhoneNameLabel = '名前';
+  static const settingsPhoneNameHint = '例：あかり（娘）';
+  static const settingsPhoneNameRequired = '名前を入力してください';
+  static const settingsPhoneNumberLabel = '電話番号';
+  static const settingsPhoneNumberHint = '例：080-0000-0000';
+  static const settingsPhoneNumberRequired = '電話番号を入力してください';
+  static const settingsPhoneSaveButton = '上書き保存';
+  static const settingsPhoneDeleteButton = '登録を削除する';
+  static const settingsPhoneDeleteConfirmMessage = '通知先の登録を削除しますか？';
+  static const settingsPhoneDeleteConfirmButton = '削除する';
 
   // アカウント管理
   static const settingsAccountTitle = 'アカウント';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -139,6 +139,7 @@ abstract class AppStrings {
   static const settingsPhoneDeleteButton = '登録を削除する';
   static const settingsPhoneDeleteConfirmMessage = '通知先の登録を削除しますか？';
   static const settingsPhoneDeleteConfirmButton = '削除する';
+  static const settingsPhoneAddButton = '追加する';
 
   // アカウント管理
   static const settingsAccountTitle = 'アカウント';

--- a/lib/data/repositories/firestore_contact_repository_impl.dart
+++ b/lib/data/repositories/firestore_contact_repository_impl.dart
@@ -29,6 +29,7 @@ class FirestoreContactRepositoryImpl implements ContactRepository {
 
   @override
   Future<void> saveContact(Contact contact) async {
+    if (_uid.isEmpty) return;
     final data = {'name': contact.name, 'phone': contact.phone};
     if (contact.id.isEmpty) {
       await _collection.add(data);
@@ -39,6 +40,7 @@ class FirestoreContactRepositoryImpl implements ContactRepository {
 
   @override
   Future<void> deleteContact(String id) async {
+    if (_uid.isEmpty) return;
     await _collection.doc(id).delete();
   }
 }

--- a/lib/data/repositories/firestore_contact_repository_impl.dart
+++ b/lib/data/repositories/firestore_contact_repository_impl.dart
@@ -13,14 +13,14 @@ class FirestoreContactRepositoryImpl implements ContactRepository {
 
   @override
   Stream<List<Contact>> watchContacts() {
-    if (_uid.isEmpty) return const Stream.empty();
+    if (_uid.isEmpty) return Stream.value([]);
     return _collection.snapshots().map(
           (snap) => snap.docs
               .map(
                 (doc) => Contact(
                   id: doc.id,
-                  name: doc.data()['name'] as String,
-                  phone: doc.data()['phone'] as String,
+                  name: doc.data()['name'] as String? ?? '',
+                  phone: doc.data()['phone'] as String? ?? '',
                 ),
               )
               .toList(),

--- a/lib/data/repositories/firestore_contact_repository_impl.dart
+++ b/lib/data/repositories/firestore_contact_repository_impl.dart
@@ -1,0 +1,39 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tekushare/domain/entities/contact.dart';
+import 'package:tekushare/domain/repositories/contact_repository.dart';
+
+class FirestoreContactRepositoryImpl implements ContactRepository {
+  FirestoreContactRepositoryImpl(this._firestore, this._uid);
+
+  final FirebaseFirestore _firestore;
+  final String _uid;
+
+  DocumentReference<Map<String, dynamic>> get _doc => _firestore
+      .collection('users')
+      .doc(_uid)
+      .collection('settings')
+      .doc('contact');
+
+  @override
+  Stream<Contact?> watchContact() {
+    if (_uid.isEmpty) return const Stream.empty();
+    return _doc.snapshots().map((snap) {
+      if (!snap.exists) return null;
+      final data = snap.data()!;
+      return Contact(
+        name: data['name'] as String,
+        phone: data['phone'] as String,
+      );
+    });
+  }
+
+  @override
+  Future<void> saveContact(Contact contact) async {
+    await _doc.set({'name': contact.name, 'phone': contact.phone});
+  }
+
+  @override
+  Future<void> deleteContact() async {
+    await _doc.delete();
+  }
+}

--- a/lib/data/repositories/firestore_contact_repository_impl.dart
+++ b/lib/data/repositories/firestore_contact_repository_impl.dart
@@ -8,32 +8,37 @@ class FirestoreContactRepositoryImpl implements ContactRepository {
   final FirebaseFirestore _firestore;
   final String _uid;
 
-  DocumentReference<Map<String, dynamic>> get _doc => _firestore
-      .collection('users')
-      .doc(_uid)
-      .collection('settings')
-      .doc('contact');
+  CollectionReference<Map<String, dynamic>> get _collection =>
+      _firestore.collection('users').doc(_uid).collection('contacts');
 
   @override
-  Stream<Contact?> watchContact() {
+  Stream<List<Contact>> watchContacts() {
     if (_uid.isEmpty) return const Stream.empty();
-    return _doc.snapshots().map((snap) {
-      if (!snap.exists) return null;
-      final data = snap.data()!;
-      return Contact(
-        name: data['name'] as String,
-        phone: data['phone'] as String,
-      );
-    });
+    return _collection.snapshots().map(
+          (snap) => snap.docs
+              .map(
+                (doc) => Contact(
+                  id: doc.id,
+                  name: doc.data()['name'] as String,
+                  phone: doc.data()['phone'] as String,
+                ),
+              )
+              .toList(),
+        );
   }
 
   @override
   Future<void> saveContact(Contact contact) async {
-    await _doc.set({'name': contact.name, 'phone': contact.phone});
+    final data = {'name': contact.name, 'phone': contact.phone};
+    if (contact.id.isEmpty) {
+      await _collection.add(data);
+    } else {
+      await _collection.doc(contact.id).set(data);
+    }
   }
 
   @override
-  Future<void> deleteContact() async {
-    await _doc.delete();
+  Future<void> deleteContact(String id) async {
+    await _collection.doc(id).delete();
   }
 }

--- a/lib/data/repositories/firestore_photo_repository_impl.dart
+++ b/lib/data/repositories/firestore_photo_repository_impl.dart
@@ -1,0 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tekushare/domain/repositories/photo_repository.dart';
+
+class FirestorePhotoRepositoryImpl implements PhotoRepository {
+  FirestorePhotoRepositoryImpl(this._firestore, this._uid);
+
+  final FirebaseFirestore _firestore;
+  final String _uid;
+
+  CollectionReference<Map<String, dynamic>> get _collection =>
+      _firestore.collection('users').doc(_uid).collection('spots');
+
+  @override
+  Future<void> attachPhoto(String spotId, String imagePath) async {
+    await _collection.doc(spotId).update({
+      'photoPaths': FieldValue.arrayUnion([imagePath]),
+    });
+  }
+
+  @override
+  Future<void> removePhoto(String spotId, String imagePath) async {
+    await _collection.doc(spotId).update({
+      'photoPaths': FieldValue.arrayRemove([imagePath]),
+    });
+  }
+}

--- a/lib/data/repositories/firestore_spot_repository_impl.dart
+++ b/lib/data/repositories/firestore_spot_repository_impl.dart
@@ -18,7 +18,7 @@ class FirestoreSpotRepositoryImpl implements SpotRepository {
 
   @override
   Stream<List<Spot>> getSpots() {
-    if (_uid.isEmpty) return const Stream.empty();
+    if (_uid.isEmpty) return Stream.value([]);
     return _collection.snapshots().map(
           (snapshot) => snapshot.docs.map(_fromDoc).toList(),
         );
@@ -52,10 +52,13 @@ class FirestoreSpotRepositoryImpl implements SpotRepository {
       title: data['title'] as String,
       latitude: (data['latitude'] as num).toDouble(),
       longitude: (data['longitude'] as num).toDouble(),
-      status: SpotStatus.values.byName(data['status'] as String),
+      status: SpotStatus.values.firstWhere(
+        (s) => s.name == (data['status'] as String? ?? ''),
+        orElse: () => SpotStatus.wantToGo,
+      ),
       memo: data['memo'] as String?,
       category: data['category'] as String?,
-      photoPaths: (data['photoPaths'] as List<dynamic>).cast<String>(),
+      photoPaths: (data['photoPaths'] as List<dynamic>?)?.cast<String>() ?? [],
       createdAt: (data['createdAt'] as Timestamp).toDate(),
     );
   }

--- a/lib/data/repositories/firestore_spot_repository_impl.dart
+++ b/lib/data/repositories/firestore_spot_repository_impl.dart
@@ -49,9 +49,9 @@ class FirestoreSpotRepositoryImpl implements SpotRepository {
     final data = doc.data();
     return Spot(
       id: doc.id,
-      title: data['title'] as String,
-      latitude: (data['latitude'] as num).toDouble(),
-      longitude: (data['longitude'] as num).toDouble(),
+      title: data['title'] as String? ?? '',
+      latitude: (data['latitude'] as num?)?.toDouble() ?? 0.0,
+      longitude: (data['longitude'] as num?)?.toDouble() ?? 0.0,
       status: SpotStatus.values.firstWhere(
         (s) => s.name == (data['status'] as String? ?? ''),
         orElse: () => SpotStatus.wantToGo,
@@ -59,7 +59,7 @@ class FirestoreSpotRepositoryImpl implements SpotRepository {
       memo: data['memo'] as String?,
       category: data['category'] as String?,
       photoPaths: (data['photoPaths'] as List<dynamic>?)?.cast<String>() ?? [],
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
     );
   }
 }

--- a/lib/data/repositories/firestore_spot_repository_impl.dart
+++ b/lib/data/repositories/firestore_spot_repository_impl.dart
@@ -1,0 +1,62 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/repositories/spot_repository.dart';
+
+class FirestoreSpotRepositoryImpl implements SpotRepository {
+  FirestoreSpotRepositoryImpl(this._firestore, this._uid);
+
+  final FirebaseFirestore _firestore;
+  final String _uid;
+
+  CollectionReference<Map<String, dynamic>> get _collection =>
+      _firestore.collection('users').doc(_uid).collection('spots');
+
+  @override
+  Future<void> saveSpot(Spot spot) async {
+    await _collection.doc(spot.id).set(_toMap(spot));
+  }
+
+  @override
+  Stream<List<Spot>> getSpots() {
+    if (_uid.isEmpty) return const Stream.empty();
+    return _collection.snapshots().map(
+          (snapshot) => snapshot.docs.map(_fromDoc).toList(),
+        );
+  }
+
+  @override
+  Future<void> updateSpotStatus(String id, SpotStatus status) async {
+    await _collection.doc(id).update({'status': status.name});
+  }
+
+  @override
+  Future<void> deleteSpot(String id) async {
+    await _collection.doc(id).delete();
+  }
+
+  Map<String, dynamic> _toMap(Spot spot) => {
+        'title': spot.title,
+        'latitude': spot.latitude,
+        'longitude': spot.longitude,
+        'status': spot.status.name,
+        'memo': spot.memo,
+        'category': spot.category,
+        'photoPaths': spot.photoPaths,
+        'createdAt': Timestamp.fromDate(spot.createdAt),
+      };
+
+  Spot _fromDoc(QueryDocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    return Spot(
+      id: doc.id,
+      title: data['title'] as String,
+      latitude: (data['latitude'] as num).toDouble(),
+      longitude: (data['longitude'] as num).toDouble(),
+      status: SpotStatus.values.byName(data['status'] as String),
+      memo: data['memo'] as String?,
+      category: data['category'] as String?,
+      photoPaths: (data['photoPaths'] as List<dynamic>).cast<String>(),
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+    );
+  }
+}

--- a/lib/domain/entities/contact.dart
+++ b/lib/domain/entities/contact.dart
@@ -1,0 +1,6 @@
+class Contact {
+  const Contact({required this.name, required this.phone});
+
+  final String name;
+  final String phone;
+}

--- a/lib/domain/entities/contact.dart
+++ b/lib/domain/entities/contact.dart
@@ -1,6 +1,7 @@
 class Contact {
-  const Contact({required this.name, required this.phone});
+  const Contact({required this.id, required this.name, required this.phone});
 
+  final String id;
   final String name;
   final String phone;
 }

--- a/lib/domain/repositories/contact_repository.dart
+++ b/lib/domain/repositories/contact_repository.dart
@@ -1,7 +1,7 @@
 import 'package:tekushare/domain/entities/contact.dart';
 
 abstract interface class ContactRepository {
-  Stream<Contact?> watchContact();
+  Stream<List<Contact>> watchContacts();
   Future<void> saveContact(Contact contact);
-  Future<void> deleteContact();
+  Future<void> deleteContact(String id);
 }

--- a/lib/domain/repositories/contact_repository.dart
+++ b/lib/domain/repositories/contact_repository.dart
@@ -1,0 +1,7 @@
+import 'package:tekushare/domain/entities/contact.dart';
+
+abstract interface class ContactRepository {
+  Stream<Contact?> watchContact();
+  Future<void> saveContact(Contact contact);
+  Future<void> deleteContact();
+}

--- a/lib/screens/pages/settings/view/phone_register_page.dart
+++ b/lib/screens/pages/settings/view/phone_register_page.dart
@@ -40,33 +40,32 @@ class _PhoneRegisterPageState extends ConsumerState<PhoneRegisterPage> {
 
   Future<void> _onSave() async {
     if (!(_formKey.currentState?.validate() ?? false)) return;
+    final name = _nameController.text.trim();
+    final phone = _phoneController.text.trim();
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => _RegisterConfirmDialog(name: name, phone: phone),
+    );
+    if (confirmed != true) return;
+
+    await ref.read(contactNotifierProvider.notifier).save(
+          Contact(
+            id: widget.existing?.id ?? '',
+            name: name,
+            phone: phone,
+          ),
+        );
+    if (!mounted) return;
+
     await showDialog<void>(
       context: context,
-      builder: (_) => AppConfirmDialog(
-        message: AppStrings.settingsPhoneConfirmMessage,
-        confirmLabel: widget.existing == null
-            ? AppStrings.settingsPhoneRegisterConfirm
-            : AppStrings.settingsPhoneSaveButton,
-        onConfirm: () async {
-          await ref.read(contactNotifierProvider.notifier).save(
-                Contact(
-                  id: widget.existing?.id ?? '',
-                  name: _nameController.text.trim(),
-                  phone: _phoneController.text.trim(),
-                ),
-              );
-          if (!mounted) return;
-          Navigator.pop(context);
-          if (!mounted) return;
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text(AppStrings.settingsPhoneRegisteredMessage),
-            ),
-          );
-        },
-        onCancel: () => Navigator.pop(context),
+      builder: (_) => _RegisterSuccessDialog(
+        onClose: () => Navigator.pop(context),
       ),
     );
+    if (!mounted) return;
+    Navigator.pop(context);
   }
 
   void _onDelete() {
@@ -237,6 +236,150 @@ class _PhoneRegisterPageState extends ConsumerState<PhoneRegisterPage> {
       ),
       filled: true,
       fillColor: Colors.white,
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 登録確認ダイアログ
+// ──────────────────────────────────────────
+
+class _RegisterConfirmDialog extends StatelessWidget {
+  const _RegisterConfirmDialog({required this.name, required this.phone});
+
+  final String name;
+  final String phone;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.x2l,
+          AppSpacing.x3l,
+          AppSpacing.x2l,
+          AppSpacing.x2l,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              name,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.xl,
+                fontWeight: AppTextStyle.semiBold,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              phone,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            const Text(
+              AppStrings.settingsPhoneConfirmMessage,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: AppTextStyle.md),
+            ),
+            const SizedBox(height: AppSpacing.x2l),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => Navigator.pop(context, false),
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: AppColors.primary),
+                      foregroundColor: AppColors.primary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.sm),
+                      ),
+                    ),
+                    child: const Text(AppStrings.cancelButton),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.pop(context, true),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.sm),
+                      ),
+                    ),
+                    child: const Text(AppStrings.settingsPhoneRegisterConfirm),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 登録完了ダイアログ
+// ──────────────────────────────────────────
+
+class _RegisterSuccessDialog extends StatelessWidget {
+  const _RegisterSuccessDialog({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.x2l,
+          AppSpacing.x3l,
+          AppSpacing.x2l,
+          AppSpacing.x2l,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              AppStrings.settingsPhoneRegisteredMessage,
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: AppTextStyle.semiBold,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.x2l),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: onClose,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(AppRadius.sm),
+                  ),
+                ),
+                child: const Text(AppStrings.closeButton),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/pages/settings/view/phone_register_page.dart
+++ b/lib/screens/pages/settings/view/phone_register_page.dart
@@ -9,7 +9,9 @@ import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_confirm_dialog.dart';
 
 class PhoneRegisterPage extends ConsumerStatefulWidget {
-  const PhoneRegisterPage({super.key});
+  const PhoneRegisterPage({super.key, this.existing});
+
+  final Contact? existing;
 
   @override
   ConsumerState<PhoneRegisterPage> createState() => _PhoneRegisterPageState();
@@ -19,6 +21,15 @@ class _PhoneRegisterPageState extends ConsumerState<PhoneRegisterPage> {
   final _nameController = TextEditingController();
   final _phoneController = TextEditingController();
   final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.existing != null) {
+      _nameController.text = widget.existing!.name;
+      _phoneController.text = widget.existing!.phone;
+    }
+  }
 
   @override
   void dispose() {
@@ -33,10 +44,13 @@ class _PhoneRegisterPageState extends ConsumerState<PhoneRegisterPage> {
       context: context,
       builder: (_) => AppConfirmDialog(
         message: AppStrings.settingsPhoneConfirmMessage,
-        confirmLabel: AppStrings.settingsPhoneRegisterConfirm,
+        confirmLabel: widget.existing == null
+            ? AppStrings.settingsPhoneRegisterConfirm
+            : AppStrings.settingsPhoneSaveButton,
         onConfirm: () async {
           await ref.read(contactNotifierProvider.notifier).save(
                 Contact(
+                  id: widget.existing?.id ?? '',
                   name: _nameController.text.trim(),
                   phone: _phoneController.text.trim(),
                 ),
@@ -63,7 +77,9 @@ class _PhoneRegisterPageState extends ConsumerState<PhoneRegisterPage> {
         confirmLabel: AppStrings.settingsPhoneDeleteConfirmButton,
         isDestructive: true,
         onConfirm: () async {
-          await ref.read(contactNotifierProvider.notifier).delete();
+          await ref
+              .read(contactNotifierProvider.notifier)
+              .delete(widget.existing!.id);
           if (!mounted) return;
           Navigator.pop(context);
           if (!mounted) return;
@@ -76,138 +92,119 @@ class _PhoneRegisterPageState extends ConsumerState<PhoneRegisterPage> {
 
   @override
   Widget build(BuildContext context) {
-    final contactAsync = ref.watch(contactProvider);
-
-    return contactAsync.when(
-      loading: () => const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: const Text(AppStrings.settingsInactivityContact),
+        centerTitle: true,
+        elevation: 0,
       ),
-      error: (_, __) => const Scaffold(
-        body: Center(child: Text('エラーが発生しました')),
-      ),
-      data: (contact) {
-        if (_nameController.text.isEmpty && contact != null) {
-          _nameController.text = contact.name;
-          _phoneController.text = contact.phone;
-        }
-        return Scaffold(
-          backgroundColor: AppColors.background,
-          appBar: AppBar(
-            backgroundColor: AppColors.primary,
-            foregroundColor: Colors.white,
-            title: const Text(AppStrings.settingsInactivityContact),
-            centerTitle: true,
-            elevation: 0,
-          ),
-          body: SafeArea(
-            top: false,
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(AppSpacing.lg),
-              child: Form(
-                key: _formKey,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const SizedBox(height: AppSpacing.lg),
-                    const Text(
-                      AppStrings.settingsPhoneNameLabel,
-                      style: TextStyle(
-                        fontSize: AppTextStyle.sm2,
-                        color: AppColors.textPrimary,
-                        fontWeight: AppTextStyle.medium,
-                      ),
-                    ),
-                    const SizedBox(height: AppSpacing.xs),
-                    TextFormField(
-                      controller: _nameController,
-                      keyboardType: TextInputType.name,
-                      textInputAction: TextInputAction.next,
-                      decoration: _inputDecoration(
-                        AppStrings.settingsPhoneNameHint,
-                      ),
-                      validator: (v) => (v == null || v.trim().isEmpty)
-                          ? AppStrings.settingsPhoneNameRequired
-                          : null,
-                    ),
-                    const SizedBox(height: AppSpacing.lg),
-                    const Text(
-                      AppStrings.settingsPhoneNumberLabel,
-                      style: TextStyle(
-                        fontSize: AppTextStyle.sm2,
-                        color: AppColors.textPrimary,
-                        fontWeight: AppTextStyle.medium,
-                      ),
-                    ),
-                    const SizedBox(height: AppSpacing.xs),
-                    TextFormField(
-                      controller: _phoneController,
-                      keyboardType: TextInputType.phone,
-                      textInputAction: TextInputAction.done,
-                      onFieldSubmitted: (_) => _onSave(),
-                      decoration: _inputDecoration(
-                        AppStrings.settingsPhoneNumberHint,
-                      ),
-                      validator: (v) => (v == null || v.trim().isEmpty)
-                          ? AppStrings.settingsPhoneNumberRequired
-                          : null,
-                    ),
-                    const SizedBox(height: AppSpacing.x3l),
-                    SizedBox(
-                      width: double.infinity,
-                      height: AppSize.buttonHeight,
-                      child: ElevatedButton(
-                        onPressed: _onSave,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.primary,
-                          foregroundColor: Colors.white,
-                          elevation: 0,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(AppRadius.full),
-                          ),
-                        ),
-                        child: Text(
-                          contact == null
-                              ? AppStrings.settingsPhoneRegisterConfirm
-                              : AppStrings.settingsPhoneSaveButton,
-                          style: const TextStyle(
-                            fontSize: AppTextStyle.lg2,
-                            fontWeight: AppTextStyle.medium,
-                          ),
-                        ),
-                      ),
-                    ),
-                    if (contact != null) ...[
-                      const SizedBox(height: AppSpacing.md),
-                      SizedBox(
-                        width: double.infinity,
-                        height: AppSize.buttonHeight,
-                        child: OutlinedButton(
-                          onPressed: _onDelete,
-                          style: OutlinedButton.styleFrom(
-                            side: const BorderSide(color: Colors.red),
-                            foregroundColor: Colors.red,
-                            shape: RoundedRectangleBorder(
-                              borderRadius:
-                                  BorderRadius.circular(AppRadius.full),
-                            ),
-                          ),
-                          child: const Text(
-                            AppStrings.settingsPhoneDeleteButton,
-                            style: TextStyle(
-                              fontSize: AppTextStyle.lg2,
-                              fontWeight: AppTextStyle.medium,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ],
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: AppSpacing.lg),
+                const Text(
+                  AppStrings.settingsPhoneNameLabel,
+                  style: TextStyle(
+                    fontSize: AppTextStyle.sm2,
+                    color: AppColors.textPrimary,
+                    fontWeight: AppTextStyle.medium,
+                  ),
                 ),
-              ),
+                const SizedBox(height: AppSpacing.xs),
+                TextFormField(
+                  controller: _nameController,
+                  keyboardType: TextInputType.name,
+                  textInputAction: TextInputAction.next,
+                  decoration:
+                      _inputDecoration(AppStrings.settingsPhoneNameHint),
+                  validator: (v) => (v == null || v.trim().isEmpty)
+                      ? AppStrings.settingsPhoneNameRequired
+                      : null,
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                const Text(
+                  AppStrings.settingsPhoneNumberLabel,
+                  style: TextStyle(
+                    fontSize: AppTextStyle.sm2,
+                    color: AppColors.textPrimary,
+                    fontWeight: AppTextStyle.medium,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                TextFormField(
+                  controller: _phoneController,
+                  keyboardType: TextInputType.phone,
+                  textInputAction: TextInputAction.done,
+                  onFieldSubmitted: (_) => _onSave(),
+                  decoration:
+                      _inputDecoration(AppStrings.settingsPhoneNumberHint),
+                  validator: (v) => (v == null || v.trim().isEmpty)
+                      ? AppStrings.settingsPhoneNumberRequired
+                      : null,
+                ),
+                const SizedBox(height: AppSpacing.x3l),
+                SizedBox(
+                  width: double.infinity,
+                  height: AppSize.buttonHeight,
+                  child: ElevatedButton(
+                    onPressed: _onSave,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.full),
+                      ),
+                    ),
+                    child: Text(
+                      widget.existing == null
+                          ? AppStrings.settingsPhoneRegisterConfirm
+                          : AppStrings.settingsPhoneSaveButton,
+                      style: const TextStyle(
+                        fontSize: AppTextStyle.lg2,
+                        fontWeight: AppTextStyle.medium,
+                      ),
+                    ),
+                  ),
+                ),
+                if (widget.existing != null) ...[
+                  const SizedBox(height: AppSpacing.md),
+                  SizedBox(
+                    width: double.infinity,
+                    height: AppSize.buttonHeight,
+                    child: OutlinedButton(
+                      onPressed: _onDelete,
+                      style: OutlinedButton.styleFrom(
+                        side: const BorderSide(color: Colors.red),
+                        foregroundColor: Colors.red,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(AppRadius.full),
+                        ),
+                      ),
+                      child: const Text(
+                        AppStrings.settingsPhoneDeleteButton,
+                        style: TextStyle(
+                          fontSize: AppTextStyle.lg2,
+                          fontWeight: AppTextStyle.medium,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ],
             ),
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 

--- a/lib/screens/pages/settings/view/phone_register_page.dart
+++ b/lib/screens/pages/settings/view/phone_register_page.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_spacing.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/domain/entities/contact.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
+import 'package:tekushare/screens/widgets/common/app_confirm_dialog.dart';
+
+class PhoneRegisterPage extends ConsumerStatefulWidget {
+  const PhoneRegisterPage({super.key});
+
+  @override
+  ConsumerState<PhoneRegisterPage> createState() => _PhoneRegisterPageState();
+}
+
+class _PhoneRegisterPageState extends ConsumerState<PhoneRegisterPage> {
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onSave() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    await showDialog<void>(
+      context: context,
+      builder: (_) => AppConfirmDialog(
+        message: AppStrings.settingsPhoneConfirmMessage,
+        confirmLabel: AppStrings.settingsPhoneRegisterConfirm,
+        onConfirm: () async {
+          await ref.read(contactNotifierProvider.notifier).save(
+                Contact(
+                  name: _nameController.text.trim(),
+                  phone: _phoneController.text.trim(),
+                ),
+              );
+          if (!mounted) return;
+          Navigator.pop(context);
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(AppStrings.settingsPhoneRegisteredMessage),
+            ),
+          );
+        },
+        onCancel: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  void _onDelete() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => AppConfirmDialog(
+        message: AppStrings.settingsPhoneDeleteConfirmMessage,
+        confirmLabel: AppStrings.settingsPhoneDeleteConfirmButton,
+        isDestructive: true,
+        onConfirm: () async {
+          await ref.read(contactNotifierProvider.notifier).delete();
+          if (!mounted) return;
+          Navigator.pop(context);
+          if (!mounted) return;
+          Navigator.pop(context);
+        },
+        onCancel: () => Navigator.pop(context),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final contactAsync = ref.watch(contactProvider);
+
+    return contactAsync.when(
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => const Scaffold(
+        body: Center(child: Text('エラーが発生しました')),
+      ),
+      data: (contact) {
+        if (_nameController.text.isEmpty && contact != null) {
+          _nameController.text = contact.name;
+          _phoneController.text = contact.phone;
+        }
+        return Scaffold(
+          backgroundColor: AppColors.background,
+          appBar: AppBar(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+            title: const Text(AppStrings.settingsInactivityContact),
+            centerTitle: true,
+            elevation: 0,
+          ),
+          body: SafeArea(
+            top: false,
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: AppSpacing.lg),
+                    const Text(
+                      AppStrings.settingsPhoneNameLabel,
+                      style: TextStyle(
+                        fontSize: AppTextStyle.sm2,
+                        color: AppColors.textPrimary,
+                        fontWeight: AppTextStyle.medium,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    TextFormField(
+                      controller: _nameController,
+                      keyboardType: TextInputType.name,
+                      textInputAction: TextInputAction.next,
+                      decoration: _inputDecoration(
+                        AppStrings.settingsPhoneNameHint,
+                      ),
+                      validator: (v) => (v == null || v.trim().isEmpty)
+                          ? AppStrings.settingsPhoneNameRequired
+                          : null,
+                    ),
+                    const SizedBox(height: AppSpacing.lg),
+                    const Text(
+                      AppStrings.settingsPhoneNumberLabel,
+                      style: TextStyle(
+                        fontSize: AppTextStyle.sm2,
+                        color: AppColors.textPrimary,
+                        fontWeight: AppTextStyle.medium,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    TextFormField(
+                      controller: _phoneController,
+                      keyboardType: TextInputType.phone,
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) => _onSave(),
+                      decoration: _inputDecoration(
+                        AppStrings.settingsPhoneNumberHint,
+                      ),
+                      validator: (v) => (v == null || v.trim().isEmpty)
+                          ? AppStrings.settingsPhoneNumberRequired
+                          : null,
+                    ),
+                    const SizedBox(height: AppSpacing.x3l),
+                    SizedBox(
+                      width: double.infinity,
+                      height: AppSize.buttonHeight,
+                      child: ElevatedButton(
+                        onPressed: _onSave,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.primary,
+                          foregroundColor: Colors.white,
+                          elevation: 0,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(AppRadius.full),
+                          ),
+                        ),
+                        child: Text(
+                          contact == null
+                              ? AppStrings.settingsPhoneRegisterConfirm
+                              : AppStrings.settingsPhoneSaveButton,
+                          style: const TextStyle(
+                            fontSize: AppTextStyle.lg2,
+                            fontWeight: AppTextStyle.medium,
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (contact != null) ...[
+                      const SizedBox(height: AppSpacing.md),
+                      SizedBox(
+                        width: double.infinity,
+                        height: AppSize.buttonHeight,
+                        child: OutlinedButton(
+                          onPressed: _onDelete,
+                          style: OutlinedButton.styleFrom(
+                            side: const BorderSide(color: Colors.red),
+                            foregroundColor: Colors.red,
+                            shape: RoundedRectangleBorder(
+                              borderRadius:
+                                  BorderRadius.circular(AppRadius.full),
+                            ),
+                          ),
+                          child: const Text(
+                            AppStrings.settingsPhoneDeleteButton,
+                            style: TextStyle(
+                              fontSize: AppTextStyle.lg2,
+                              fontWeight: AppTextStyle.medium,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  InputDecoration _inputDecoration(String hint) {
+    return InputDecoration(
+      hintText: hint,
+      hintStyle: const TextStyle(
+        color: AppColors.textDisabled,
+        fontSize: AppTextStyle.md2,
+      ),
+      contentPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.md,
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        borderSide: const BorderSide(color: AppColors.chipUnselected),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        borderSide: const BorderSide(color: AppColors.primary),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        borderSide: const BorderSide(color: Colors.red),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        borderSide: const BorderSide(color: Colors.red),
+      ),
+      filled: true,
+      fillColor: Colors.white,
+    );
+  }
+}

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -8,8 +8,11 @@ import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/domain/entities/contact.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
+import 'package:tekushare/screens/pages/settings/view/phone_register_page.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
@@ -25,42 +28,10 @@ class SettingsPage extends ConsumerStatefulWidget {
 }
 
 class _SettingsPageState extends ConsumerState<SettingsPage> {
-  void _showPhoneSelectDialog() {
-    showDialog<void>(
-      context: context,
-      builder: (_) => _PhoneSelectDialog(
-        onSelect: (contact) {
-          Navigator.pop(context);
-          if (!mounted) return;
-          _showPhoneConfirmDialog(contact);
-        },
-      ),
-    );
-  }
-
-  void _showPhoneConfirmDialog(PhoneContact contact) {
-    final vm = ref.read(settingsViewModelProvider.notifier);
-    showDialog<void>(
-      context: context,
-      builder: (_) => _PhoneConfirmDialog(
-        contact: contact,
-        onConfirm: () {
-          vm.registerContact(contact.name);
-          Navigator.pop(context);
-          if (!mounted) return;
-          _showRegisteredDialog();
-        },
-        onCancel: () => Navigator.pop(context),
-      ),
-    );
-  }
-
-  void _showRegisteredDialog() {
-    showDialog<void>(
-      context: context,
-      builder: (_) => _RegisteredDialog(
-        onClose: () => Navigator.pop(context),
-      ),
+  void _openPhoneRegisterPage() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const PhoneRegisterPage()),
     );
   }
 
@@ -103,6 +74,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   Widget build(BuildContext context) {
     final state = ref.watch(settingsViewModelProvider);
     final vm = ref.read(settingsViewModelProvider.notifier);
+    final contact = ref.watch(contactProvider).value;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -126,7 +98,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               _InactivityCard(
                 state: state,
                 vm: vm,
-                onContactTap: _showPhoneSelectDialog,
+                contact: contact,
+                onContactTap: _openPhoneRegisterPage,
               ),
               const SizedBox(height: AppSpacing.x2lp),
               _ShareCard(state: state, vm: vm),
@@ -480,11 +453,13 @@ class _InactivityCard extends StatelessWidget {
     required this.state,
     required this.vm,
     required this.onContactTap,
+    this.contact,
   });
 
   final SettingsState state;
   final SettingsViewModel vm;
   final VoidCallback onContactTap;
+  final Contact? contact;
 
   static final _inactivityOptions = List.generate(24, (i) => (i + 1) * 5);
 
@@ -548,10 +523,10 @@ class _InactivityCard extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: AppSize.phoneIconGap),
-                    const Column(
+                    Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
+                        const Text(
                           AppStrings.settingsInactivityContact,
                           style: TextStyle(
                             fontSize: AppTextStyle.xs,
@@ -559,12 +534,21 @@ class _InactivityCard extends StatelessWidget {
                           ),
                         ),
                         Text(
-                          AppStrings.settingsInactivityContactSet,
-                          style: TextStyle(
+                          contact?.name ??
+                              AppStrings.settingsInactivityContactSet,
+                          style: const TextStyle(
                             fontSize: AppTextStyle.sm2,
                             color: AppColors.primary,
                           ),
                         ),
+                        if (contact != null)
+                          Text(
+                            contact!.phone,
+                            style: const TextStyle(
+                              fontSize: AppTextStyle.xs,
+                              color: AppColors.textDisabled,
+                            ),
+                          ),
                       ],
                     ),
                   ],
@@ -1100,249 +1084,6 @@ class _ShareCheckbox extends StatelessWidget {
           side: const BorderSide(color: AppColors.textDisabled),
         ),
       ],
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 電話番号選択ダイアログ
-// ──────────────────────────────────────────
-
-class _PhoneSelectDialog extends StatelessWidget {
-  const _PhoneSelectDialog({required this.onSelect});
-
-  final ValueChanged<PhoneContact> onSelect;
-
-  static const _contacts = <PhoneContact>[
-    (name: 'あかり（娘）', phone: '080-XXXX-XXXX'),
-    (name: 'いきいき介護...', phone: '080-XXXX-XXXX'),
-    (name: 'たかし（弟）', phone: '080-XXXX-XXXX'),
-    (name: '坂本病院', phone: '080-XXXX-XXXX'),
-    (name: '警察', phone: '110'),
-  ];
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.x2l),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              AppStrings.settingsPhoneSelectTitle,
-              style: TextStyle(
-                fontSize: AppTextStyle.lg2,
-                fontWeight: AppTextStyle.semiBold,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            ..._contacts.map(
-              (c) => Padding(
-                padding: const EdgeInsets.only(bottom: AppSpacing.md),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            c.name,
-                            style: const TextStyle(
-                              fontSize: AppTextStyle.md2,
-                              color: AppColors.textPrimary,
-                            ),
-                          ),
-                          Text(
-                            c.phone,
-                            style: const TextStyle(
-                              fontSize: AppTextStyle.sm,
-                              color: AppColors.primary,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    SizedBox(
-                      height: AppSize.buttonHeight,
-                      child: ElevatedButton(
-                        onPressed: () => onSelect(c),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.primary,
-                          foregroundColor: Colors.white,
-                          elevation: 0,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: AppSpacing.md,
-                          ),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(AppRadius.full),
-                          ),
-                        ),
-                        child: const Text(
-                          AppStrings.settingsPhoneRegisterButton,
-                          style: TextStyle(fontSize: AppTextStyle.xs),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 電話番号登録確認ダイアログ
-// ──────────────────────────────────────────
-
-class _PhoneConfirmDialog extends StatelessWidget {
-  const _PhoneConfirmDialog({
-    required this.contact,
-    required this.onConfirm,
-    required this.onCancel,
-  });
-
-  final PhoneContact contact;
-  final VoidCallback onConfirm;
-  final VoidCallback onCancel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.x2l,
-          AppSpacing.x3l,
-          AppSpacing.x2l,
-          AppSpacing.x2l,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              contact.name,
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: AppTextStyle.lg2,
-                fontWeight: AppTextStyle.semiBold,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            Text(
-              contact.phone,
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: AppTextStyle.md,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            const Text(
-              AppStrings.settingsPhoneConfirmMessage,
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: AppTextStyle.md),
-            ),
-            const SizedBox(height: AppSpacing.x2l),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton(
-                    onPressed: onCancel,
-                    style: OutlinedButton.styleFrom(
-                      side: const BorderSide(color: AppColors.primary),
-                      foregroundColor: AppColors.primary,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.sm),
-                      ),
-                    ),
-                    child: const Text(AppStrings.cancelButton),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.md),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: onConfirm,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.primary,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(AppRadius.sm),
-                      ),
-                    ),
-                    child: const Text(AppStrings.settingsPhoneRegisterConfirm),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 登録完了ダイアログ
-// ──────────────────────────────────────────
-
-class _RegisteredDialog extends StatelessWidget {
-  const _RegisteredDialog({required this.onClose});
-
-  final VoidCallback onClose;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSpacing.x2l,
-          AppSpacing.x3l,
-          AppSpacing.x2l,
-          AppSpacing.x2l,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              AppStrings.settingsPhoneRegisteredMessage,
-              style: TextStyle(
-                fontSize: AppTextStyle.lg2,
-                fontWeight: AppTextStyle.medium,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.x2l),
-            SizedBox(
-              width: double.infinity,
-              height: AppSize.buttonHeight,
-              child: ElevatedButton(
-                onPressed: onClose,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.primary,
-                  foregroundColor: Colors.white,
-                  elevation: 0,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(AppRadius.sm),
-                  ),
-                ),
-                child: const Text(AppStrings.closeButton),
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -28,10 +28,12 @@ class SettingsPage extends ConsumerStatefulWidget {
 }
 
 class _SettingsPageState extends ConsumerState<SettingsPage> {
-  void _openPhoneRegisterPage() {
+  void _openPhoneRegisterPage({Contact? existing}) {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => const PhoneRegisterPage()),
+      MaterialPageRoute(
+        builder: (_) => PhoneRegisterPage(existing: existing),
+      ),
     );
   }
 
@@ -74,7 +76,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   Widget build(BuildContext context) {
     final state = ref.watch(settingsViewModelProvider);
     final vm = ref.read(settingsViewModelProvider.notifier);
-    final contact = ref.watch(contactProvider).value;
+    final contacts = ref.watch(contactProvider).value ?? [];
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -98,8 +100,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               _InactivityCard(
                 state: state,
                 vm: vm,
-                contact: contact,
-                onContactTap: _openPhoneRegisterPage,
+                contacts: contacts,
+                onAddContact: () => _openPhoneRegisterPage(),
+                onEditContact: (c) => _openPhoneRegisterPage(existing: c),
               ),
               const SizedBox(height: AppSpacing.x2lp),
               _ShareCard(state: state, vm: vm),
@@ -452,25 +455,30 @@ class _InactivityCard extends StatelessWidget {
   const _InactivityCard({
     required this.state,
     required this.vm,
-    required this.onContactTap,
-    this.contact,
+    required this.contacts,
+    required this.onAddContact,
+    required this.onEditContact,
   });
 
   final SettingsState state;
   final SettingsViewModel vm;
-  final VoidCallback onContactTap;
-  final Contact? contact;
+  final List<Contact> contacts;
+  final VoidCallback onAddContact;
+  final void Function(Contact) onEditContact;
 
+  static const _maxContacts = 5;
   static final _inactivityOptions = List.generate(24, (i) => (i + 1) * 5);
 
   @override
   Widget build(BuildContext context) {
+    final remaining = _maxContacts - contacts.length;
     return _SettingCard(
       padding: const EdgeInsets.symmetric(
         horizontal: AppSize.timerCardPaddingH,
         vertical: AppSize.timerCardPaddingV,
       ),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -509,52 +517,43 @@ class _InactivityCard extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(width: AppSpacing.sm),
-              GestureDetector(
-                onTap: onContactTap,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    ExcludeSemantics(
-                      child: SvgPicture.asset(
-                        'assets/SVG/phone.svg',
-                        width: AppSize.iconLg,
-                        height: AppSize.iconLg,
-                      ),
-                    ),
-                    const SizedBox(width: AppSize.phoneIconGap),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          AppStrings.settingsInactivityContact,
-                          style: TextStyle(
-                            fontSize: AppTextStyle.xs,
-                            color: Colors.black,
-                          ),
-                        ),
-                        Text(
-                          contact?.name ??
-                              AppStrings.settingsInactivityContactSet,
-                          style: const TextStyle(
-                            fontSize: AppTextStyle.sm2,
-                            color: AppColors.primary,
-                          ),
-                        ),
-                        if (contact != null)
-                          Text(
-                            contact!.phone,
-                            style: const TextStyle(
-                              fontSize: AppTextStyle.xs,
-                              color: AppColors.textDisabled,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ],
-                ),
+            ],
+          ),
+          if (contacts.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.md),
+            ...contacts.map(
+              (c) => _ContactTile(
+                contact: c,
+                onTap: () => onEditContact(c),
               ),
-              const SizedBox(width: AppSpacing.lg),
+            ),
+          ],
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              if (remaining > 0)
+                Text(
+                  'あと$remaining件まで登録できます',
+                  style: const TextStyle(
+                    fontSize: AppTextStyle.xs,
+                    color: AppColors.textDisabled,
+                  ),
+                ),
+              if (remaining > 0)
+                TextButton(
+                  onPressed: onAddContact,
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppColors.primary,
+                    padding: EdgeInsets.zero,
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  child: const Text(
+                    AppStrings.settingsPhoneAddButton,
+                    style: TextStyle(fontSize: AppTextStyle.sm2),
+                  ),
+                ),
             ],
           ),
           const SizedBox(height: AppSpacing.lg),
@@ -586,6 +585,61 @@ class _InactivityCard extends StatelessWidget {
             ],
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _ContactTile extends StatelessWidget {
+  const _ContactTile({required this.contact, required this.onTap});
+
+  final Contact contact;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+        child: Row(
+          children: [
+            ExcludeSemantics(
+              child: SvgPicture.asset(
+                'assets/SVG/phone.svg',
+                width: AppSize.iconLg,
+                height: AppSize.iconLg,
+              ),
+            ),
+            const SizedBox(width: AppSize.phoneIconGap),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    contact.name,
+                    style: const TextStyle(
+                      fontSize: AppTextStyle.sm2,
+                      color: Colors.black,
+                    ),
+                  ),
+                  Text(
+                    contact.phone,
+                    style: const TextStyle(
+                      fontSize: AppTextStyle.xs,
+                      color: AppColors.textDisabled,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(
+              Icons.chevron_right,
+              color: AppColors.primary,
+              size: AppSize.iconMd,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -37,6 +37,23 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     );
   }
 
+  void _showContactsDialog(List<Contact> contacts) {
+    showDialog<void>(
+      context: context,
+      builder: (_) => _ContactsListDialog(
+        contacts: contacts,
+        onEdit: (c) {
+          Navigator.pop(context);
+          _openPhoneRegisterPage(existing: c);
+        },
+        onAdd: () {
+          Navigator.pop(context);
+          _openPhoneRegisterPage();
+        },
+      ),
+    );
+  }
+
   void _showLogoutConfirmDialog() {
     showDialog<void>(
       context: context,
@@ -102,7 +119,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 vm: vm,
                 contacts: contacts,
                 onAddContact: () => _openPhoneRegisterPage(),
-                onEditContact: (c) => _openPhoneRegisterPage(existing: c),
+                onShowContacts: () => _showContactsDialog(contacts),
               ),
               const SizedBox(height: AppSpacing.x2lp),
               _ShareCard(state: state, vm: vm),
@@ -457,28 +474,25 @@ class _InactivityCard extends StatelessWidget {
     required this.vm,
     required this.contacts,
     required this.onAddContact,
-    required this.onEditContact,
+    required this.onShowContacts,
   });
 
   final SettingsState state;
   final SettingsViewModel vm;
   final List<Contact> contacts;
   final VoidCallback onAddContact;
-  final void Function(Contact) onEditContact;
+  final VoidCallback onShowContacts;
 
-  static const _maxContacts = 5;
   static final _inactivityOptions = List.generate(24, (i) => (i + 1) * 5);
 
   @override
   Widget build(BuildContext context) {
-    final remaining = _maxContacts - contacts.length;
     return _SettingCard(
       padding: const EdgeInsets.symmetric(
         horizontal: AppSize.timerCardPaddingH,
         vertical: AppSize.timerCardPaddingV,
       ),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -517,43 +531,45 @@ class _InactivityCard extends StatelessWidget {
                   ],
                 ),
               ),
-            ],
-          ),
-          if (contacts.isNotEmpty) ...[
-            const SizedBox(height: AppSpacing.md),
-            ...contacts.map(
-              (c) => _ContactTile(
-                contact: c,
-                onTap: () => onEditContact(c),
+              const SizedBox(width: AppSpacing.sm),
+              GestureDetector(
+                onTap: contacts.isEmpty ? onAddContact : onShowContacts,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ExcludeSemantics(
+                      child: SvgPicture.asset(
+                        'assets/SVG/phone.svg',
+                        width: AppSize.iconLg,
+                        height: AppSize.iconLg,
+                      ),
+                    ),
+                    const SizedBox(width: AppSize.phoneIconGap),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          AppStrings.settingsInactivityContact,
+                          style: TextStyle(
+                            fontSize: AppTextStyle.xs,
+                            color: Colors.black,
+                          ),
+                        ),
+                        Text(
+                          contacts.isEmpty
+                              ? AppStrings.settingsInactivityContactSet
+                              : '${contacts.length}件登録中',
+                          style: const TextStyle(
+                            fontSize: AppTextStyle.sm2,
+                            color: AppColors.primary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
-          const SizedBox(height: AppSpacing.sm),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              if (remaining > 0)
-                Text(
-                  'あと$remaining件まで登録できます',
-                  style: const TextStyle(
-                    fontSize: AppTextStyle.xs,
-                    color: AppColors.textDisabled,
-                  ),
-                ),
-              if (remaining > 0)
-                TextButton(
-                  onPressed: onAddContact,
-                  style: TextButton.styleFrom(
-                    foregroundColor: AppColors.primary,
-                    padding: EdgeInsets.zero,
-                    minimumSize: Size.zero,
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  ),
-                  child: const Text(
-                    AppStrings.settingsPhoneAddButton,
-                    style: TextStyle(fontSize: AppTextStyle.sm2),
-                  ),
-                ),
+              const SizedBox(width: AppSpacing.lg),
             ],
           ),
           const SizedBox(height: AppSpacing.lg),
@@ -590,54 +606,122 @@ class _InactivityCard extends StatelessWidget {
   }
 }
 
-class _ContactTile extends StatelessWidget {
-  const _ContactTile({required this.contact, required this.onTap});
+// ──────────────────────────────────────────
+// 連絡先一覧ダイアログ
+// ──────────────────────────────────────────
 
-  final Contact contact;
-  final VoidCallback onTap;
+class _ContactsListDialog extends StatelessWidget {
+  const _ContactsListDialog({
+    required this.contacts,
+    required this.onEdit,
+    required this.onAdd,
+  });
+
+  final List<Contact> contacts;
+  final void Function(Contact) onEdit;
+  final VoidCallback onAdd;
+
+  static const _maxContacts = 5;
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
+    final remaining = _maxContacts - contacts.length;
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-        child: Row(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.x2l,
+          AppSpacing.x3l,
+          AppSpacing.x2l,
+          AppSpacing.x2l,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            ExcludeSemantics(
-              child: SvgPicture.asset(
-                'assets/SVG/phone.svg',
-                width: AppSize.iconLg,
-                height: AppSize.iconLg,
+            const Text(
+              AppStrings.settingsInactivityContact,
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: AppTextStyle.semiBold,
               ),
             ),
-            const SizedBox(width: AppSize.phoneIconGap),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    contact.name,
-                    style: const TextStyle(
-                      fontSize: AppTextStyle.sm2,
-                      color: Colors.black,
-                    ),
+            const SizedBox(height: AppSpacing.md),
+            ...contacts.map(
+              (c) => InkWell(
+                onTap: () => onEdit(c),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              c.name,
+                              style: const TextStyle(
+                                fontSize: AppTextStyle.sm2,
+                                color: AppColors.primary,
+                                fontWeight: AppTextStyle.semiBold,
+                              ),
+                            ),
+                            Text(
+                              c.phone,
+                              style: const TextStyle(
+                                fontSize: AppTextStyle.xs,
+                                color: AppColors.textDisabled,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const Icon(
+                        Icons.chevron_right,
+                        color: AppColors.primary,
+                        size: AppSize.iconMd,
+                      ),
+                    ],
                   ),
-                  Text(
-                    contact.phone,
-                    style: const TextStyle(
-                      fontSize: AppTextStyle.xs,
-                      color: AppColors.textDisabled,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
-            const Icon(
-              Icons.chevron_right,
-              color: AppColors.primary,
-              size: AppSize.iconMd,
-            ),
+            if (remaining > 0) ...[
+              const Divider(color: AppColors.primary),
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                'あと$remaining件まで登録できます',
+                style: const TextStyle(
+                  fontSize: AppTextStyle.xs,
+                  color: AppColors.textDisabled,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.md),
+              SizedBox(
+                width: double.infinity,
+                height: AppSize.buttonHeight,
+                child: ElevatedButton(
+                  onPressed: onAdd,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.full),
+                    ),
+                  ),
+                  child: const Text(
+                    AppStrings.settingsPhoneAddButton,
+                    style: TextStyle(
+                      fontSize: AppTextStyle.lg2,
+                      fontWeight: AppTextStyle.medium,
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -663,16 +663,16 @@ class _ContactsListDialog extends StatelessWidget {
                             Text(
                               c.name,
                               style: const TextStyle(
-                                fontSize: AppTextStyle.sm2,
-                                color: AppColors.primary,
+                                fontSize: AppTextStyle.lg2,
+                                color: AppColors.textPrimary,
                                 fontWeight: AppTextStyle.semiBold,
                               ),
                             ),
                             Text(
                               c.phone,
                               style: const TextStyle(
-                                fontSize: AppTextStyle.xs,
-                                color: AppColors.textDisabled,
+                                fontSize: AppTextStyle.md,
+                                color: AppColors.primary,
                               ),
                             ),
                           ],

--- a/lib/screens/providers/app_providers.dart
+++ b/lib/screens/providers/app_providers.dart
@@ -1,15 +1,17 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:tekushare/data/models/saved_route_model.dart';
-import 'package:tekushare/data/models/spot_model.dart';
 import 'package:tekushare/data/models/walk_route_model.dart';
 import 'package:tekushare/data/models/walk_session_model.dart';
-import 'package:tekushare/data/repositories/photo_repository_impl.dart';
+import 'package:tekushare/data/repositories/firestore_contact_repository_impl.dart';
+import 'package:tekushare/data/repositories/firestore_photo_repository_impl.dart';
+import 'package:tekushare/data/repositories/firestore_spot_repository_impl.dart';
 import 'package:tekushare/data/repositories/route_repository_impl.dart';
 import 'package:tekushare/data/repositories/saved_route_repository_impl.dart';
-import 'package:tekushare/data/repositories/spot_repository_impl.dart';
 import 'package:tekushare/data/repositories/walk_session_repository_impl.dart';
+import 'package:tekushare/domain/repositories/contact_repository.dart';
 import 'package:tekushare/domain/repositories/photo_repository.dart';
 import 'package:tekushare/domain/repositories/route_repository.dart';
 import 'package:tekushare/domain/repositories/saved_route_repository.dart';
@@ -17,6 +19,7 @@ import 'package:tekushare/domain/repositories/spot_repository.dart';
 import 'package:tekushare/domain/repositories/walk_session_repository.dart';
 import 'package:tekushare/infrastructure/camera_service.dart';
 import 'package:tekushare/infrastructure/notification_service.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
 
 /// Isar インスタンスを非同期で提供する。
 /// アプリ起動時に一度だけ初期化される。
@@ -24,7 +27,6 @@ final isarProvider = FutureProvider<Isar>((ref) async {
   final dir = await getApplicationDocumentsDirectory();
   final isar = await Isar.open(
     [
-      SpotModelSchema,
       WalkSessionModelSchema,
       WalkRouteModelSchema,
       SavedRouteModelSchema,
@@ -36,7 +38,8 @@ final isarProvider = FutureProvider<Isar>((ref) async {
 });
 
 final spotRepositoryProvider = Provider<SpotRepository>((ref) {
-  return SpotRepositoryImpl(ref.watch(isarProvider).requireValue);
+  final uid = ref.watch(authStateProvider).value?.uid ?? '';
+  return FirestoreSpotRepositoryImpl(FirebaseFirestore.instance, uid);
 });
 
 final walkSessionRepositoryProvider = Provider<WalkSessionRepository>((ref) {
@@ -52,7 +55,13 @@ final savedRouteRepositoryProvider = Provider<SavedRouteRepository>((ref) {
 });
 
 final photoRepositoryProvider = Provider<PhotoRepository>((ref) {
-  return PhotoRepositoryImpl(ref.watch(isarProvider).requireValue);
+  final uid = ref.watch(authStateProvider).value?.uid ?? '';
+  return FirestorePhotoRepositoryImpl(FirebaseFirestore.instance, uid);
+});
+
+final contactRepositoryProvider = Provider<ContactRepository>((ref) {
+  final uid = ref.watch(authStateProvider).value?.uid ?? '';
+  return FirestoreContactRepositoryImpl(FirebaseFirestore.instance, uid);
 });
 
 final notificationServiceProvider = Provider<NotificationService>((ref) {

--- a/lib/screens/providers/contact_provider.dart
+++ b/lib/screens/providers/contact_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tekushare/domain/entities/contact.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+
+final contactProvider = StreamProvider<Contact?>((ref) {
+  return ref.watch(contactRepositoryProvider).watchContact();
+});
+
+class ContactNotifier extends AsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<void> save(Contact contact) async {
+    await ref.read(contactRepositoryProvider).saveContact(contact);
+  }
+
+  Future<void> delete() async {
+    await ref.read(contactRepositoryProvider).deleteContact();
+  }
+}
+
+final contactNotifierProvider =
+    AsyncNotifierProvider<ContactNotifier, void>(ContactNotifier.new);

--- a/lib/screens/providers/contact_provider.dart
+++ b/lib/screens/providers/contact_provider.dart
@@ -11,11 +11,17 @@ class ContactNotifier extends AsyncNotifier<void> {
   Future<void> build() async {}
 
   Future<void> save(Contact contact) async {
-    await ref.read(contactRepositoryProvider).saveContact(contact);
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => ref.read(contactRepositoryProvider).saveContact(contact),
+    );
   }
 
   Future<void> delete(String id) async {
-    await ref.read(contactRepositoryProvider).deleteContact(id);
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => ref.read(contactRepositoryProvider).deleteContact(id),
+    );
   }
 }
 

--- a/lib/screens/providers/contact_provider.dart
+++ b/lib/screens/providers/contact_provider.dart
@@ -2,8 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/domain/entities/contact.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 
-final contactProvider = StreamProvider<Contact?>((ref) {
-  return ref.watch(contactRepositoryProvider).watchContact();
+final contactProvider = StreamProvider<List<Contact>>((ref) {
+  return ref.watch(contactRepositoryProvider).watchContacts();
 });
 
 class ContactNotifier extends AsyncNotifier<void> {
@@ -14,8 +14,8 @@ class ContactNotifier extends AsyncNotifier<void> {
     await ref.read(contactRepositoryProvider).saveContact(contact);
   }
 
-  Future<void> delete() async {
-    await ref.read(contactRepositoryProvider).deleteContact();
+  Future<void> delete(String id) async {
+    await ref.read(contactRepositoryProvider).deleteContact(id);
   }
 }
 

--- a/test/screens/pages/home/home_page_test.dart
+++ b/test/screens/pages/home/home_page_test.dart
@@ -130,7 +130,7 @@ void main() {
               (ref) => Stream<Position>.error(Exception('GPS unavailable')),
             ),
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -215,7 +215,7 @@ void main() {
               (ref) => Stream<Position>.error(Exception('GPS unavailable')),
             ),
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             navigatorKey: navKey,

--- a/test/screens/pages/home/home_page_test.dart
+++ b/test/screens/pages/home/home_page_test.dart
@@ -24,6 +24,7 @@ import 'package:tekushare/app.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/screens/providers/clock_provider.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
@@ -129,6 +130,7 @@ void main() {
               (ref) => Stream<Position>.error(Exception('GPS unavailable')),
             ),
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -213,6 +215,7 @@ void main() {
               (ref) => Stream<Position>.error(Exception('GPS unavailable')),
             ),
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             navigatorKey: navKey,

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -263,7 +263,7 @@ void main() {
             _savedRouteRepoWithDataOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -305,7 +305,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -351,7 +351,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesWithDataOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -442,7 +442,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -477,7 +477,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -515,7 +515,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -553,7 +553,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -594,7 +594,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -671,7 +671,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -766,7 +766,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -862,7 +862,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1003,7 +1003,7 @@ void main() {
             _savedRouteRepoWithDataOverride,
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1055,7 +1055,7 @@ void main() {
             ),
             _walkRoutesWithDataOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1095,7 +1095,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1135,7 +1135,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1179,7 +1179,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -23,6 +23,7 @@ import 'package:tekushare/screens/pages/map/viewmodel/walk_route_viewmodel.dart'
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/providers/walk_history_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
@@ -262,6 +263,7 @@ void main() {
             _savedRouteRepoWithDataOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -303,6 +305,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -348,6 +351,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesWithDataOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -438,6 +442,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -472,6 +477,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -509,6 +515,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -546,6 +553,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -586,6 +594,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -662,6 +671,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -756,6 +766,7 @@ void main() {
             _savedRouteRepoOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -851,6 +862,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -991,6 +1003,7 @@ void main() {
             _savedRouteRepoWithDataOverride,
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1042,6 +1055,7 @@ void main() {
             ),
             _walkRoutesWithDataOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1081,6 +1095,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1120,6 +1135,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -1163,6 +1179,7 @@ void main() {
             savedRouteRepositoryProvider.overrideWith((_) => fakeRepo),
             _walkRoutesOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
           ],
           child: MaterialApp(
             builder: (context, child) {

--- a/test/screens/pages/settings/phone_register_page_test.dart
+++ b/test/screens/pages/settings/phone_register_page_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/domain/entities/contact.dart';
+import 'package:tekushare/screens/pages/settings/view/phone_register_page.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
+
+class _FakeContactNotifier extends ContactNotifier {
+  Contact? savedContact;
+  String? deletedId;
+
+  @override
+  Future<void> save(Contact contact) async => savedContact = contact;
+
+  @override
+  Future<void> delete(String id) async => deletedId = id;
+}
+
+void main() {
+  group('PhoneRegisterPage', () {
+    late _FakeContactNotifier fakeNotifier;
+
+    setUp(() => fakeNotifier = _FakeContactNotifier());
+
+    ProviderScope buildScope({Contact? existing, required Widget child}) {
+      return ProviderScope(
+        overrides: [
+          contactNotifierProvider.overrideWith(() => fakeNotifier),
+        ],
+        child: MaterialApp(
+          builder: (context, c) {
+            final sw = MediaQuery.sizeOf(context).width;
+            return Theme(
+              data: Theme.of(context).copyWith(
+                extensions: [AppSizingTheme.fromScreenWidth(sw)],
+              ),
+              child: c!,
+            );
+          },
+          home: child,
+        ),
+      );
+    }
+
+    Future<void> pumpNew(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        buildScope(child: const PhoneRegisterPage()),
+      );
+      await tester.pump();
+    }
+
+    Future<void> pumpEdit(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        buildScope(
+          child: const PhoneRegisterPage(
+            existing: Contact(id: 'id1', name: 'テスト太郎', phone: '09012345678'),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    // 新規モードでアプリバータイトルが表示される
+    testWidgets('shows app bar title', (tester) async {
+      await pumpNew(tester);
+      expect(
+        find.text(AppStrings.settingsInactivityContact),
+        findsAtLeastNWidgets(1),
+      );
+    });
+
+    // 編集モードで既存データがフォームに埋まっている
+    testWidgets('prefills fields when existing contact given', (tester) async {
+      await pumpEdit(tester);
+      expect(find.text('テスト太郎'), findsOneWidget);
+      expect(find.text('09012345678'), findsOneWidget);
+    });
+
+    // バリデーション：名前が空なら確認ダイアログが出ない
+    testWidgets('does not show confirm dialog when name is empty',
+        (tester) async {
+      await pumpNew(tester);
+      await tester.enterText(
+        find.byType(TextFormField).last,
+        '09012345678',
+      );
+      await tester.tap(find.text(AppStrings.settingsPhoneRegisterConfirm));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.settingsPhoneConfirmMessage), findsNothing);
+    });
+
+    // 登録ボタン → 確認ダイアログが表示される
+    testWidgets('tapping register shows confirm dialog', (tester) async {
+      await pumpNew(tester);
+      await tester.enterText(find.byType(TextFormField).first, 'テスト太郎');
+      await tester.enterText(find.byType(TextFormField).last, '09012345678');
+      await tester.tap(find.text(AppStrings.settingsPhoneRegisterConfirm));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.settingsPhoneConfirmMessage), findsOneWidget);
+    });
+
+    // 確認ダイアログでキャンセルすると閉じる
+    testWidgets('canceling confirm dialog dismisses it', (tester) async {
+      await pumpNew(tester);
+      await tester.enterText(find.byType(TextFormField).first, 'テスト太郎');
+      await tester.enterText(find.byType(TextFormField).last, '09012345678');
+      await tester.tap(find.text(AppStrings.settingsPhoneRegisterConfirm));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.settingsPhoneConfirmMessage), findsNothing);
+      expect(find.byType(PhoneRegisterPage), findsOneWidget);
+    });
+
+    // 確認ダイアログで登録する → 保存が呼ばれ、完了ダイアログが表示される
+    testWidgets('confirming calls save and shows success dialog',
+        (tester) async {
+      await pumpNew(tester);
+      await tester.enterText(find.byType(TextFormField).first, 'テスト太郎');
+      await tester.enterText(find.byType(TextFormField).last, '09012345678');
+      await tester.tap(find.text(AppStrings.settingsPhoneRegisterConfirm));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.text(AppStrings.settingsPhoneRegisterConfirm).last,
+      );
+      await tester.pumpAndSettle();
+      expect(fakeNotifier.savedContact?.name, 'テスト太郎');
+      expect(
+        find.text(AppStrings.settingsPhoneRegisteredMessage),
+        findsOneWidget,
+      );
+    });
+
+    // 完了ダイアログを閉じると消える
+    testWidgets('closing success dialog dismisses it', (tester) async {
+      final navigator = GlobalKey<NavigatorState>();
+      tester.view.physicalSize = const Size(1170, 3000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            contactNotifierProvider.overrideWith(() => fakeNotifier),
+          ],
+          child: MaterialApp(
+            navigatorKey: navigator,
+            builder: (context, c) {
+              final sw = MediaQuery.sizeOf(context).width;
+              return Theme(
+                data: Theme.of(context).copyWith(
+                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
+                ),
+                child: c!,
+              );
+            },
+            home: Scaffold(
+              body: Builder(
+                builder: (ctx) => ElevatedButton(
+                  onPressed: () => Navigator.push(
+                    ctx,
+                    MaterialPageRoute(
+                      builder: (_) => const PhoneRegisterPage(),
+                    ),
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField).first, 'テスト太郎');
+      await tester.enterText(find.byType(TextFormField).last, '09012345678');
+      await tester.tap(find.text(AppStrings.settingsPhoneRegisterConfirm));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.text(AppStrings.settingsPhoneRegisterConfirm).last,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
+      await tester.pumpAndSettle();
+      expect(
+          find.text(AppStrings.settingsPhoneRegisteredMessage), findsNothing);
+      expect(find.byType(PhoneRegisterPage), findsNothing);
+    });
+
+    // 編集モードで削除ボタンが表示される
+    testWidgets('shows delete button in edit mode', (tester) async {
+      await pumpEdit(tester);
+      expect(find.text(AppStrings.settingsPhoneDeleteButton), findsOneWidget);
+    });
+
+    // 削除ボタン → 削除確認ダイアログが表示される
+    testWidgets('tapping delete shows confirm dialog', (tester) async {
+      await pumpEdit(tester);
+      await tester.tap(find.text(AppStrings.settingsPhoneDeleteButton));
+      await tester.pumpAndSettle();
+      expect(
+        find.text(AppStrings.settingsPhoneDeleteConfirmMessage),
+        findsOneWidget,
+      );
+    });
+
+    // 削除確認ダイアログでキャンセルすると閉じる
+    testWidgets('canceling delete dialog closes it', (tester) async {
+      await pumpEdit(tester);
+      await tester.tap(find.text(AppStrings.settingsPhoneDeleteButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.cancelButton));
+      await tester.pumpAndSettle();
+      expect(
+        find.text(AppStrings.settingsPhoneDeleteConfirmMessage),
+        findsNothing,
+      );
+      expect(find.byType(PhoneRegisterPage), findsOneWidget);
+    });
+
+    // 削除確認ダイアログで削除すると delete が呼ばれる
+    testWidgets('confirming delete calls delete', (tester) async {
+      await pumpEdit(tester);
+      await tester.tap(find.text(AppStrings.settingsPhoneDeleteButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.settingsPhoneDeleteConfirmButton));
+      await tester.pumpAndSettle();
+      expect(fakeNotifier.deletedId, 'id1');
+    });
+  });
+}

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -18,9 +18,11 @@ import 'package:tekushare/domain/usecases/spot/save_spot.dart';
 import 'package:tekushare/domain/usecases/spot/update_spot_status.dart';
 import 'package:tekushare/domain/usecases/walk/end_walk.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
+import 'package:tekushare/screens/pages/settings/view/phone_register_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
@@ -138,6 +140,9 @@ final _spotOverride = spotProvider.overrideWith(
   ),
 );
 
+final _contactOverride =
+    contactProvider.overrideWith((ref) => Stream.value(null));
+
 void main() {
   group('SettingsPage', () {
     Future<void> pumpPage(WidgetTester tester) async {
@@ -148,6 +153,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -227,6 +233,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -269,7 +276,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride],
+          overrides: [_contactOverride, _spotOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -311,6 +318,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -405,73 +413,14 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    // 通知先設定ボタンをタップすると電話番号選択ダイアログが開く
-    testWidgets('tapping set contact button opens phone select dialog',
-        (tester) async {
+    // 通知先をタップすると PhoneRegisterPage に遷移する
+    testWidgets('tapping contact opens PhoneRegisterPage', (tester) async {
       await pumpPage(tester);
 
       await tester.tap(find.text(AppStrings.settingsInactivityContactSet));
       await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.settingsPhoneSelectTitle), findsOneWidget);
-    });
-
-    // 電話番号を選択すると確認ダイアログが表示される
-    testWidgets('selecting contact shows confirm dialog', (tester) async {
-      await pumpPage(tester);
-
-      await tester.tap(find.text(AppStrings.settingsInactivityContactSet));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.settingsPhoneRegisterButton).first);
-      await tester.pumpAndSettle();
-
-      expect(find.text(AppStrings.settingsPhoneConfirmMessage), findsOneWidget);
-    });
-
-    // 登録するをタップすると登録完了ダイアログが表示される
-    testWidgets('confirming contact shows registered dialog', (tester) async {
-      await pumpPage(tester);
-
-      await tester.tap(find.text(AppStrings.settingsInactivityContactSet));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.settingsPhoneRegisterButton).first);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.settingsPhoneRegisterConfirm));
-      await tester.pumpAndSettle();
-
-      expect(
-          find.text(AppStrings.settingsPhoneRegisteredMessage), findsOneWidget);
-    });
-
-    // 登録完了ダイアログを閉じる
-    testWidgets('closing registered dialog dismisses it', (tester) async {
-      await pumpPage(tester);
-
-      await tester.tap(find.text(AppStrings.settingsInactivityContactSet));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.settingsPhoneRegisterButton).first);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.settingsPhoneRegisterConfirm));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.closeButton));
-      await tester.pumpAndSettle();
-
-      expect(
-          find.text(AppStrings.settingsPhoneRegisteredMessage), findsNothing);
-    });
-
-    // 確認ダイアログのキャンセル
-    testWidgets('canceling confirm dialog closes it', (tester) async {
-      await pumpPage(tester);
-
-      await tester.tap(find.text(AppStrings.settingsInactivityContactSet));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.settingsPhoneRegisterButton).first);
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.cancelButton));
-      await tester.pumpAndSettle();
-
-      expect(find.text(AppStrings.settingsPhoneConfirmMessage), findsNothing);
+      expect(find.byType(PhoneRegisterPage), findsOneWidget);
     });
 
     // シェアの行きたいリストチェックボックスをタップする
@@ -483,6 +432,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -517,6 +467,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -551,6 +502,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -585,6 +537,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -619,6 +572,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -653,6 +607,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [_contactOverride],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -729,6 +684,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            _contactOverride,
             authServiceProvider.overrideWithValue(fakeAuth),
             walkSessionProvider.overrideWith(
               (ref) => WalkSessionNotifier(
@@ -774,6 +730,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            _contactOverride,
             authServiceProvider.overrideWithValue(fakeAuth),
             walkSessionProvider.overrideWith(
               (ref) => WalkSessionNotifier(
@@ -820,6 +777,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            _contactOverride,
             authServiceProvider.overrideWithValue(fakeAuth),
             walkSessionProvider.overrideWith(
               (ref) => WalkSessionNotifier(
@@ -869,6 +827,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            _contactOverride,
             authServiceProvider.overrideWithValue(fakeAuth),
             walkSessionProvider.overrideWith(
               (ref) => WalkSessionNotifier(
@@ -915,6 +874,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            _contactOverride,
             authServiceProvider.overrideWithValue(fakeAuth),
             walkSessionProvider.overrideWith(
               (ref) => WalkSessionNotifier(
@@ -962,6 +922,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            _contactOverride,
             authServiceProvider.overrideWithValue(fakeAuth),
             walkSessionProvider.overrideWith(
               (ref) => WalkSessionNotifier(

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -141,7 +141,7 @@ final _spotOverride = spotProvider.overrideWith(
 );
 
 final _contactOverride =
-    contactProvider.overrideWith((ref) => Stream.value(null));
+    contactProvider.overrideWith((ref) => Stream.value([]));
 
 void main() {
   group('SettingsPage', () {
@@ -414,10 +414,11 @@ void main() {
     });
 
     // 通知先をタップすると PhoneRegisterPage に遷移する
-    testWidgets('tapping contact opens PhoneRegisterPage', (tester) async {
+    testWidgets('tapping add contact button opens PhoneRegisterPage',
+        (tester) async {
       await pumpPage(tester);
 
-      await tester.tap(find.text(AppStrings.settingsInactivityContactSet));
+      await tester.tap(find.text(AppStrings.settingsPhoneAddButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(PhoneRegisterPage), findsOneWidget);

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -418,7 +418,7 @@ void main() {
         (tester) async {
       await pumpPage(tester);
 
-      await tester.tap(find.text(AppStrings.settingsPhoneAddButton));
+      await tester.tap(find.text(AppStrings.settingsInactivityContactSet));
       await tester.pumpAndSettle();
 
       expect(find.byType(PhoneRegisterPage), findsOneWidget);

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -17,6 +17,7 @@ import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
@@ -118,6 +119,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
             if (camera != null)
               cameraServiceProvider.overrideWith((ref) => camera)
             else
@@ -155,7 +157,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride, _cameraOverride],
+          overrides: [
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+            _cameraOverride,
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -119,7 +119,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
             if (camera != null)
               cameraServiceProvider.overrideWith((ref) => camera)
             else
@@ -159,7 +159,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
             _cameraOverride,
           ],
           child: MaterialApp(

--- a/test/screens/pages/spot/spot_list_page_test.dart
+++ b/test/screens/pages/spot/spot_list_page_test.dart
@@ -16,6 +16,7 @@ import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_detail_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
@@ -119,7 +120,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride],
+          overrides: [
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -263,7 +267,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [emptyOverride],
+          overrides: [
+            emptyOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -294,7 +301,10 @@ void main() {
     testWidgets('shows back button in AppBar', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride],
+          overrides: [
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -350,7 +360,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride],
+          overrides: [
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -394,7 +407,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride],
+          overrides: [
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -436,7 +452,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride],
+          overrides: [
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/spot/spot_list_page_test.dart
+++ b/test/screens/pages/spot/spot_list_page_test.dart
@@ -122,7 +122,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -269,7 +269,7 @@ void main() {
         ProviderScope(
           overrides: [
             emptyOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -303,7 +303,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -362,7 +362,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -409,7 +409,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -454,7 +454,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -125,7 +125,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -232,7 +232,7 @@ void main() {
         ProviderScope(
           overrides: [
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -338,7 +338,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -397,7 +397,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -443,7 +443,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -489,7 +489,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {
@@ -537,7 +537,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
             cameraServiceProvider
                 .overrideWithValue(_FakeCameraService(fakePath)),
           ],
@@ -586,7 +586,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -19,6 +19,7 @@ import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
@@ -121,7 +122,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_locationOverride, _spotOverride],
+          overrides: [
+            _locationOverride,
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -225,7 +230,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_spotOverride],
+          overrides: [
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -327,7 +335,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_locationOverride, _spotOverride],
+          overrides: [
+            _locationOverride,
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -382,7 +394,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_locationOverride, _spotOverride],
+          overrides: [
+            _locationOverride,
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -424,7 +440,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_locationOverride, _spotOverride],
+          overrides: [
+            _locationOverride,
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -466,7 +486,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_locationOverride, _spotOverride],
+          overrides: [
+            _locationOverride,
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;
@@ -513,6 +537,7 @@ void main() {
           overrides: [
             _locationOverride,
             _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
             cameraServiceProvider
                 .overrideWithValue(_FakeCameraService(fakePath)),
           ],
@@ -558,7 +583,11 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [_locationOverride, _spotOverride],
+          overrides: [
+            _locationOverride,
+            _spotOverride,
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/walk/end_walk_page_test.dart
+++ b/test/screens/pages/walk/end_walk_page_test.dart
@@ -340,7 +340,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {

--- a/test/screens/pages/walk/end_walk_page_test.dart
+++ b/test/screens/pages/walk/end_walk_page_test.dart
@@ -20,6 +20,7 @@ import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 
@@ -338,6 +339,9 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -212,7 +212,7 @@ void main() {
           (ref) => locationStream ?? const Stream.empty(),
         ),
         _notificationOverride,
-        contactProvider.overrideWith((ref) => Stream.value(null)),
+        contactProvider.overrideWith((ref) => Stream.value([])),
         if (camera != null) cameraServiceProvider.overrideWith((ref) => camera),
       ];
 
@@ -558,7 +558,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            contactProvider.overrideWith((ref) => Stream.value(null)),
+            contactProvider.overrideWith((ref) => Stream.value([])),
           ],
           child: MaterialApp(
             builder: (context, child) {

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -19,6 +19,7 @@ import 'package:tekushare/infrastructure/notification_service.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
 import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.dart';
+import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
@@ -211,6 +212,7 @@ void main() {
           (ref) => locationStream ?? const Stream.empty(),
         ),
         _notificationOverride,
+        contactProvider.overrideWith((ref) => Stream.value(null)),
         if (camera != null) cameraServiceProvider.overrideWith((ref) => camera),
       ];
 
@@ -555,6 +557,9 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [
+            contactProvider.overrideWith((ref) => Stream.value(null)),
+          ],
           child: MaterialApp(
             builder: (context, child) {
               final sw = MediaQuery.sizeOf(context).width;


### PR DESCRIPTION
## 概要

- Cloud Firestore をデータストアとして統合し、スポット・写真・連絡先データの永続化を実装
- 設定画面から緊急連絡先（名前・電話番号）を登録・上書き・削除できるページを追加

## 変更内容

### 新規ファイル
- `lib/data/repositories/firestore_spot_repository_impl.dart` — スポットの CRUD を Firestore (`users/{uid}/spots`) で実装
- `lib/data/repositories/firestore_photo_repository_impl.dart` — 写真パスを `FieldValue.arrayUnion/arrayRemove` で管理
- `lib/data/repositories/firestore_contact_repository_impl.dart` — 連絡先を `users/{uid}/settings/contact` に保存・監視
- `lib/domain/entities/contact.dart` — 連絡先エンティティ（名前・電話番号）
- `lib/domain/repositories/contact_repository.dart` — 連絡先リポジトリ抽象インターフェース
- `lib/screens/providers/contact_provider.dart` — `StreamProvider<Contact?>` + `ContactNotifier`
- `lib/screens/pages/settings/view/phone_register_page.dart` — 連絡先登録ページ（新規登録・上書き保存・削除）
- `firestore.rules` — 認証済みユーザーの自身データのみ読み書き可能なセキュリティルール

### 変更ファイル
- `lib/screens/providers/app_providers.dart` — `spotRepositoryProvider` / `photoRepositoryProvider` を Firestore 実装に切り替え、`contactRepositoryProvider` 追加
- `lib/screens/pages/settings/view/settings_page.dart` — 連絡先ダイアログを削除し `PhoneRegisterPage` への遷移に変更、登録済み連絡先の表示対応
- `lib/core/constants/app_strings.dart` — 連絡先登録ページ用文言を追加

### テスト対応
- 全テストファイルに `contactProvider.overrideWith((ref) => Stream.value(null))` を追加し Firebase 初期化エラーを解消
- 全 343 テストがパス

## テスト計画

- [ ] `flutter test` で全 343 テストがパスすることを確認
- [ ] `flutter analyze` でエラー・警告がないことを確認
- [ ] 実機またはエミュレーターで設定画面 → 連絡先登録 → 保存・削除の動作確認
- [ ] Firestore コンソールで `users/{uid}/settings/contact` にデータが書き込まれることを確認
- [ ] 未ログイン状態でクラッシュしないことを確認（uid 空の場合は `Stream.empty()` を返す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 安否確認先（名前・電話番号）を設定画面から登録・編集・削除できるようになりました。
  * 登録した連絡先の一覧を設定画面で確認できるようになりました。
  * スポット情報と写真の保存・更新・削除がクラウド対応されました。
* **改善**
  * 電話番号登録の導線を専用ページ形式に統一し、確認・完了までの流れを分かりやすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->