### PR TITLE
[Feature] #111 Firebase Storage で写真を共有できるよう実装

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,10 @@
   "firestore": {
     "rules": "firestore.rules"
   },
+  "storage": {
+    "bucket": "tekushare.firebasestorage.app",
+    "rules": "storage.rules"
+  },
   "hosting": {
     "public": "public",
     "ignore": ["firebase.json", "**/.*"],

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -47,7 +47,8 @@ class _FakeSpotRepository implements SpotRepository {
 
 class _FakePhotoRepository implements PhotoRepository {
   @override
-  Future<void> attachPhoto(String spotId, String imagePath) async {}
+  Future<String> attachPhoto(String spotId, String imagePath) async =>
+      imagePath;
   @override
   Future<void> removePhoto(String spotId, String imagePath) async {}
 }

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -188,4 +188,5 @@ abstract class AppStrings {
   static const acceptInviteSelfMessage = '自分自身のリンクは使用できません。';
   static const acceptInviteAlreadyLinkedMessage = 'すでに連携済みです。';
   static const acceptInviteErrorMessage = '連携に失敗しました。もう一度お試しください。';
+  static const operationError = 'エラーが発生しました。もう一度お試しください。';
 }

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -93,6 +93,7 @@ abstract class AppStrings {
   static const spotDetailSaveButton = '上書き保存';
   static const spotDetailDeleteButton = '削除する';
   static const spotDetailMoveToWentButton = '行った！に保存';
+  static const spotDetailMoveToWentConfirmLabel = '行った！';
   static const spotDetailSaveConfirmMessage = '上書き保存しますか？';
   static const spotDetailDeleteConfirmMessage = '削除しますか？';
   static const spotDetailMoveToWentConfirmMessage = '「行った！」に保存しますか？';

--- a/lib/data/repositories/firestore_photo_repository_impl.dart
+++ b/lib/data/repositories/firestore_photo_repository_impl.dart
@@ -21,17 +21,23 @@ class FirestorePhotoRepositoryImpl implements PhotoRepository {
     final ref = _storage.ref('users/$_uid/spots/$spotId/$fileName');
     await ref.putFile(File(imagePath));
     final url = await ref.getDownloadURL();
-    await _collection.doc(spotId).update({
-      'photoPaths': FieldValue.arrayUnion([url]),
-    });
+    await _collection.doc(spotId).set(
+      {
+        'photoPaths': FieldValue.arrayUnion([url])
+      },
+      SetOptions(merge: true),
+    );
     return url;
   }
 
   @override
   Future<void> removePhoto(String spotId, String imagePath) async {
-    await _collection.doc(spotId).update({
-      'photoPaths': FieldValue.arrayRemove([imagePath]),
-    });
+    await _collection.doc(spotId).set(
+      {
+        'photoPaths': FieldValue.arrayRemove([imagePath])
+      },
+      SetOptions(merge: true),
+    );
     if (imagePath.startsWith('https://')) {
       try {
         await _storage.refFromURL(imagePath).delete();

--- a/lib/data/repositories/firestore_photo_repository_impl.dart
+++ b/lib/data/repositories/firestore_photo_repository_impl.dart
@@ -1,20 +1,30 @@
+import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:tekushare/domain/repositories/photo_repository.dart';
 
 class FirestorePhotoRepositoryImpl implements PhotoRepository {
-  FirestorePhotoRepositoryImpl(this._firestore, this._uid);
+  FirestorePhotoRepositoryImpl(this._firestore, this._storage, this._uid);
 
   final FirebaseFirestore _firestore;
+  final FirebaseStorage _storage;
   final String _uid;
 
   CollectionReference<Map<String, dynamic>> get _collection =>
       _firestore.collection('users').doc(_uid).collection('spots');
 
   @override
-  Future<void> attachPhoto(String spotId, String imagePath) async {
+  Future<String> attachPhoto(String spotId, String imagePath) async {
+    final fileName =
+        '${DateTime.now().millisecondsSinceEpoch}_${imagePath.split('/').last}';
+    final ref = _storage.ref('users/$_uid/spots/$spotId/$fileName');
+    await ref.putFile(File(imagePath));
+    final url = await ref.getDownloadURL();
     await _collection.doc(spotId).update({
-      'photoPaths': FieldValue.arrayUnion([imagePath]),
+      'photoPaths': FieldValue.arrayUnion([url]),
     });
+    return url;
   }
 
   @override
@@ -22,5 +32,12 @@ class FirestorePhotoRepositoryImpl implements PhotoRepository {
     await _collection.doc(spotId).update({
       'photoPaths': FieldValue.arrayRemove([imagePath]),
     });
+    if (imagePath.startsWith('https://')) {
+      try {
+        await _storage.refFromURL(imagePath).delete();
+      } catch (_) {
+        // Storage上に存在しない場合は無視
+      }
+    }
   }
 }

--- a/lib/data/repositories/firestore_spot_repository_impl.dart
+++ b/lib/data/repositories/firestore_spot_repository_impl.dart
@@ -26,7 +26,10 @@ class FirestoreSpotRepositoryImpl implements SpotRepository {
 
   @override
   Future<void> updateSpotStatus(String id, SpotStatus status) async {
-    await _collection.doc(id).update({'status': status.name});
+    await _collection.doc(id).set(
+      {'status': status.name},
+      SetOptions(merge: true),
+    );
   }
 
   @override

--- a/lib/data/repositories/photo_repository_impl.dart
+++ b/lib/data/repositories/photo_repository_impl.dart
@@ -11,7 +11,7 @@ class PhotoRepositoryImpl implements PhotoRepository {
   Future<String> attachPhoto(String spotId, String imagePath) async {
     await _isar.writeTxn(() async {
       final model = await _isar.spotModels.getByUid(spotId);
-      if (model == null) return;
+      if (model == null) throw StateError('Spot not found: $spotId');
       model.photoPaths = [...model.photoPaths, imagePath];
       await _isar.spotModels.put(model);
     });

--- a/lib/data/repositories/photo_repository_impl.dart
+++ b/lib/data/repositories/photo_repository_impl.dart
@@ -8,13 +8,14 @@ class PhotoRepositoryImpl implements PhotoRepository {
   final Isar _isar;
 
   @override
-  Future<void> attachPhoto(String spotId, String imagePath) async {
+  Future<String> attachPhoto(String spotId, String imagePath) async {
     await _isar.writeTxn(() async {
       final model = await _isar.spotModels.getByUid(spotId);
       if (model == null) return;
       model.photoPaths = [...model.photoPaths, imagePath];
       await _isar.spotModels.put(model);
     });
+    return imagePath;
   }
 
   @override

--- a/lib/domain/repositories/photo_repository.dart
+++ b/lib/domain/repositories/photo_repository.dart
@@ -1,4 +1,5 @@
 abstract interface class PhotoRepository {
-  Future<void> attachPhoto(String spotId, String imagePath);
+  /// 写真を Storage にアップロードし、保存した URL を返す
+  Future<String> attachPhoto(String spotId, String imagePath);
   Future<void> removePhoto(String spotId, String imagePath);
 }

--- a/lib/domain/usecases/photo/attach_photo_to_spot.dart
+++ b/lib/domain/usecases/photo/attach_photo_to_spot.dart
@@ -5,7 +5,7 @@ class AttachPhotoToSpot {
 
   final PhotoRepository _repository;
 
-  Future<void> call(String spotId, String imagePath) {
+  Future<String> call(String spotId, String imagePath) {
     return _repository.attachPhoto(spotId, imagePath);
   }
 }

--- a/lib/screens/pages/settings/view/linked_account_detail_page.dart
+++ b/lib/screens/pages/settings/view/linked_account_detail_page.dart
@@ -39,32 +39,37 @@ class LinkedAccountDetailPage extends ConsumerWidget {
         ),
         data: (spots) => SafeArea(
           top: false,
-          child: ListView(
-            padding: const EdgeInsets.all(AppSpacing.lg),
-            children: [
-              const _SectionHeader(label: AppStrings.wantToGo),
-              const SizedBox(height: AppSpacing.sm),
-              if (spots.wantToGoSpots.isEmpty)
-                const _EmptyState(message: AppStrings.linkedAccountSpotsEmpty)
-              else
-                for (final spot in spots.wantToGoSpots)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-                    child: _SpotCard(spot: spot, otherUid: account.uid),
-                  ),
-              const SizedBox(height: AppSpacing.x2lp),
-              const _SectionHeader(label: AppStrings.listWentTab),
-              const SizedBox(height: AppSpacing.sm),
-              if (spots.visitedSpots.isEmpty)
-                const _EmptyState(message: AppStrings.linkedAccountSpotsEmpty)
-              else
-                for (final spot in spots.visitedSpots)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-                    child: _SpotCard(spot: spot, otherUid: account.uid),
-                  ),
-              const SizedBox(height: AppSpacing.lg),
-            ],
+          child: RefreshIndicator(
+            onRefresh: () async =>
+                ref.refresh(linkedAccountSpotsProvider(account.uid).future),
+            color: AppColors.primary,
+            child: ListView(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              children: [
+                const _SectionHeader(label: AppStrings.wantToGo),
+                const SizedBox(height: AppSpacing.sm),
+                if (spots.wantToGoSpots.isEmpty)
+                  const _EmptyState(message: AppStrings.linkedAccountSpotsEmpty)
+                else
+                  for (final spot in spots.wantToGoSpots)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+                      child: _SpotCard(spot: spot),
+                    ),
+                const SizedBox(height: AppSpacing.x2lp),
+                const _SectionHeader(label: AppStrings.listWentTab),
+                const SizedBox(height: AppSpacing.sm),
+                if (spots.visitedSpots.isEmpty)
+                  const _EmptyState(message: AppStrings.linkedAccountSpotsEmpty)
+                else
+                  for (final spot in spots.visitedSpots)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+                      child: _SpotCard(spot: spot),
+                    ),
+                const SizedBox(height: AppSpacing.lg),
+              ],
+            ),
           ),
         ),
       ),
@@ -113,10 +118,9 @@ class _EmptyState extends StatelessWidget {
 }
 
 class _SpotCard extends StatelessWidget {
-  const _SpotCard({required this.spot, required this.otherUid});
+  const _SpotCard({required this.spot});
 
   final Spot spot;
-  final String otherUid;
 
   @override
   Widget build(BuildContext context) {
@@ -126,7 +130,7 @@ class _SpotCard extends StatelessWidget {
       onTap: () => Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => LinkedSpotDetailPage(spot: spot, otherUid: otherUid),
+          builder: (_) => LinkedSpotDetailPage(spot: spot),
         ),
       ),
       child: Container(

--- a/lib/screens/pages/settings/view/linked_account_detail_page.dart
+++ b/lib/screens/pages/settings/view/linked_account_detail_page.dart
@@ -50,7 +50,7 @@ class LinkedAccountDetailPage extends ConsumerWidget {
                 for (final spot in spots.wantToGoSpots)
                   Padding(
                     padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-                    child: _SpotCard(spot: spot),
+                    child: _SpotCard(spot: spot, otherUid: account.uid),
                   ),
               const SizedBox(height: AppSpacing.x2lp),
               const _SectionHeader(label: AppStrings.listWentTab),
@@ -61,7 +61,7 @@ class LinkedAccountDetailPage extends ConsumerWidget {
                 for (final spot in spots.visitedSpots)
                   Padding(
                     padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-                    child: _SpotCard(spot: spot),
+                    child: _SpotCard(spot: spot, otherUid: account.uid),
                   ),
               const SizedBox(height: AppSpacing.lg),
             ],
@@ -113,9 +113,10 @@ class _EmptyState extends StatelessWidget {
 }
 
 class _SpotCard extends StatelessWidget {
-  const _SpotCard({required this.spot});
+  const _SpotCard({required this.spot, required this.otherUid});
 
   final Spot spot;
+  final String otherUid;
 
   @override
   Widget build(BuildContext context) {
@@ -125,7 +126,7 @@ class _SpotCard extends StatelessWidget {
       onTap: () => Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (_) => LinkedSpotDetailPage(spot: spot),
+          builder: (_) => LinkedSpotDetailPage(spot: spot, otherUid: otherUid),
         ),
       ),
       child: Container(

--- a/lib/screens/pages/settings/view/linked_spot_detail_page.dart
+++ b/lib/screens/pages/settings/view/linked_spot_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
@@ -9,20 +10,50 @@ import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/core/constants/map_constants.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/screens/providers/linked_account_spots_provider.dart';
 import 'package:tekushare/screens/widgets/common/photo_viewer_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// 連携アカウントのスポット詳細（読み取り専用）
-class LinkedSpotDetailPage extends StatelessWidget {
-  const LinkedSpotDetailPage({super.key, required this.spot});
+class LinkedSpotDetailPage extends ConsumerStatefulWidget {
+  const LinkedSpotDetailPage({
+    super.key,
+    required this.spot,
+    required this.otherUid,
+  });
 
   final Spot spot;
+  final String otherUid;
+
+  @override
+  ConsumerState<LinkedSpotDetailPage> createState() =>
+      _LinkedSpotDetailPageState();
+}
+
+class _LinkedSpotDetailPageState extends ConsumerState<LinkedSpotDetailPage> {
+  late Spot _spot;
+
+  @override
+  void initState() {
+    super.initState();
+    _spot = widget.spot;
+  }
+
+  Future<void> _onRefresh() async {
+    final data =
+        await ref.refresh(linkedAccountSpotsProvider(widget.otherUid).future);
+    final allSpots = [...data.wantToGoSpots, ...data.visitedSpots];
+    final updated = allSpots.where((s) => s.id == _spot.id).firstOrNull;
+    if (updated != null && mounted) {
+      setState(() => _spot = updated);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final sizing = AppSizingTheme.of(context);
-    final point = LatLng(spot.latitude, spot.longitude);
-    final isWantToGo = spot.status == SpotStatus.wantToGo;
+    final point = LatLng(_spot.latitude, _spot.longitude);
+    final isWantToGo = _spot.status == SpotStatus.wantToGo;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -37,40 +68,45 @@ class LinkedSpotDetailPage extends StatelessWidget {
       body: SafeArea(
         top: false,
         bottom: false,
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.lg,
-            AppSpacing.x4l,
-            AppSpacing.lg,
-            AppSpacing.lg,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _MapArea(
-                  point: point,
-                  latitude: spot.latitude,
-                  longitude: spot.longitude,
-                  photoPaths: spot.photoPaths,
-                  height: sizing.locationAreaHeight * 1.4),
-              SizedBox(height: sizing.sectionSpacing),
-              const _SectionLabel(label: AppStrings.linkedSpotLabelTitle),
-              const SizedBox(height: AppSpacing.xs),
-              _TitleText(title: spot.title),
-              if (spot.category != null && spot.category!.isNotEmpty) ...[
+        child: RefreshIndicator(
+          onRefresh: _onRefresh,
+          color: AppColors.primary,
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              AppSpacing.x4l,
+              AppSpacing.lg,
+              AppSpacing.lg,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _MapArea(
+                    point: point,
+                    latitude: _spot.latitude,
+                    longitude: _spot.longitude,
+                    photoPaths: _spot.photoPaths,
+                    height: sizing.locationAreaHeight * 1.4),
                 SizedBox(height: sizing.sectionSpacing),
-                const _SectionLabel(label: AppStrings.linkedSpotLabelTag),
+                const _SectionLabel(label: AppStrings.linkedSpotLabelTitle),
                 const SizedBox(height: AppSpacing.xs),
-                _CategoryChip(category: spot.category!),
-              ],
-              if (spot.photoPaths.isNotEmpty) ...[
+                _TitleText(title: _spot.title),
+                if (_spot.category != null && _spot.category!.isNotEmpty) ...[
+                  SizedBox(height: sizing.sectionSpacing),
+                  const _SectionLabel(label: AppStrings.linkedSpotLabelTag),
+                  const SizedBox(height: AppSpacing.xs),
+                  _CategoryChip(category: _spot.category!),
+                ],
+                if (_spot.photoPaths.isNotEmpty) ...[
+                  SizedBox(height: sizing.sectionSpacing),
+                  const _SectionLabel(label: AppStrings.linkedSpotLabelPhoto),
+                  const SizedBox(height: AppSpacing.xs),
+                  _PhotoGrid(photoPaths: _spot.photoPaths),
+                ],
                 SizedBox(height: sizing.sectionSpacing),
-                const _SectionLabel(label: AppStrings.linkedSpotLabelPhoto),
-                const SizedBox(height: AppSpacing.xs),
-                _PhotoGrid(photoPaths: spot.photoPaths),
               ],
-              SizedBox(height: sizing.sectionSpacing),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/pages/settings/view/linked_spot_detail_page.dart
+++ b/lib/screens/pages/settings/view/linked_spot_detail_page.dart
@@ -1,7 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
@@ -10,50 +9,20 @@ import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/core/constants/map_constants.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/spot.dart';
-import 'package:tekushare/screens/providers/linked_account_spots_provider.dart';
 import 'package:tekushare/screens/widgets/common/photo_viewer_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// 連携アカウントのスポット詳細（読み取り専用）
-class LinkedSpotDetailPage extends ConsumerStatefulWidget {
-  const LinkedSpotDetailPage({
-    super.key,
-    required this.spot,
-    required this.otherUid,
-  });
+class LinkedSpotDetailPage extends StatelessWidget {
+  const LinkedSpotDetailPage({super.key, required this.spot});
 
   final Spot spot;
-  final String otherUid;
-
-  @override
-  ConsumerState<LinkedSpotDetailPage> createState() =>
-      _LinkedSpotDetailPageState();
-}
-
-class _LinkedSpotDetailPageState extends ConsumerState<LinkedSpotDetailPage> {
-  late Spot _spot;
-
-  @override
-  void initState() {
-    super.initState();
-    _spot = widget.spot;
-  }
-
-  Future<void> _onRefresh() async {
-    final data =
-        await ref.refresh(linkedAccountSpotsProvider(widget.otherUid).future);
-    final allSpots = [...data.wantToGoSpots, ...data.visitedSpots];
-    final updated = allSpots.where((s) => s.id == _spot.id).firstOrNull;
-    if (updated != null && mounted) {
-      setState(() => _spot = updated);
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
     final sizing = AppSizingTheme.of(context);
-    final point = LatLng(_spot.latitude, _spot.longitude);
-    final isWantToGo = _spot.status == SpotStatus.wantToGo;
+    final point = LatLng(spot.latitude, spot.longitude);
+    final isWantToGo = spot.status == SpotStatus.wantToGo;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -68,45 +37,40 @@ class _LinkedSpotDetailPageState extends ConsumerState<LinkedSpotDetailPage> {
       body: SafeArea(
         top: false,
         bottom: false,
-        child: RefreshIndicator(
-          onRefresh: _onRefresh,
-          color: AppColors.primary,
-          child: SingleChildScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.lg,
-              AppSpacing.x4l,
-              AppSpacing.lg,
-              AppSpacing.lg,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _MapArea(
-                    point: point,
-                    latitude: _spot.latitude,
-                    longitude: _spot.longitude,
-                    photoPaths: _spot.photoPaths,
-                    height: sizing.locationAreaHeight * 1.4),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.lg,
+            AppSpacing.x4l,
+            AppSpacing.lg,
+            AppSpacing.lg,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _MapArea(
+                  point: point,
+                  latitude: spot.latitude,
+                  longitude: spot.longitude,
+                  photoPaths: spot.photoPaths,
+                  height: sizing.locationAreaHeight * 1.4),
+              SizedBox(height: sizing.sectionSpacing),
+              const _SectionLabel(label: AppStrings.linkedSpotLabelTitle),
+              const SizedBox(height: AppSpacing.xs),
+              _TitleText(title: spot.title),
+              if (spot.category != null && spot.category!.isNotEmpty) ...[
                 SizedBox(height: sizing.sectionSpacing),
-                const _SectionLabel(label: AppStrings.linkedSpotLabelTitle),
+                const _SectionLabel(label: AppStrings.linkedSpotLabelTag),
                 const SizedBox(height: AppSpacing.xs),
-                _TitleText(title: _spot.title),
-                if (_spot.category != null && _spot.category!.isNotEmpty) ...[
-                  SizedBox(height: sizing.sectionSpacing),
-                  const _SectionLabel(label: AppStrings.linkedSpotLabelTag),
-                  const SizedBox(height: AppSpacing.xs),
-                  _CategoryChip(category: _spot.category!),
-                ],
-                if (_spot.photoPaths.isNotEmpty) ...[
-                  SizedBox(height: sizing.sectionSpacing),
-                  const _SectionLabel(label: AppStrings.linkedSpotLabelPhoto),
-                  const SizedBox(height: AppSpacing.xs),
-                  _PhotoGrid(photoPaths: _spot.photoPaths),
-                ],
-                SizedBox(height: sizing.sectionSpacing),
+                _CategoryChip(category: spot.category!),
               ],
-            ),
+              if (spot.photoPaths.isNotEmpty) ...[
+                SizedBox(height: sizing.sectionSpacing),
+                const _SectionLabel(label: AppStrings.linkedSpotLabelPhoto),
+                const SizedBox(height: AppSpacing.xs),
+                _PhotoGrid(photoPaths: spot.photoPaths),
+              ],
+              SizedBox(height: sizing.sectionSpacing),
+            ],
           ),
         ),
       ),

--- a/lib/screens/pages/settings/view/linked_spot_detail_page.dart
+++ b/lib/screens/pages/settings/view/linked_spot_detail_page.dart
@@ -148,6 +148,19 @@ class _MapArea extends StatelessWidget {
                           width: MapConstants.photoThumbnailSize,
                           height: MapConstants.photoThumbnailSize,
                           fit: BoxFit.cover,
+                          placeholder: (_, __) => const ColoredBox(
+                            color: AppColors.chipUnselected,
+                            child: Center(
+                              child: SizedBox(
+                                width: AppSize.iconSm,
+                                height: AppSize.iconSm,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 1.5,
+                                  color: AppColors.primary,
+                                ),
+                              ),
+                            ),
+                          ),
                           errorWidget: (_, __, ___) => const ColoredBox(
                             color: AppColors.textDisabled,
                             child: Icon(
@@ -257,6 +270,10 @@ class _PhotoGrid extends StatelessWidget {
                 width: tileW,
                 height: tileH,
                 fit: BoxFit.cover,
+                placeholder: (_, __) => const ColoredBox(
+                  color: AppColors.chipUnselected,
+                  child: Center(child: CircularProgressIndicator()),
+                ),
                 errorWidget: (_, __, ___) => const ColoredBox(
                   color: AppColors.chipUnselected,
                   child: Icon(Icons.photo, color: AppColors.textDisabled),

--- a/lib/screens/pages/settings/view/linked_spot_detail_page.dart
+++ b/lib/screens/pages/settings/view/linked_spot_detail_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -8,6 +9,7 @@ import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/core/constants/map_constants.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/screens/widgets/common/photo_viewer_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// 連携アカウントのスポット詳細（読み取り専用）
@@ -49,6 +51,7 @@ class LinkedSpotDetailPage extends StatelessWidget {
                   point: point,
                   latitude: spot.latitude,
                   longitude: spot.longitude,
+                  photoPaths: spot.photoPaths,
                   height: sizing.locationAreaHeight * 1.4),
               SizedBox(height: sizing.sectionSpacing),
               const _SectionLabel(label: AppStrings.linkedSpotLabelTitle),
@@ -80,12 +83,14 @@ class _MapArea extends StatelessWidget {
     required this.point,
     required this.latitude,
     required this.longitude,
+    required this.photoPaths,
     required this.height,
   });
 
   final LatLng point;
   final double latitude;
   final double longitude;
+  final List<String> photoPaths;
   final double height;
 
   @override
@@ -119,16 +124,42 @@ class _MapArea extends StatelessWidget {
             ),
             MarkerLayer(
               markers: [
-                Marker(
-                  point: point,
-                  width: AppSize.iconLg,
-                  height: AppSize.iconLg,
-                  child: const Icon(
-                    Icons.location_on,
-                    color: AppColors.primary,
-                    size: AppSize.iconLg,
+                if (photoPaths.isEmpty)
+                  Marker(
+                    point: point,
+                    width: AppSize.iconLg,
+                    height: AppSize.iconLg,
+                    child: const Icon(
+                      Icons.location_on,
+                      color: AppColors.primary,
+                      size: AppSize.iconLg,
+                    ),
                   ),
-                ),
+                for (final path in photoPaths)
+                  Marker(
+                    point: point,
+                    width: MapConstants.photoThumbnailSize,
+                    height: MapConstants.photoThumbnailSize,
+                    child: GestureDetector(
+                      onTap: () => showPhotoViewer(context, path),
+                      child: ClipOval(
+                        child: CachedNetworkImage(
+                          imageUrl: path,
+                          width: MapConstants.photoThumbnailSize,
+                          height: MapConstants.photoThumbnailSize,
+                          fit: BoxFit.cover,
+                          errorWidget: (_, __, ___) => const ColoredBox(
+                            color: AppColors.textDisabled,
+                            child: Icon(
+                              Icons.photo,
+                              color: Colors.white,
+                              size: AppSize.iconSm,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
               ],
             ),
           ],
@@ -217,15 +248,16 @@ class _PhotoGrid extends StatelessWidget {
       runSpacing: AppSpacing.md,
       children: [
         for (final path in photoPaths)
-          ClipRRect(
-            borderRadius: BorderRadius.circular(AppRadius.sm),
-            child: SizedBox(
-              width: tileW,
-              height: tileH,
-              child: Image.network(
-                path,
+          GestureDetector(
+            onTap: () => showPhotoViewer(context, path),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(AppRadius.sm),
+              child: CachedNetworkImage(
+                imageUrl: path,
+                width: tileW,
+                height: tileH,
                 fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => const ColoredBox(
+                errorWidget: (_, __, ___) => const ColoredBox(
                   color: AppColors.chipUnselected,
                   child: Icon(Icons.photo, color: AppColors.textDisabled),
                 ),

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -144,7 +144,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
       builder: (_) => AppConfirmDialog(
         title: title,
         message: AppStrings.spotDetailMoveToWentConfirmMessage,
-        confirmLabel: AppStrings.spotDetailMoveToWentButton,
+        confirmLabel: AppStrings.spotDetailMoveToWentConfirmLabel,
         confirmColor: AppColors.listSelected,
         onConfirm: () => _runWithLoading(
           () => notifier.updateSpot(
@@ -345,6 +345,19 @@ class _LocationArea extends StatelessWidget {
                           width: MapConstants.photoThumbnailSize,
                           height: MapConstants.photoThumbnailSize,
                           fit: BoxFit.cover,
+                          placeholder: (_, __) => const ColoredBox(
+                            color: AppColors.chipUnselected,
+                            child: Center(
+                              child: SizedBox(
+                                width: AppSize.iconSm,
+                                height: AppSize.iconSm,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 1.5,
+                                  color: AppColors.primary,
+                                ),
+                              ),
+                            ),
+                          ),
                           errorWidget: (_, __, ___) => const ColoredBox(
                             color: AppColors.textDisabled,
                             child: Icon(
@@ -440,6 +453,10 @@ class _PhotoBox extends StatelessWidget {
                     width: tileW,
                     height: tileH,
                     fit: BoxFit.cover,
+                    placeholder: (_, __) => const ColoredBox(
+                      color: AppColors.chipUnselected,
+                      child: Center(child: CircularProgressIndicator()),
+                    ),
                     errorWidget: (_, __, ___) => _placeholder(sizing),
                   ),
                 ),

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -68,9 +68,10 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
   }
 
   Future<void> _onPhotoTap() async {
-    final path = await ref.read(cameraServiceProvider).takePhoto();
-    if (path == null || !mounted) return;
+    final camera = ref.read(cameraServiceProvider);
     final notifier = ref.read(spotProvider.notifier);
+    final path = await camera.takePhoto();
+    if (path == null || !mounted) return;
     final url = await notifier.attachPhoto(widget.spot.id, path);
     if (!mounted) return;
     setState(() => _photoPaths = [..._photoPaths, url]);
@@ -93,6 +94,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         ? AppStrings.noTitle
         : _titleController.text;
     final category = ref.read(spotDetailViewModelProvider).selectedCategory;
+    final notifier = ref.read(spotProvider.notifier);
     showDialog<void>(
       context: context,
       builder: (_) => AppConfirmDialog(
@@ -101,9 +103,9 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         confirmLabel: AppStrings.saveButton,
         onConfirm: () async {
           Navigator.pop(context);
-          await ref.read(spotProvider.notifier).updateSpot(
-                widget.spot.copyWith(title: title, category: category),
-              );
+          await notifier.updateSpot(
+            widget.spot.copyWith(title: title, category: category),
+          );
           if (!mounted) return;
           _showResultDialog(AppStrings.saved);
         },
@@ -113,6 +115,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
   }
 
   void _onDeletePressed() {
+    final notifier = ref.read(spotProvider.notifier);
     showDialog<void>(
       context: context,
       builder: (_) => AppConfirmDialog(
@@ -124,7 +127,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         isDestructive: true,
         onConfirm: () async {
           Navigator.pop(context);
-          await ref.read(spotProvider.notifier).deleteSpot(widget.spot.id);
+          await notifier.deleteSpot(widget.spot.id);
           if (!mounted) return;
           _showResultDialog(AppStrings.spotDetailDeleted);
         },
@@ -138,6 +141,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         ? AppStrings.noTitle
         : _titleController.text;
     final category = ref.read(spotDetailViewModelProvider).selectedCategory;
+    final notifier = ref.read(spotProvider.notifier);
     showDialog<void>(
       context: context,
       builder: (_) => AppConfirmDialog(
@@ -147,13 +151,13 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         confirmColor: AppColors.listSelected,
         onConfirm: () async {
           Navigator.pop(context);
-          await ref.read(spotProvider.notifier).updateSpot(
-                widget.spot.copyWith(
-                  title: title,
-                  status: SpotStatus.visited,
-                  category: category,
-                ),
-              );
+          await notifier.updateSpot(
+            widget.spot.copyWith(
+              title: title,
+              status: SpotStatus.visited,
+              category: category,
+            ),
+          );
           if (!mounted) return;
           _showResultDialog(AppStrings.spotDetailMoveToWentDone);
         },

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -70,14 +70,16 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
   Future<void> _onPhotoTap() async {
     final path = await ref.read(cameraServiceProvider).takePhoto();
     if (path == null || !mounted) return;
-    final url =
-        await ref.read(spotProvider.notifier).attachPhoto(widget.spot.id, path);
+    final notifier = ref.read(spotProvider.notifier);
+    final url = await notifier.attachPhoto(widget.spot.id, path);
     if (!mounted) return;
     setState(() => _photoPaths = [..._photoPaths, url]);
   }
 
   Future<void> _onPhotoDelete(String path) async {
-    await ref.read(spotProvider.notifier).removePhoto(widget.spot.id, path);
+    if (!mounted) return;
+    final notifier = ref.read(spotProvider.notifier);
+    await notifier.removePhoto(widget.spot.id, path);
     if (!mounted) return;
     setState(() => _photoPaths = _photoPaths.where((p) => p != path).toList());
   }

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -72,9 +70,10 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
   Future<void> _onPhotoTap() async {
     final path = await ref.read(cameraServiceProvider).takePhoto();
     if (path == null || !mounted) return;
-    await ref.read(spotProvider.notifier).attachPhoto(widget.spot.id, path);
+    final url =
+        await ref.read(spotProvider.notifier).attachPhoto(widget.spot.id, path);
     if (!mounted) return;
-    setState(() => _photoPaths = [..._photoPaths, path]);
+    setState(() => _photoPaths = [..._photoPaths, url]);
   }
 
   Future<void> _onPhotoDelete(String path) async {
@@ -326,8 +325,8 @@ class _LocationArea extends StatelessWidget {
                     width: MapConstants.photoThumbnailSize,
                     height: MapConstants.photoThumbnailSize,
                     child: ClipOval(
-                      child: Image.file(
-                        File(path),
+                      child: Image.network(
+                        path,
                         width: MapConstants.photoThumbnailSize,
                         height: MapConstants.photoThumbnailSize,
                         fit: BoxFit.cover,
@@ -423,8 +422,8 @@ class _PhotoBox extends StatelessWidget {
                   child: SizedBox(
                     width: tileW,
                     height: tileH,
-                    child: Image.file(
-                      File(path),
+                    child: Image.network(
+                      path,
                       fit: BoxFit.cover,
                       errorBuilder: (_, __, ___) => _placeholder(sizing),
                     ),

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -124,10 +124,30 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         message: AppStrings.spotDetailDeleteConfirmMessage,
         confirmLabel: AppStrings.spotDetailDeleteButton,
         isDestructive: true,
-        onConfirm: () => _runWithLoading(
-          () => notifier.deleteSpot(widget.spot.id),
-          AppStrings.spotDetailDeleted,
-        ),
+        onConfirm: () async {
+          Navigator.pop(context); // 確認ダイアログを閉じる
+          showDialog<void>(
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => const PopScope(
+              canPop: false,
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          );
+          await notifier.deleteSpot(widget.spot.id);
+          if (!mounted) return;
+          Navigator.pop(context); // ローディングを閉じる
+          showDialog<void>(
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => _DeletedDialog(
+              onClose: () {
+                Navigator.pop(context); // ダイアログを閉じる
+                Navigator.pop(context); // リストへ戻る
+              },
+            ),
+          );
+        },
         onCancel: () => Navigator.pop(context),
       ),
     );
@@ -635,6 +655,63 @@ class _SaveButton extends StatelessWidget {
             fontSize: sizing.detailBtnFontSize,
             fontWeight: FontWeight.w500,
           ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 削除完了ダイアログ
+// ──────────────────────────────────────────
+
+class _DeletedDialog extends StatelessWidget {
+  const _DeletedDialog({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x2l,
+        vertical: AppSpacing.x2l,
+      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          28,
+          AppSpacing.lg,
+          AppSpacing.xl,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              AppStrings.spotDetailDeleted,
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: onClose,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text(AppStrings.closeButton),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -691,7 +691,7 @@ class _DeletedDialog extends StatelessWidget {
             const Text(
               AppStrings.spotDetailDeleted,
               style: TextStyle(
-                color: AppColors.primary,
+                color: AppColors.textPrimary,
                 fontSize: AppTextStyle.lg2,
                 fontWeight: FontWeight.w600,
               ),

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -87,7 +87,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
   }
 
   void _onPhotoExpand(String path) {
-    showPhotoViewer(context, path, () => _onPhotoDelete(path));
+    showPhotoViewer(context, path, onDelete: () => _onPhotoDelete(path));
   }
 
   void _onSavePressed() {
@@ -102,12 +102,12 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         title: title,
         message: AppStrings.spotDetailSaveConfirmMessage,
         confirmLabel: AppStrings.saveButton,
-        onConfirm: () {
-          notifier.updateSpot(
+        onConfirm: () => _runWithLoading(
+          () => notifier.updateSpot(
             widget.spot.copyWith(title: title, category: category),
-          );
-          _popWithSnackBar(AppStrings.saved);
-        },
+          ),
+          AppStrings.saved,
+        ),
         onCancel: () => Navigator.pop(context),
       ),
     );
@@ -124,10 +124,10 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         message: AppStrings.spotDetailDeleteConfirmMessage,
         confirmLabel: AppStrings.spotDetailDeleteButton,
         isDestructive: true,
-        onConfirm: () {
-          notifier.deleteSpot(widget.spot.id);
-          _popWithSnackBar(AppStrings.spotDetailDeleted);
-        },
+        onConfirm: () => _runWithLoading(
+          () => notifier.deleteSpot(widget.spot.id),
+          AppStrings.spotDetailDeleted,
+        ),
         onCancel: () => Navigator.pop(context),
       ),
     );
@@ -146,24 +146,39 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         message: AppStrings.spotDetailMoveToWentConfirmMessage,
         confirmLabel: AppStrings.spotDetailMoveToWentButton,
         confirmColor: AppColors.listSelected,
-        onConfirm: () {
-          notifier.updateSpot(
+        onConfirm: () => _runWithLoading(
+          () => notifier.updateSpot(
             widget.spot.copyWith(
               title: title,
               status: SpotStatus.visited,
               category: category,
             ),
-          );
-          _popWithSnackBar(AppStrings.spotDetailMoveToWentDone);
-        },
+          ),
+          AppStrings.spotDetailMoveToWentDone,
+        ),
         onCancel: () => Navigator.pop(context),
       ),
     );
   }
 
-  void _popWithSnackBar(String message) {
-    final messenger = ScaffoldMessenger.of(context);
+  /// 確認ダイアログを閉じ→ローディング表示→操作完了→ページバック+SnackBar
+  Future<void> _runWithLoading(
+    Future<void> Function() operation,
+    String message,
+  ) async {
     Navigator.pop(context); // 確認ダイアログを閉じる
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const PopScope(
+        canPop: false,
+        child: Center(child: CircularProgressIndicator()),
+      ),
+    );
+    await operation();
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    Navigator.pop(context); // ローディングを閉じる
     Navigator.pop(context); // 詳細ページから戻る
     messenger.showSnackBar(SnackBar(content: Text(message)));
   }

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -102,12 +103,10 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         message: AppStrings.spotDetailSaveConfirmMessage,
         confirmLabel: AppStrings.saveButton,
         onConfirm: () {
-          Navigator.pop(context);
           notifier.updateSpot(
             widget.spot.copyWith(title: title, category: category),
           );
-          if (!mounted) return;
-          _showResultDialog(AppStrings.saved);
+          _popWithSnackBar(AppStrings.saved);
         },
         onCancel: () => Navigator.pop(context),
       ),
@@ -126,10 +125,8 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         confirmLabel: AppStrings.spotDetailDeleteButton,
         isDestructive: true,
         onConfirm: () {
-          Navigator.pop(context);
           notifier.deleteSpot(widget.spot.id);
-          if (!mounted) return;
-          _showResultDialog(AppStrings.spotDetailDeleted);
+          _popWithSnackBar(AppStrings.spotDetailDeleted);
         },
         onCancel: () => Navigator.pop(context),
       ),
@@ -150,7 +147,6 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         confirmLabel: AppStrings.spotDetailMoveToWentButton,
         confirmColor: AppColors.listSelected,
         onConfirm: () {
-          Navigator.pop(context);
           notifier.updateSpot(
             widget.spot.copyWith(
               title: title,
@@ -158,25 +154,18 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
               category: category,
             ),
           );
-          if (!mounted) return;
-          _showResultDialog(AppStrings.spotDetailMoveToWentDone);
+          _popWithSnackBar(AppStrings.spotDetailMoveToWentDone);
         },
         onCancel: () => Navigator.pop(context),
       ),
     );
   }
 
-  void _showResultDialog(String message) {
-    showDialog<void>(
-      context: context,
-      builder: (_) => _ResultDialog(
-        message: message,
-        onClose: () {
-          Navigator.pop(context);
-          Navigator.pop(context);
-        },
-      ),
-    );
+  void _popWithSnackBar(String message) {
+    final messenger = ScaffoldMessenger.of(context);
+    Navigator.pop(context); // 確認ダイアログを閉じる
+    Navigator.pop(context); // 詳細ページから戻る
+    messenger.showSnackBar(SnackBar(content: Text(message)));
   }
 
   @override
@@ -336,12 +325,12 @@ class _LocationArea extends StatelessWidget {
                     child: GestureDetector(
                       onTap: () => onPhotoExpand?.call(path),
                       child: ClipOval(
-                        child: Image.network(
-                          path,
+                        child: CachedNetworkImage(
+                          imageUrl: path,
                           width: MapConstants.photoThumbnailSize,
                           height: MapConstants.photoThumbnailSize,
                           fit: BoxFit.cover,
-                          errorBuilder: (_, __, ___) => const ColoredBox(
+                          errorWidget: (_, __, ___) => const ColoredBox(
                             color: AppColors.textDisabled,
                             child: Icon(
                               Icons.photo,
@@ -431,14 +420,12 @@ class _PhotoBox extends StatelessWidget {
                 onTap: () => onExpand(path),
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(AppRadius.sm),
-                  child: SizedBox(
+                  child: CachedNetworkImage(
+                    imageUrl: path,
                     width: tileW,
                     height: tileH,
-                    child: Image.network(
-                      path,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => _placeholder(sizing),
-                    ),
+                    fit: BoxFit.cover,
+                    errorWidget: (_, __, ___) => _placeholder(sizing),
                   ),
                 ),
               ),
@@ -616,55 +603,6 @@ class _SaveButton extends StatelessWidget {
             fontSize: sizing.detailBtnFontSize,
             fontWeight: FontWeight.w500,
           ),
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 完了ダイアログ（保存・削除共通）
-// ──────────────────────────────────────────
-
-class _ResultDialog extends StatelessWidget {
-  const _ResultDialog({required this.message, required this.onClose});
-
-  final String message;
-  final VoidCallback onClose;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              message,
-              style: const TextStyle(
-                fontSize: AppTextStyle.lg2,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 24),
-            SizedBox(
-              width: double.infinity,
-              height: AppSizingTheme.of(context).dialogBtnHeight,
-              child: ElevatedButton(
-                onPressed: onClose,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.primary,
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-                child: const Text(AppStrings.closeButton),
-              ),
-            ),
-          ],
         ),
       ),
     );

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -134,7 +134,16 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
               child: Center(child: CircularProgressIndicator()),
             ),
           );
-          await notifier.deleteSpot(widget.spot.id);
+          try {
+            await notifier.deleteSpot(widget.spot.id);
+          } catch (_) {
+            if (!mounted) return;
+            Navigator.pop(context); // ローディングを閉じる
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text(AppStrings.operationError)),
+            );
+            return;
+          }
           if (!mounted) return;
           Navigator.pop(context); // ローディングを閉じる
           showDialog<void>(
@@ -195,7 +204,16 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         child: Center(child: CircularProgressIndicator()),
       ),
     );
-    await operation();
+    try {
+      await operation();
+    } catch (_) {
+      if (!mounted) return;
+      Navigator.pop(context); // ローディングを閉じる
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(AppStrings.operationError)),
+      );
+      return;
+    }
     if (!mounted) return;
     final messenger = ScaffoldMessenger.of(context);
     Navigator.pop(context); // ローディングを閉じる

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -101,9 +101,9 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         title: title,
         message: AppStrings.spotDetailSaveConfirmMessage,
         confirmLabel: AppStrings.saveButton,
-        onConfirm: () async {
+        onConfirm: () {
           Navigator.pop(context);
-          await notifier.updateSpot(
+          notifier.updateSpot(
             widget.spot.copyWith(title: title, category: category),
           );
           if (!mounted) return;
@@ -125,9 +125,9 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         message: AppStrings.spotDetailDeleteConfirmMessage,
         confirmLabel: AppStrings.spotDetailDeleteButton,
         isDestructive: true,
-        onConfirm: () async {
+        onConfirm: () {
           Navigator.pop(context);
-          await notifier.deleteSpot(widget.spot.id);
+          notifier.deleteSpot(widget.spot.id);
           if (!mounted) return;
           _showResultDialog(AppStrings.spotDetailDeleted);
         },
@@ -149,9 +149,9 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
         message: AppStrings.spotDetailMoveToWentConfirmMessage,
         confirmLabel: AppStrings.spotDetailMoveToWentButton,
         confirmColor: AppColors.listSelected,
-        onConfirm: () async {
+        onConfirm: () {
           Navigator.pop(context);
-          await notifier.updateSpot(
+          notifier.updateSpot(
             widget.spot.copyWith(
               title: title,
               status: SpotStatus.visited,
@@ -208,7 +208,8 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
               _LocationArea(
                 latitude: widget.spot.latitude,
                 longitude: widget.spot.longitude,
-                photoPaths: widget.spot.photoPaths,
+                photoPaths: _photoPaths,
+                onPhotoExpand: _onPhotoExpand,
               ),
               SizedBox(height: AppSizingTheme.of(context).sectionSpacing),
               CategoryChipGroup(
@@ -274,11 +275,13 @@ class _LocationArea extends StatelessWidget {
     required this.latitude,
     required this.longitude,
     required this.photoPaths,
+    this.onPhotoExpand,
   });
 
   final double latitude;
   final double longitude;
   final List<String> photoPaths;
+  final void Function(String path)? onPhotoExpand;
 
   @override
   Widget build(BuildContext context) {
@@ -330,18 +333,21 @@ class _LocationArea extends StatelessWidget {
                     point: point,
                     width: MapConstants.photoThumbnailSize,
                     height: MapConstants.photoThumbnailSize,
-                    child: ClipOval(
-                      child: Image.network(
-                        path,
-                        width: MapConstants.photoThumbnailSize,
-                        height: MapConstants.photoThumbnailSize,
-                        fit: BoxFit.cover,
-                        errorBuilder: (_, __, ___) => const ColoredBox(
-                          color: AppColors.textDisabled,
-                          child: Icon(
-                            Icons.photo,
-                            color: Colors.white,
-                            size: AppSize.iconSm,
+                    child: GestureDetector(
+                      onTap: () => onPhotoExpand?.call(path),
+                      child: ClipOval(
+                        child: Image.network(
+                          path,
+                          width: MapConstants.photoThumbnailSize,
+                          height: MapConstants.photoThumbnailSize,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => const ColoredBox(
+                            color: AppColors.textDisabled,
+                            child: Icon(
+                              Icons.photo,
+                              color: Colors.white,
+                              size: AppSize.iconSm,
+                            ),
                           ),
                         ),
                       ),

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -82,34 +82,36 @@ class _WantToGoPageState extends ConsumerState<WantToGoPage> {
       builder: (_) => _ConfirmDialog(
         title: title,
         onConfirm: () async {
-          Navigator.pop(context);
-          final spotId = await ref.read(spotProvider.notifier).saveSpot(
-                title: title,
-                latitude: location.latitude,
-                longitude: location.longitude,
-                category: category,
-              );
+          final notifier = ref.read(spotProvider.notifier);
+          Navigator.pop(context); // 確認ダイアログを閉じる
+          showDialog<void>(
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => const PopScope(
+              canPop: false,
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          );
+          final spotId = await notifier.saveSpot(
+            title: title,
+            latitude: location.latitude,
+            longitude: location.longitude,
+            category: category,
+          );
           final photos = ref.read(pendingPhotoProvider);
           for (final photo in photos) {
-            await ref.read(spotProvider.notifier).attachPhoto(spotId, photo);
+            await notifier.attachPhoto(spotId, photo);
           }
           ref.read(pendingPhotoProvider.notifier).state = [];
           if (!mounted) return;
-          _showSavedDialog();
+          final messenger = ScaffoldMessenger.of(context);
+          Navigator.pop(context); // ローディングを閉じる
+          Navigator.pop(context); // 行きたいリストへ戻る
+          messenger.showSnackBar(
+            const SnackBar(content: Text(AppStrings.saved)),
+          );
         },
         onCancel: () => Navigator.pop(context),
-      ),
-    );
-  }
-
-  void _showSavedDialog() {
-    showDialog<void>(
-      context: context,
-      builder: (_) => _SavedDialog(
-        onClose: () {
-          Navigator.pop(context); // ダイアログを閉じる
-          Navigator.pop(context); // 行きたいリストへ戻る
-        },
       ),
     );
   }
@@ -548,52 +550,6 @@ class _ConfirmDialog extends StatelessWidget {
                   ),
                 ),
               ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ──────────────────────────────────────────
-// 保存完了ダイアログ
-// ──────────────────────────────────────────
-
-class _SavedDialog extends StatelessWidget {
-  const _SavedDialog({required this.onClose});
-
-  final VoidCallback onClose;
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              AppStrings.saved,
-              style: TextStyle(
-                  fontSize: AppTextStyle.lg2, fontWeight: FontWeight.w500),
-            ),
-            const SizedBox(height: 24),
-            SizedBox(
-              width: double.infinity,
-              height: AppSizingTheme.of(context).dialogBtnHeight,
-              child: ElevatedButton(
-                onPressed: onClose,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.primary,
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-                child: const Text(AppStrings.closeButton),
-              ),
             ),
           ],
         ),

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -92,17 +92,26 @@ class _WantToGoPageState extends ConsumerState<WantToGoPage> {
               child: Center(child: CircularProgressIndicator()),
             ),
           );
-          final spotId = await notifier.saveSpot(
-            title: title,
-            latitude: location.latitude,
-            longitude: location.longitude,
-            category: category,
-          );
-          final photos = ref.read(pendingPhotoProvider);
-          for (final photo in photos) {
-            await notifier.attachPhoto(spotId, photo);
+          try {
+            final spotId = await notifier.saveSpot(
+              title: title,
+              latitude: location.latitude,
+              longitude: location.longitude,
+              category: category,
+            );
+            final photos = ref.read(pendingPhotoProvider);
+            for (final photo in photos) {
+              await notifier.attachPhoto(spotId, photo);
+            }
+            ref.read(pendingPhotoProvider.notifier).state = [];
+          } catch (_) {
+            if (!mounted) return;
+            Navigator.pop(context); // ローディングを閉じる
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text(AppStrings.operationError)),
+            );
+            return;
           }
-          ref.read(pendingPhotoProvider.notifier).state = [];
           if (!mounted) return;
           Navigator.pop(context); // ローディングを閉じる
           showDialog<void>(

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -62,7 +62,7 @@ class _WantToGoPageState extends ConsumerState<WantToGoPage> {
   }
 
   void _onPhotoExpand(String path) {
-    showPhotoViewer(context, path, () => _onPhotoDelete(path));
+    showPhotoViewer(context, path, onDelete: () => _onPhotoDelete(path));
   }
 
   void _onSavePressed() {

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -504,7 +504,7 @@ class _SavedDialog extends StatelessWidget {
             const Text(
               AppStrings.saved,
               style: TextStyle(
-                color: AppColors.primary,
+                color: AppColors.textPrimary,
                 fontSize: AppTextStyle.lg2,
                 fontWeight: FontWeight.w600,
               ),

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -104,11 +104,16 @@ class _WantToGoPageState extends ConsumerState<WantToGoPage> {
           }
           ref.read(pendingPhotoProvider.notifier).state = [];
           if (!mounted) return;
-          final messenger = ScaffoldMessenger.of(context);
           Navigator.pop(context); // ローディングを閉じる
-          Navigator.pop(context); // 行きたいリストへ戻る
-          messenger.showSnackBar(
-            const SnackBar(content: Text(AppStrings.saved)),
+          showDialog<void>(
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => _SavedDialog(
+              onClose: () {
+                Navigator.pop(context); // ダイアログを閉じる
+                Navigator.popUntil(context, (route) => route.isFirst);
+              },
+            ),
           );
         },
         onCancel: () => Navigator.pop(context),
@@ -463,6 +468,63 @@ class _SaveButton extends StatelessWidget {
             fontSize: sizing.detailBtnFontSize,
             fontWeight: FontWeight.w500,
           ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 保存完了ダイアログ
+// ──────────────────────────────────────────
+
+class _SavedDialog extends StatelessWidget {
+  const _SavedDialog({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x2l,
+        vertical: AppSpacing.x2l,
+      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          28,
+          AppSpacing.lg,
+          AppSpacing.xl,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              AppStrings.saved,
+              style: TextStyle(
+                color: AppColors.primary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: onClose,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text(AppStrings.closeButton),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/providers/app_providers.dart
+++ b/lib/screens/providers/app_providers.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
@@ -61,7 +62,11 @@ final savedRouteRepositoryProvider = Provider<SavedRouteRepository>((ref) {
 
 final photoRepositoryProvider = Provider<PhotoRepository>((ref) {
   final uid = ref.watch(authStateProvider).value?.uid ?? '';
-  return FirestorePhotoRepositoryImpl(FirebaseFirestore.instance, uid);
+  return FirestorePhotoRepositoryImpl(
+    FirebaseFirestore.instance,
+    FirebaseStorage.instance,
+    uid,
+  );
 });
 
 final contactRepositoryProvider = Provider<ContactRepository>((ref) {

--- a/lib/screens/providers/spot_provider.dart
+++ b/lib/screens/providers/spot_provider.dart
@@ -64,7 +64,7 @@ class SpotNotifier extends StateNotifier<List<Spot>> {
     return _updateSpotStatus.call(spotId, status);
   }
 
-  Future<void> attachPhoto(String spotId, String imagePath) {
+  Future<String> attachPhoto(String spotId, String imagePath) {
     return _attachPhotoToSpot.call(spotId, imagePath);
   }
 

--- a/lib/screens/widgets/common/photo_viewer_dialog.dart
+++ b/lib/screens/widgets/common/photo_viewer_dialog.dart
@@ -5,12 +5,13 @@ import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
 import 'package:tekushare/core/constants/map_constants.dart';
 
-/// 写真をフルスクリーンで表示し、削除も行えるビューアーを開く
+/// 写真をフルスクリーンで表示するビューアーを開く。
+/// [onDelete] を渡すと削除ボタンを表示する。
 void showPhotoViewer(
   BuildContext context,
-  String path,
-  void Function() onDelete,
-) {
+  String path, {
+  void Function()? onDelete,
+}) {
   showDialog<void>(
     context: context,
     barrierColor: Colors.black87,
@@ -63,31 +64,32 @@ void showPhotoViewer(
                 ),
               ),
             ),
-            Positioned(
-              bottom: AppSpacing.x2l,
-              left: 0,
-              right: 0,
-              child: Center(
-                child: TextButton.icon(
-                  onPressed: () {
-                    Navigator.pop(ctx);
-                    onDelete();
-                  },
-                  icon: const Icon(
-                    Icons.delete_outline,
-                    color: Colors.white,
-                    size: AppSize.iconMd,
-                  ),
-                  label: const Text(
-                    AppStrings.removePhoto,
-                    style: TextStyle(
+            if (onDelete != null)
+              Positioned(
+                bottom: AppSpacing.x2l,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: TextButton.icon(
+                    onPressed: () {
+                      Navigator.pop(ctx);
+                      onDelete();
+                    },
+                    icon: const Icon(
+                      Icons.delete_outline,
                       color: Colors.white,
-                      fontSize: AppTextStyle.md2,
+                      size: AppSize.iconMd,
+                    ),
+                    label: const Text(
+                      AppStrings.removePhoto,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: AppTextStyle.md2,
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
           ],
         ),
       ),

--- a/lib/screens/widgets/common/photo_viewer_dialog.dart
+++ b/lib/screens/widgets/common/photo_viewer_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -23,10 +24,10 @@ void showPhotoViewer(
               child: SizedBox.expand(
                 child: InteractiveViewer(
                   child: Center(
-                    child: Image.network(
-                      path,
+                    child: CachedNetworkImage(
+                      imageUrl: path,
                       fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => const Icon(
+                      errorWidget: (_, __, ___) => const Icon(
                         Icons.broken_image,
                         color: Colors.white54,
                         size: AppSize.iconXl,

--- a/lib/screens/widgets/common/photo_viewer_dialog.dart
+++ b/lib/screens/widgets/common/photo_viewer_dialog.dart
@@ -28,6 +28,9 @@ void showPhotoViewer(
                     child: CachedNetworkImage(
                       imageUrl: path,
                       fit: BoxFit.contain,
+                      placeholder: (_, __) => const Center(
+                        child: CircularProgressIndicator(color: Colors.white54),
+                      ),
                       errorWidget: (_, __, ___) => const Icon(
                         Icons.broken_image,
                         color: Colors.white54,

--- a/lib/screens/widgets/common/photo_viewer_dialog.dart
+++ b/lib/screens/widgets/common/photo_viewer_dialog.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -25,8 +23,8 @@ void showPhotoViewer(
               child: SizedBox.expand(
                 child: InteractiveViewer(
                   child: Center(
-                    child: Image.file(
-                      File(path),
+                    child: Image.network(
+                      path,
                       fit: BoxFit.contain,
                       errorBuilder: (_, __, ___) => const Icon(
                         Icons.broken_image,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "78f98c1f9c4dbbd22c2bb7b7f17c4a5c06150e8b2cb791a0947979ad0d3dabd5"
+      sha256: "85c85838ba41c5823ca05ecbc5fc8d85d78e9f945195d1e4d5069abd451916e7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.73"
+    version: "1.3.74"
   analyzer:
     dependency: transitive
     description:
@@ -461,10 +461,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: d2625088d8f8836a7a74a7eb94a5372d70ad88382602ba2dcc02805c294d0d16
+      sha256: e744b63446de56d9f72fec870b19e9c6f075fd3da099a3a34535f6e8c4e60823
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -481,6 +481,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.9.0"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      sha256: "8b581635d61852bf74d95d21ca181a3c52815813f5fafafa69da3610b870e998"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.4.4"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      sha256: "61772e88dd79db1e373f144fcbd29a0b6b3b275806732d44ab17daa62d9d9914"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.4"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      sha256: c41d5b7f2c7c6003832692762d86f2cd40a327aefea05756a5ace09ed95a0f77
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.11.10"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.12.6"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   cel:
     dependency: transitive
     description:
@@ -518,6 +542,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -1071,6 +1103,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.4.1"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -1372,6 +1412,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.8"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1420,6 +1500,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1685,5 +1773,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -485,10 +485,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_storage
-      sha256: "8b581635d61852bf74d95d21ca181a3c52815813f5fafafa69da3610b870e998"
+      sha256: f732bbcd82d21cfbe49b6fe5f4c50334f5f3660a151f004f58da388f8e39e6d3
       url: "https://pub.dev"
     source: hosted
-    version: "13.4.4"
+    version: "13.4.3"
   firebase_storage_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   url_launcher: ^6.3.2
   flutter_sms: ^3.0.1
   shared_preferences: ^2.3.4
+  firebase_storage: ^13.4.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   url_launcher: ^6.3.2
   flutter_sms: ^3.0.1
   shared_preferences: ^2.3.4
-  firebase_storage: ^13.4.4
+  firebase_storage: 13.4.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   flutter_sms: ^3.0.1
   shared_preferences: ^2.3.4
   firebase_storage: 13.4.3
+  cached_network_image: ^3.4.1
 
 dev_dependencies:
   flutter_test:

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,18 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+
+    // ユーザーの写真: オーナーのみ書き込み可、連携ユーザーは読み取り可
+    match /users/{uid}/spots/{spotId}/{fileName} {
+      // オーナーは読み書き可
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+
+      // 連携済みユーザーは読み取り可
+      // Storage ルールは Firestore の get() が使えないため、
+      // 認証済みユーザー全員に読み取りを許可し、
+      // Firestore セキュリティルール側でスポット取得を制御する
+      allow read: if request.auth != null;
+    }
+  }
+}

--- a/test/data/repositories/account_link_repository_impl_test.dart
+++ b/test/data/repositories/account_link_repository_impl_test.dart
@@ -27,11 +27,12 @@ void main() {
   });
 
   group('createInviteLink', () {
-    test('tekushare://link/ 形式のURLを返し、Firestoreにドキュメントを作る', () async {
+    test('https://tekushare.web.app/link/ 形式のURLを返し、Firestoreにドキュメントを作る',
+        () async {
       final repo = repoFor('uidA');
       final link = await repo.createInviteLink();
 
-      expect(link, startsWith('tekushare://link/'));
+      expect(link, startsWith('https://tekushare.web.app/link/'));
 
       final token = link.split('/').last;
       final doc = await firestore.collection('linkInvites').doc(token).get();

--- a/test/data/repositories/photo_repository_impl_test.dart
+++ b/test/data/repositories/photo_repository_impl_test.dart
@@ -53,10 +53,10 @@ void main() {
           result.first.photoPaths, ['/photos/first.jpg', '/photos/second.jpg']);
     });
 
-    test('attachPhoto で存在しない spotId を指定しても例外にならない', () async {
+    test('attachPhoto で存在しない spotId を指定すると StateError が発生する', () async {
       await expectLater(
         repo.attachPhoto('no-such-id', '/photos/test.jpg'),
-        completes,
+        throwsA(isA<StateError>()),
       );
     });
 

--- a/test/domain/usecases/photo/attach_photo_to_spot_test.dart
+++ b/test/domain/usecases/photo/attach_photo_to_spot_test.dart
@@ -15,7 +15,7 @@ void main() {
     mockRepo = MockPhotoRepository();
     usecase = AttachPhotoToSpot(mockRepo);
     when(mockRepo.attachPhoto(any, any))
-        .thenAnswer((_) => Future<void>.value());
+        .thenAnswer((_) => Future<String>.value(''));
   });
 
   group('AttachPhotoToSpot', () {

--- a/test/screens/pages/home/home_page_test.dart
+++ b/test/screens/pages/home/home_page_test.dart
@@ -58,7 +58,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/pages/map/walk_route_page_test.dart
+++ b/test/screens/pages/map/walk_route_page_test.dart
@@ -64,7 +64,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -110,7 +110,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/pages/settings/settings_viewmodel_test.dart
+++ b/test/screens/pages/settings/settings_viewmodel_test.dart
@@ -1,8 +1,41 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tekushare/domain/entities/linked_account.dart';
+import 'package:tekushare/domain/entities/spot.dart';
+import 'package:tekushare/domain/repositories/account_link_repository.dart';
 import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+
+class _FakeAccountLinkRepository implements AccountLinkRepository {
+  @override
+  Stream<List<LinkedAccount>> watchLinkedAccounts() => Stream.value([]);
+  @override
+  Future<String> createInviteLink() async => '';
+  @override
+  Future<InviteDetails> fetchInviteDetails(String token) async =>
+      throw const InviteInvalidException();
+  @override
+  Future<void> acceptInvite(String token) async {}
+  @override
+  Future<void> unlink(String otherUid) async {}
+  @override
+  Future<void> updateShareSettings({
+    required bool shareWantToGo,
+    required bool shareVisited,
+  }) async {}
+  @override
+  Future<({bool shareWantToGo, bool shareVisited})> fetchShareSettings(
+          String otherUid) async =>
+      (shareWantToGo: true, shareVisited: true);
+  @override
+  Future<List<Spot>> fetchSharedSpots(
+    String otherUid, {
+    required bool shareWantToGo,
+    required bool shareVisited,
+  }) async =>
+      [];
+}
 
 void main() {
   group('SettingsViewModel', () {
@@ -10,7 +43,12 @@ void main() {
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      container = ProviderContainer();
+      container = ProviderContainer(
+        overrides: [
+          accountLinkRepositoryProvider
+              .overrideWithValue(_FakeAccountLinkRepository()),
+        ],
+      );
       // prefs ロード完了を待ってから各テストへ
       await container.read(sharedPrefsProvider.future);
     });

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -478,8 +478,8 @@ void main() {
           find.text(AppStrings.spotDetailDeleteConfirmMessage), findsNothing);
     });
 
-    // 削除確認でSnackBarにメッセージが表示される
-    testWidgets('confirming delete shows snackbar', (tester) async {
+    // 削除確認で削除完了ダイアログが表示される
+    testWidgets('confirming delete shows deleted dialog', (tester) async {
       await pumpPage(tester, isWantToGo: false);
 
       await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
@@ -490,13 +490,19 @@ void main() {
           matching: find.text(AppStrings.spotDetailDeleteButton),
         ),
       );
-      await tester.pump();
+      await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.spotDetailDeleted), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text(AppStrings.spotDetailDeleted),
+        ),
+        findsOneWidget,
+      );
     });
 
-    // 削除確認で詳細ページから離れる
-    testWidgets('confirming delete leaves the page', (tester) async {
+    // 削除完了ダイアログを閉じると詳細ページから離れる
+    testWidgets('closing deleted dialog leaves the page', (tester) async {
       await pumpPushedPage(tester, isWantToGo: false);
 
       await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
@@ -507,6 +513,8 @@ void main() {
           matching: find.text(AppStrings.spotDetailDeleteButton),
         ),
       );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(SpotDetailPage), findsNothing);

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -50,7 +50,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -378,7 +378,7 @@ void main() {
       await tester.tap(
         find.descendant(
           of: find.byType(Dialog),
-          matching: find.text(AppStrings.spotDetailMoveToWentButton),
+          matching: find.text(AppStrings.spotDetailMoveToWentConfirmLabel),
         ),
       );
       await tester.pump();
@@ -395,7 +395,7 @@ void main() {
       await tester.tap(
         find.descendant(
           of: find.byType(Dialog),
-          matching: find.text(AppStrings.spotDetailMoveToWentButton),
+          matching: find.text(AppStrings.spotDetailMoveToWentConfirmLabel),
         ),
       );
       await tester.pumpAndSettle();

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -369,8 +369,8 @@ void main() {
           findsOneWidget);
     });
 
-    // 行った！確認でステータス変更完了ダイアログが表示される
-    testWidgets('confirming move to went shows result dialog', (tester) async {
+    // 行った！確認でSnackBarにメッセージが表示される
+    testWidgets('confirming move to went shows snackbar', (tester) async {
       await pumpPage(tester, isWantToGo: true);
 
       await tester.tap(find.text(AppStrings.spotDetailMoveToWentButton));
@@ -381,14 +381,13 @@ void main() {
           matching: find.text(AppStrings.spotDetailMoveToWentButton),
         ),
       );
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(find.text(AppStrings.spotDetailMoveToWentDone), findsOneWidget);
     });
 
-    // 行った！完了ダイアログの閉じるでページを離れる
-    testWidgets('closing move-to-went result dialog leaves the page',
-        (tester) async {
+    // 行った！確認で詳細ページから離れる
+    testWidgets('confirming move to went leaves the page', (tester) async {
       await pumpPushedPage(tester, isWantToGo: true);
 
       await tester.tap(find.text(AppStrings.spotDetailMoveToWentButton));
@@ -399,8 +398,6 @@ void main() {
           matching: find.text(AppStrings.spotDetailMoveToWentButton),
         ),
       );
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(SpotDetailPage), findsNothing);
@@ -481,9 +478,8 @@ void main() {
           find.text(AppStrings.spotDetailDeleteConfirmMessage), findsNothing);
     });
 
-    // 削除確認で削除完了ダイアログが表示される
-    testWidgets('confirming delete shows deletion complete dialog',
-        (tester) async {
+    // 削除確認でSnackBarにメッセージが表示される
+    testWidgets('confirming delete shows snackbar', (tester) async {
       await pumpPage(tester, isWantToGo: false);
 
       await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
@@ -494,14 +490,13 @@ void main() {
           matching: find.text(AppStrings.spotDetailDeleteButton),
         ),
       );
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(find.text(AppStrings.spotDetailDeleted), findsOneWidget);
     });
 
-    // 削除完了ダイアログの閉じるでページを離れる
-    testWidgets('closing deletion complete dialog leaves the page',
-        (tester) async {
+    // 削除確認で詳細ページから離れる
+    testWidgets('confirming delete leaves the page', (tester) async {
       await pumpPushedPage(tester, isWantToGo: false);
 
       await tester.tap(find.text(AppStrings.spotDetailDeleteButton));
@@ -512,8 +507,6 @@ void main() {
           matching: find.text(AppStrings.spotDetailDeleteButton),
         ),
       );
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(SpotDetailPage), findsNothing);
@@ -577,27 +570,25 @@ void main() {
       expect(find.text(AppStrings.spotDetailSaveConfirmMessage), findsNothing);
     });
 
-    // 保存確認で保存完了ダイアログが表示される
-    testWidgets('confirming save shows save complete dialog', (tester) async {
+    // 保存確認でSnackBarにメッセージが表示される
+    testWidgets('confirming save shows snackbar', (tester) async {
       await pumpPage(tester);
 
       await tester.tap(find.text(AppStrings.spotDetailSaveButton));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(find.text(AppStrings.saved), findsOneWidget);
     });
 
-    // 保存完了ダイアログの閉じるでページを離れる
-    testWidgets('closing save complete dialog leaves the page', (tester) async {
+    // 保存確認で詳細ページから離れる
+    testWidgets('confirming save leaves the page', (tester) async {
       await pumpPushedPage(tester);
 
       await tester.tap(find.text(AppStrings.spotDetailSaveButton));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(SpotDetailPage), findsNothing);

--- a/test/screens/pages/spot/spot_list_page_test.dart
+++ b/test/screens/pages/spot/spot_list_page_test.dart
@@ -50,7 +50,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -312,22 +312,21 @@ void main() {
       expect(find.text(AppStrings.wantToGoConfirmMessage), findsNothing);
     });
 
-    // 確認ダイアログの保存でスポットが保存されて完了ダイアログが表示される
-    testWidgets('confirming save stores spot and shows save complete dialog',
-        (tester) async {
+    // 確認ダイアログの保存でSnackBarにメッセージが表示される
+    testWidgets('confirming save shows snackbar', (tester) async {
       await pumpPage(tester);
       await tester.pumpAndSettle();
 
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(find.text(AppStrings.saved), findsOneWidget);
     });
 
-    // 保存完了ダイアログの閉じるでページを離れる
-    testWidgets('closing save complete dialog leaves the page', (tester) async {
+    // 確認ダイアログの保存で保存後にページを離れる
+    testWidgets('confirming save leaves the page', (tester) async {
       tester.view.physicalSize = const Size(1170, 3000);
       tester.view.devicePixelRatio = 3.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -377,8 +376,6 @@ void main() {
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(WantToGoPage), findsNothing);

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -62,7 +62,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/pages/spot/want_to_go_page_test.dart
+++ b/test/screens/pages/spot/want_to_go_page_test.dart
@@ -312,21 +312,27 @@ void main() {
       expect(find.text(AppStrings.wantToGoConfirmMessage), findsNothing);
     });
 
-    // 確認ダイアログの保存でSnackBarにメッセージが表示される
-    testWidgets('confirming save shows snackbar', (tester) async {
+    // 確認ダイアログの保存で保存完了ダイアログが表示される
+    testWidgets('confirming save shows saved dialog', (tester) async {
       await pumpPage(tester);
       await tester.pumpAndSettle();
 
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.saved), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text(AppStrings.saved),
+        ),
+        findsOneWidget,
+      );
     });
 
-    // 確認ダイアログの保存で保存後にページを離れる
-    testWidgets('confirming save leaves the page', (tester) async {
+    // 保存完了ダイアログを閉じるとホームに戻る
+    testWidgets('closing saved dialog leaves the page', (tester) async {
       tester.view.physicalSize = const Size(1170, 3000);
       tester.view.devicePixelRatio = 3.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -376,6 +382,8 @@ void main() {
       await tester.tap(find.text(AppStrings.wantToGoSave));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(WantToGoPage), findsNothing);

--- a/test/screens/pages/walk/end_walk_page_test.dart
+++ b/test/screens/pages/walk/end_walk_page_test.dart
@@ -53,7 +53,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -63,7 +63,7 @@ class _FakeUpdateSpotStatus implements UpdateSpotStatus {
 class _FakeAttachPhotoToSpot implements AttachPhotoToSpot {
   const _FakeAttachPhotoToSpot();
   @override
-  Future<void> call(String spotId, String imagePath) async {}
+  Future<String> call(String spotId, String imagePath) async => imagePath;
 }
 
 class _FakeRemovePhotoFromSpot implements RemovePhotoFromSpot {

--- a/test/screens/providers/spot_provider_test.dart
+++ b/test/screens/providers/spot_provider_test.dart
@@ -32,7 +32,7 @@ void main() {
     when(mockSpotRepo.updateSpotStatus(any, any))
         .thenAnswer((_) => Future<void>.value());
     when(mockPhotoRepo.attachPhoto(any, any))
-        .thenAnswer((_) => Future<void>.value());
+        .thenAnswer((_) => Future<String>.value(''));
     when(mockPhotoRepo.removePhoto(any, any))
         .thenAnswer((_) => Future<void>.value());
   });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -47,7 +47,8 @@ class _FakeAuthService implements AuthService {
 
 class _FakePhotoRepository implements PhotoRepository {
   @override
-  Future<void> attachPhoto(String spotId, String imagePath) async {}
+  Future<String> attachPhoto(String spotId, String imagePath) async =>
+      imagePath;
   @override
   Future<void> removePhoto(String spotId, String imagePath) async {}
 }


### PR DESCRIPTION
## 概要

スポット写真を Firebase Storage にアップロードし、連携アカウントからも閲覧できるようにする。

## 変更内容

- `firebase_storage` パッケージを追加
- `FirestorePhotoRepositoryImpl`: 写真を Storage にアップロードしてダウンロード URL を Firestore に保存
  - `removePhoto`: Storage 上のファイルも合わせて削除
- `PhotoRepository.attachPhoto`: `Future<void>` → `Future<String>`（URL を返す）
- `SpotDetailPage`: `Image.file()` → `Image.network()`（マップマーカー・写真グリッド）
- `photo_viewer_dialog`: `Image.file()` → `Image.network()`
- `storage.rules` を新規作成・デプロイ済み
- `firebase.json` に storage バケット設定を追加

## 注意事項

- `walk_page` / `want_to_go_page` は保存前の一時ローカルパスのため `Image.file()` を維持
- `LinkedSpotDetailPage` はすでに `Image.network()` 済みのため変更なし（#73 対応済み）
- 既存のローカルパスデータは `errorBuilder` でプレースホルダー表示される

## テスト計画

- [ ] 写真を撮影するとスポットに添付され表示される
- [ ] Firebase Storage コンソールに写真が保存される
- [ ] 写真を削除すると Storage からも削除される
- [ ] 連携アカウントの詳細画面で写真が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 写真をクラウドストレージにアップロードし、保存したURLで管理（追加・削除がクラウド側にも反映）。
* **改善**
  * スポットのステータス更新を、既存情報を保ったまま反映。
  * 写真表示をキャッシュ付きネットワーク画像に刷新（拡大表示・削除UI含む）。
  * 連携アカウントのスポット一覧にプル更新を追加。
* **設定/セキュリティ**
  * クラウドストレージのアクセスルールを追加・反映。
* **テスト**
  * 写真添付〜表示、画面操作、リンク関連のテストを更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->