### PR TITLE
[Feature] #103 Android App Links で https 招待リンクに対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,4 @@ app.*.symbols
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
-!/dev/ci/**/Gemfile.lock
+!/dev/ci/**/Gemfile.lock.firebase/

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,12 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="tekushare" android:host="link"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="tekushare.web.app" android:pathPrefix="/link/"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,38 @@
-{"firestore":{"rules":"firestore.rules"},"flutter":{"platforms":{"android":{"default":{"projectId":"tekushare","appId":"1:607979997790:android:1d1f1528a392b6825742cf","fileOutput":"android/app/google-services.json"}},"dart":{"lib/firebase_options.dart":{"projectId":"tekushare","configurations":{"android":"1:607979997790:android:1d1f1528a392b6825742cf","ios":"1:607979997790:ios:ee2d0ae68448b7155742cf","macos":"1:607979997790:ios:ee2d0ae68448b7155742cf","web":"1:607979997790:web:369bb0b69d7d56025742cf","windows":"1:607979997790:web:ea1b35f8244bb49a5742cf"}}}}}}
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "hosting": {
+    "public": "public",
+    "ignore": ["firebase.json", "**/.*"],
+    "rewrites": [
+      {
+        "source": "/link/**",
+        "destination": "/link/index.html"
+      }
+    ]
+  },
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "tekushare",
+          "appId": "1:607979997790:android:1d1f1528a392b6825742cf",
+          "fileOutput": "android/app/google-services.json"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "tekushare",
+          "configurations": {
+            "android": "1:607979997790:android:1d1f1528a392b6825742cf",
+            "ios": "1:607979997790:ios:ee2d0ae68448b7155742cf",
+            "macos": "1:607979997790:ios:ee2d0ae68448b7155742cf",
+            "web": "1:607979997790:web:369bb0b69d7d56025742cf",
+            "windows": "1:607979997790:web:ea1b35f8244bb49a5742cf"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -57,7 +57,8 @@ service cloud.firestore {
     }
 
     match /accountLinks/{linkId} {
-      allow read: if isSignedIn() && request.auth.uid in resource.data.uids;
+      // resource == null は未作成ドキュメントの存在確認（連携済みチェック）を許可する
+      allow read: if isSignedIn() && (resource == null || request.auth.uid in resource.data.uids);
 
       allow create: if isSignedIn()
         && request.auth.uid in request.resource.data.uids

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -41,12 +41,14 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
     _appLinks.uriLinkStream.listen(_handleUri);
   }
 
-  /// tekushare://link/<token> を受け取り、ログイン済みなら即座に承認画面へ、
+  /// 招待リンクを受け取り、ログイン済みなら即座に承認画面へ、
   /// 未ログインなら pendingInviteTokenProvider に保持してログイン完了後に開く。
+  /// 対応スキーム:
+  ///   - tekushare://link/<token>
+  ///   - https://tekushare.web.app/link/<token>
   void _handleUri(Uri uri) {
-    if (uri.scheme != 'tekushare' || uri.host != 'link') return;
-    if (uri.pathSegments.isEmpty) return;
-    final token = uri.pathSegments.first;
+    final token = _extractToken(uri);
+    if (token == null) return;
     if (!_handledTokens.add(token)) return;
 
     final user = ref.read(authStateProvider).valueOrNull;
@@ -57,6 +59,19 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
     } else {
       ref.read(pendingInviteTokenProvider.notifier).state = token;
     }
+  }
+
+  String? _extractToken(Uri uri) {
+    if (uri.scheme == 'tekushare' && uri.host == 'link') {
+      return uri.pathSegments.isNotEmpty ? uri.pathSegments.first : null;
+    }
+    if (uri.scheme == 'https' &&
+        uri.host == 'tekushare.web.app' &&
+        uri.pathSegments.length >= 2 &&
+        uri.pathSegments[0] == 'link') {
+      return uri.pathSegments[1];
+    }
+    return null;
   }
 
   @override

--- a/lib/data/repositories/account_link_repository_impl.dart
+++ b/lib/data/repositories/account_link_repository_impl.dart
@@ -61,7 +61,7 @@ class AccountLinkRepositoryImpl implements AccountLinkRepository {
       'expiresAt': Timestamp.fromDate(now.add(_inviteValidDuration)),
       'used': false,
     });
-    return 'tekushare://link/${ref.id}';
+    return 'https://tekushare.web.app/link/${ref.id}';
   }
 
   @override

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -49,7 +49,15 @@ class FirebaseAuthServiceImpl implements AuthService {
   @override
   Future<void> signInWithEmail(String email, String password) async {
     try {
-      await _auth.signInWithEmailAndPassword(email: email, password: password);
+      final credential = await _auth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      final user = credential.user;
+      final name = user?.displayName;
+      if (user != null && name != null && name.isNotEmpty) {
+        await _syncUserDoc(user.uid, name);
+      }
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
     }

--- a/lib/screens/pages/account_link/view/accept_invite_page.dart
+++ b/lib/screens/pages/account_link/view/accept_invite_page.dart
@@ -40,7 +40,8 @@ class _AcceptInvitePageState extends ConsumerState<AcceptInvitePage> {
       );
       if (!mounted) return;
       Navigator.pop(context);
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('acceptInvite error: $e\n$st');
       if (!mounted) return;
       setState(() => _accepting = false);
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/pages/account_link/view/accept_invite_page.dart
+++ b/lib/screens/pages/account_link/view/accept_invite_page.dart
@@ -28,14 +28,49 @@ class _AcceptInvitePageState extends ConsumerState<AcceptInvitePage> {
       if (!mounted) return;
       await showDialog<void>(
         context: context,
-        builder: (_) => AlertDialog(
-          content: const Text(AppStrings.acceptInviteSuccessMessage),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text(AppStrings.closeButton),
+        builder: (_) => Dialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.lg),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.x2l,
+              AppSpacing.x3l,
+              AppSpacing.x2l,
+              AppSpacing.x2l,
             ),
-          ],
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  AppStrings.acceptInviteSuccessMessage,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: AppColors.primary,
+                    fontSize: AppTextStyle.lg2,
+                    fontWeight: AppTextStyle.semiBold,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.x2l),
+                SizedBox(
+                  width: double.infinity,
+                  height: AppSpacing.x5l,
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.sm),
+                      ),
+                    ),
+                    child: const Text(AppStrings.closeButton),
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       );
       if (!mounted) return;

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -66,6 +66,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         isDestructive: false,
         onConfirm: () {
           ref.read(walkSessionProvider.notifier).resetWalk();
+          ref.invalidate(settingsViewModelProvider);
           ref.read(authServiceProvider).signOut();
           Navigator.popUntil(context, (route) => route.isFirst);
         },

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,32 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.tekushare",
+      "sha256_cert_fingerprints": [
+        "8C:57:66:69:BC:F2:56:D7:41:40:08:CA:4E:2F:55:47:CC:64:B5:37:B3:01:4E:BF:7C:67:AA:51:75:C8:50:28"
+      ]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.tekushare.dev",
+      "sha256_cert_fingerprints": [
+        "8C:57:66:69:BC:F2:56:D7:41:40:08:CA:4E:2F:55:47:CC:64:B5:37:B3:01:4E:BF:7C:67:AA:51:75:C8:50:28"
+      ]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.tekushare.stg",
+      "sha256_cert_fingerprints": [
+        "8C:57:66:69:BC:F2:56:D7:41:40:08:CA:4E:2F:55:47:CC:64:B5:37:B3:01:4E:BF:7C:67:AA:51:75:C8:50:28"
+      ]
+    }
+  }
+]

--- a/public/link/index.html
+++ b/public/link/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>てくしぇあ - 招待リンク</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #f5f5f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 24px;
+    }
+    .card {
+      background: white;
+      border-radius: 16px;
+      padding: 40px 32px;
+      max-width: 400px;
+      width: 100%;
+      text-align: center;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+    }
+    .icon { font-size: 64px; margin-bottom: 16px; }
+    h1 { font-size: 22px; color: #1a1a1a; margin-bottom: 8px; }
+    p { font-size: 15px; color: #666; line-height: 1.6; margin-bottom: 24px; }
+    .btn {
+      display: block;
+      background: #4CAF87;
+      color: white;
+      text-decoration: none;
+      padding: 14px 24px;
+      border-radius: 12px;
+      font-size: 16px;
+      font-weight: bold;
+      margin-bottom: 12px;
+    }
+    .btn-sub {
+      display: block;
+      color: #4CAF87;
+      text-decoration: none;
+      padding: 12px 24px;
+      border-radius: 12px;
+      font-size: 15px;
+      border: 1.5px solid #4CAF87;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">🚶</div>
+    <h1>てくしぇあへの招待</h1>
+    <p>散歩スポットをシェアするアプリ「てくしぇあ」に招待されました。アプリをインストールして招待を承認してください。</p>
+    <a id="store-link" class="btn" href="https://play.google.com/store/apps/details?id=com.example.tekushare">
+      Google Play でインストール
+    </a>
+    <a id="open-link" class="btn-sub" href="#">アプリを開く</a>
+  </div>
+  <script>
+    const token = location.pathname.split('/').filter(Boolean).pop();
+    const appScheme = 'tekushare://link/' + token;
+    document.getElementById('open-link').href = appScheme;
+
+    // アプリがインストール済みなら即時遷移を試みる
+    const start = Date.now();
+    location.href = appScheme;
+    setTimeout(() => {
+      // アプリが開いていなければ（ページがまだ表示中なら）ストアへ
+      if (Date.now() - start < 2500) {
+        // ページがフォーカスを失っていない = アプリが開かなかった
+      }
+    }, 2000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要

カスタムスキーム `tekushare://link/...` から `https://tekushare.web.app/link/...` に変更し、LINE・SMS などのメッセージアプリでタップできる招待リンクを実現します。

## 変更内容

- **Firebase Hosting** に `assetlinks.json` を配置して Android App Links の認証を設定
- **`AndroidManifest.xml`** に `https://tekushare.web.app/link/` の intent-filter を追加（`autoVerify="true"`）
- **`app.dart`** の `_handleUri` を `https://tekushare.web.app/link/<token>` にも対応
- **`createInviteLink()`** の生成 URL を `https://tekushare.web.app/link/...` に変更
- **フォールバックページ**（`public/link/index.html`）を追加：アプリ未インストール時にブラウザで開き Play Store リンクを表示

## 動作フロー

```
招待リンク送信
  ↓
https://tekushare.web.app/link/{token}
  ↓
アプリインストール済み → Android が直接アプリを起動 → 承認画面へ
アプリ未インストール  → ブラウザでフォールバックページを表示 → Play Store へ
```

## 補足

- iOS Universal Links は Apple Developer Program 加入後に `apple-app-site-association` を追加するだけで対応可能（Dart コードの変更は不要）
- App Links はデバイスへの再インストール後に有効化される（初回インストール時に `assetlinks.json` を検証するため）
- リリースビルド用の署名証明書 SHA-256 は Play Console 登録時に `assetlinks.json` へ追記が必要

## テスト手順

- [ ] アプリをアンインストール → 再インストール
- [ ] 設定画面から招待リンクを生成し、生成される URL が `https://tekushare.web.app/link/...` になっていることを確認
- [ ] LINE / SMS で招待リンクを送信し、タップするとアプリが起動して承認画面が表示されることを確認
- [ ] アプリ未インストール端末でリンクを開き、フォールバックページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 招待リンクがWeb URLに対応し、アプリ未インストール時はGoogle Playへ案内されるようになりました。
  * 招待リンクからアプリを直接起動できるようになりました。
  * Androidのリンク自動検証に対応しました。

* **改善**
  * メールログイン時に表示名がユーザー情報へ同期されるようになりました。
  * ログアウト後、設定情報が最新状態に更新されるようになりました。

* **不具合修正**
  * 招待リンクの存在確認が適切に行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->