### PR TITLE
[UI] 連携スポット詳細の写真グリッドをSpotDetailPageと同じサイズに修正

### DIFF
--- a/lib/screens/pages/settings/view/linked_spot_detail_page.dart
+++ b/lib/screens/pages/settings/view/linked_spot_detail_page.dart
@@ -209,19 +209,19 @@ class _PhotoGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tileSize =
-        (MediaQuery.sizeOf(context).width - AppSpacing.lg * 2 - AppSpacing.sm) /
-            2;
+    final screenW = MediaQuery.sizeOf(context).width;
+    final tileW = (screenW - 32 - AppSpacing.md) / 2;
+    final tileH = AppSizingTheme.of(context).photoBoxHeight;
     return Wrap(
-      spacing: AppSpacing.sm,
-      runSpacing: AppSpacing.sm,
+      spacing: AppSpacing.md,
+      runSpacing: AppSpacing.md,
       children: [
         for (final path in photoPaths)
           ClipRRect(
             borderRadius: BorderRadius.circular(AppRadius.sm),
             child: SizedBox(
-              width: tileSize,
-              height: tileSize,
+              width: tileW,
+              height: tileH,
               child: Image.network(
                 path,
                 fit: BoxFit.cover,


### PR DESCRIPTION
## 概要

#73 マージ後の写真グリッドサイズ修正。

`SpotDetailPage` の `_PhotoBox` に合わせて幅・高さを統一。
- 幅: `(screenW - 32 - AppSpacing.md) / 2`
- 高さ: `sizing.photoBoxHeight`（100px）
- ギャップ: `AppSpacing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 設定画面のリンク済みスポット詳細にある写真タイルの表示サイズを調整しました。
  * 写真の高さを統一し、タイル間の余白を広げて、より見やすいレイアウトに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->