### PR TITLE
[Feature] #86 SNSシェアボタンの実装（LINE / X / Instagram）

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,5 +54,9 @@
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="instagram" />
+        </intent>
     </queries>
 </manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,6 +42,7 @@
 		<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>sms</string>
+		<string>instagram</string>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 		<dict>

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -169,6 +169,7 @@ abstract class AppStrings {
   static const shareInviteText = 'てくしぇあで散歩記録をシェアしませんか？';
   static const shareLinkRequired = 'リンクを先に作成してください';
   static const shareInstagramCopied = 'リンクをコピーしました。Instagramに貼り付けてください';
+  static const shareError = 'シェアに失敗しました';
 
   // 招待承認画面
   static const acceptInviteTitle = 'アカウント連携';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -165,6 +165,11 @@ abstract class AppStrings {
   static const accountLinkUnlinkTooltip = '連携を解除';
   static const accountLinkViewSpots = 'スポットを見る';
 
+  // SNSシェア
+  static const shareInviteText = 'てくしぇあで散歩記録をシェアしませんか？';
+  static const shareLinkRequired = 'リンクを先に作成してください';
+  static const shareInstagramCopied = 'リンクをコピーしました。Instagramに貼り付けてください';
+
   // 招待承認画面
   static const acceptInviteTitle = 'アカウント連携';
   static const acceptInviteMessage = 'さんと連携しますか？';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -28,7 +28,7 @@ abstract class AppStrings {
   static const timerTurnaround = '折り返し';
   static const timerInactivity = '不活動';
   static const timerReset = 'リセット';
-  static const timerFinishedTitle = 'タイムアップ';
+  static const timerFinishedTitle = '散歩タイマー';
   static const timerFinishedMessage = '設定した時間になりました。';
   static const safetyOk = '元気です';
   static const safetyConfirmTitle = '大丈夫ですか？';

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -1222,9 +1222,15 @@ class _ShareAppIcons extends StatelessWidget {
     if (!_checkLink(context)) return;
     final text =
         Uri.encodeComponent('${AppStrings.shareInviteText}\n$inviteLink');
-    final uri = Uri.parse('https://line.me/R/msg/text/?$text');
-    if (await canLaunchUrl(uri)) {
+    final uri = Uri.parse('https://line.me/R/share?text=$text');
+    try {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text(AppStrings.shareError)),
+        );
+      }
     }
   }
 
@@ -1233,17 +1239,27 @@ class _ShareAppIcons extends StatelessWidget {
     final text =
         Uri.encodeComponent('${AppStrings.shareInviteText}\n$inviteLink');
     final uri = Uri.parse('https://x.com/intent/tweet?text=$text');
-    if (await canLaunchUrl(uri)) {
+    try {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text(AppStrings.shareError)),
+        );
+      }
     }
   }
 
   Future<void> _shareToInstagram(BuildContext context) async {
     if (!_checkLink(context)) return;
     await Clipboard.setData(ClipboardData(text: inviteLink!));
-    final instagramUri = Uri.parse('instagram://app');
-    if (await canLaunchUrl(instagramUri)) {
-      await launchUrl(instagramUri, mode: LaunchMode.externalApplication);
+    try {
+      final instagramUri = Uri.parse('instagram://app');
+      if (await canLaunchUrl(instagramUri)) {
+        await launchUrl(instagramUri, mode: LaunchMode.externalApplication);
+      }
+    } catch (_) {
+      // Instagram 未インストール時もクリップボードコピー済みなのでスナックバーを表示
     }
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
@@ -908,7 +909,7 @@ class _ShareCard extends ConsumerWidget {
             ),
           ),
           const SizedBox(height: AppSpacing.x2lmm),
-          const _ShareAppIcons(),
+          _ShareAppIcons(inviteLink: state.inviteLink),
           const SizedBox(height: AppSpacing.x3lp),
           const Center(
             child: Text(
@@ -1205,7 +1206,51 @@ class _ShareLinkArea extends StatelessWidget {
 }
 
 class _ShareAppIcons extends StatelessWidget {
-  const _ShareAppIcons();
+  const _ShareAppIcons({this.inviteLink});
+
+  final String? inviteLink;
+
+  bool _checkLink(BuildContext context) {
+    if (inviteLink != null) return true;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text(AppStrings.shareLinkRequired)),
+    );
+    return false;
+  }
+
+  Future<void> _shareToLine(BuildContext context) async {
+    if (!_checkLink(context)) return;
+    final text =
+        Uri.encodeComponent('${AppStrings.shareInviteText}\n$inviteLink');
+    final uri = Uri.parse('https://line.me/R/msg/text/?$text');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  Future<void> _shareToX(BuildContext context) async {
+    if (!_checkLink(context)) return;
+    final text =
+        Uri.encodeComponent('${AppStrings.shareInviteText}\n$inviteLink');
+    final uri = Uri.parse('https://x.com/intent/tweet?text=$text');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  Future<void> _shareToInstagram(BuildContext context) async {
+    if (!_checkLink(context)) return;
+    await Clipboard.setData(ClipboardData(text: inviteLink!));
+    final instagramUri = Uri.parse('instagram://app');
+    if (await canLaunchUrl(instagramUri)) {
+      await launchUrl(instagramUri, mode: LaunchMode.externalApplication);
+    }
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(AppStrings.shareInstagramCopied)),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1216,19 +1261,19 @@ class _ShareAppIcons extends StatelessWidget {
           assetPath: 'assets/SVG/LINE.png',
           isPng: true,
           label: 'LINE',
-          onTap: () {},
+          onTap: () => _shareToLine(context),
         ),
         _AppIconItem(
           assetPath: 'assets/SVG/Instagram.png',
           isPng: true,
           label: 'Instagram',
-          onTap: () {},
+          onTap: () => _shareToInstagram(context),
         ),
         _AppIconItem(
           assetPath: 'assets/SVG/X.png',
           isPng: true,
           label: 'X',
-          onTap: () {},
+          onTap: () => _shareToX(context),
         ),
       ],
     );


### PR DESCRIPTION
## 📝 説明
設定画面のシェアカードにある LINE・X・Instagram アイコンのシェア機能を実装。
あわせてタイムアップダイアログのタイトルに「散歩タイマー」を追加し、別画面表示中に出たときのコンテキスト不明問題を解消。

## 🔗 関連 Issue
closes #86

## 📋 変更内容
- [x] 機能追加
- [ ] UI 作成
- [x] バグ修正
- [ ] ドキュメント更新
- [ ] その他：

## ✅ チェックリスト
- [ ] コードレビュー済み
- [ ] ユニットテスト実施済み
- [ ] ドキュメント更新済み
- [ ] 自分でテスト確認済み

## 📸 スクリーンショット（UI変更の場合）
<!-- 変更前後の画像を貼り付けてください -->

## 🚀 備考
- **LINE**: 招待テキスト＋リンクを URL エンコードして LINE アプリを起動
- **X**: 同テキストを X アプリ（またはブラウザ）に渡す
- **Instagram**: Instagram は外部からの文字列プリセット不可のため、クリップボードにコピー後アプリを起動しスナックバーで案内
- リンク未生成時はスナックバーで「リンクを先に作成してください」と表示
- iOS: `instagram` スキームを `LSApplicationQueriesSchemes` に追加
- Android: `instagram` スキームを `<queries>` に追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 散歩記録の共有リンクを、LINE・X・Instagramへ共有できるようになりました。
  * Instagram共有時はリンクをコピーし、そのままInstagramを開けます。
  * 共有リンク未作成時に案内メッセージを表示します。
* **改善**
  * タイマー終了時の表示を「散歩タイマー」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->