### PR TITLE
#105 パスワードリセット・メール認証の実装とデータ整合性修正

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,12 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="https" android:host="tekushare.web.app" android:pathPrefix="/link/"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="tekushare.web.app" android:pathPrefix="/__/auth/action"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/firebase.json
+++ b/firebase.json
@@ -8,7 +8,7 @@
   },
   "hosting": {
     "public": "public",
-    "ignore": ["firebase.json", "**/.*"],
+    "ignore": ["firebase.json", "**/.*", "!**/.well-known/**"],
     "rewrites": [
       {
         "source": "/link/**",

--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,12 @@
   "hosting": {
     "public": "public",
     "ignore": ["firebase.json", "**/.*", "!**/.well-known/**"],
+    "headers": [
+      {
+        "source": "/.well-known/assetlinks.json",
+        "headers": [{"key": "Content-Type", "value": "application/json"}]
+      }
+    ],
     "rewrites": [
       {
         "source": "/link/**",

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -35,6 +35,12 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> reloadCurrentUser() async {}
 }
 
 class _FakeSpotRepository implements SpotRepository {

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -32,6 +32,9 @@ class _FakeAuthService implements AuthService {
   Future<void> signOut() async {}
   @override
   Future<void> deleteUser() async {}
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
 }
 
 class _FakeSpotRepository implements SpotRepository {

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -19,7 +19,8 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(String email, String displayName, String password) async {}
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -37,6 +37,12 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> reloadCurrentUser() async {}
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async => '';
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
 }
 
 class _FakeSpotRepository implements SpotRepository {

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -19,11 +19,7 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(
-    String email,
-    String password,
-    String displayName,
-  ) async {}
+  Future<void> registerWithEmail(String email, String displayName) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -19,7 +19,7 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName, String password) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -96,7 +96,6 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
   Widget build(BuildContext context) {
     final ready = ref.watch(appReadyProvider);
     final authState = ref.watch(authStateProvider);
-    final emailAuthState = ref.watch(emailAuthProvider);
 
     ref.listen<AsyncValue<dynamic>>(authStateProvider, (previous, next) {
       final user = next.valueOrNull;
@@ -143,14 +142,6 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
                 body: Center(child: CircularProgressIndicator())),
             error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
             data: (user) {
-              // 登録処理中にアカウントが一時的に作成されてもホーム画面へのフラッシュを防ぐ。
-              // user == null のときはスピナーに差し替えず EmailAuthPage を生かし続けることで
-              // エラー時に _isRegisterMode などのローカル状態が失われるのを防ぐ。
-              if (emailAuthState is EmailAuthLoading && user != null) {
-                return const Scaffold(
-                  body: Center(child: CircularProgressIndicator()),
-                );
-              }
               if (user == null) return const EmailAuthPage();
               final name = user.displayName;
               // null は Firebase がプロフィールを同期中の一時状態。

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/pages/account_link/view/accept_invite_page.dart';
 import 'package:tekushare/screens/pages/auth/view/display_name_page.dart';
 import 'package:tekushare/screens/pages/auth/view/email_auth_page.dart';
+import 'package:tekushare/screens/pages/auth/view/email_verification_page.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/providers/account_link_provider.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
@@ -124,6 +125,7 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
           error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
           data: (user) {
             if (user == null) return const EmailAuthPage();
+            if (!user.emailVerified) return const EmailVerificationPage();
             final name = user.displayName;
             // null は Firebase がプロフィールを同期中の一時状態。
             // ローディングを挟み DisplayNamePage が誤表示されるのを防ぐ。

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -142,7 +142,9 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
                 body: Center(child: CircularProgressIndicator())),
             error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
             data: (user) {
-              if (user == null) return const EmailAuthPage();
+              if (user == null || !user.emailVerified) {
+                return const EmailAuthPage();
+              }
               final name = user.displayName;
               // null は Firebase がプロフィールを同期中の一時状態。
               // ローディングを挟み DisplayNamePage が誤表示されるのを防ぐ。

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -96,6 +96,7 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
   Widget build(BuildContext context) {
     final ready = ref.watch(appReadyProvider);
     final authState = ref.watch(authStateProvider);
+    final emailAuthState = ref.watch(emailAuthProvider);
 
     ref.listen<AsyncValue<dynamic>>(authStateProvider, (previous, next) {
       final user = next.valueOrNull;
@@ -136,24 +137,32 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
         loading: () =>
             const Scaffold(body: Center(child: CircularProgressIndicator())),
         error: (e, _) => Scaffold(body: Center(child: Text('DB初期化エラー: $e'))),
-        data: (_) => authState.when(
-          loading: () =>
-              const Scaffold(body: Center(child: CircularProgressIndicator())),
-          error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
-          data: (user) {
-            if (user == null) return const EmailAuthPage();
-            final name = user.displayName;
-            // null は Firebase がプロフィールを同期中の一時状態。
-            // ローディングを挟み DisplayNamePage が誤表示されるのを防ぐ。
-            if (name == null) {
-              return const Scaffold(
-                body: Center(child: CircularProgressIndicator()),
-              );
-            }
-            if (name.isEmpty) return const DisplayNamePage();
-            return const HomePage();
-          },
-        ),
+        data: (_) {
+          // 登録処理中はルーティングをブロックしてホームの一瞬表示を防ぐ
+          if (emailAuthState is EmailAuthLoading) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          return authState.when(
+            loading: () => const Scaffold(
+                body: Center(child: CircularProgressIndicator())),
+            error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
+            data: (user) {
+              if (user == null) return const EmailAuthPage();
+              final name = user.displayName;
+              // null は Firebase がプロフィールを同期中の一時状態。
+              // ローディングを挟み DisplayNamePage が誤表示されるのを防ぐ。
+              if (name == null) {
+                return const Scaffold(
+                  body: Center(child: CircularProgressIndicator()),
+                );
+              }
+              if (name.isEmpty) return const DisplayNamePage();
+              return const HomePage();
+            },
+          );
+        },
       ),
     );
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/pages/account_link/view/accept_invite_page.dart';
 import 'package:tekushare/screens/pages/auth/view/display_name_page.dart';
 import 'package:tekushare/screens/pages/auth/view/email_auth_page.dart';
+import 'package:tekushare/screens/pages/auth/view/email_verification_page.dart';
 import 'package:tekushare/screens/pages/auth/view/password_set_page.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/providers/account_link_provider.dart';
@@ -142,9 +143,8 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
                 body: Center(child: CircularProgressIndicator())),
             error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
             data: (user) {
-              if (user == null || !user.emailVerified) {
-                return const EmailAuthPage();
-              }
+              if (user == null) return const EmailAuthPage();
+              if (!user.emailVerified) return const EmailVerificationPage();
               final name = user.displayName;
               // null は Firebase がプロフィールを同期中の一時状態。
               // ローディングを挟み DisplayNamePage が誤表示されるのを防ぐ。

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,7 +9,6 @@ import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/screens/pages/account_link/view/accept_invite_page.dart';
 import 'package:tekushare/screens/pages/auth/view/display_name_page.dart';
 import 'package:tekushare/screens/pages/auth/view/email_auth_page.dart';
-import 'package:tekushare/screens/pages/auth/view/email_verification_page.dart';
 import 'package:tekushare/screens/pages/auth/view/password_set_page.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/providers/account_link_provider.dart';
@@ -143,7 +142,6 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
           error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
           data: (user) {
             if (user == null) return const EmailAuthPage();
-            if (!user.emailVerified) return const EmailVerificationPage();
             final name = user.displayName;
             // null は Firebase がプロフィールを同期中の一時状態。
             // ローディングを挟み DisplayNamePage が誤表示されるのを防ぐ。

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,6 +10,7 @@ import 'package:tekushare/screens/pages/account_link/view/accept_invite_page.dar
 import 'package:tekushare/screens/pages/auth/view/display_name_page.dart';
 import 'package:tekushare/screens/pages/auth/view/email_auth_page.dart';
 import 'package:tekushare/screens/pages/auth/view/email_verification_page.dart';
+import 'package:tekushare/screens/pages/auth/view/password_set_page.dart';
 import 'package:tekushare/screens/pages/home/view/home_page.dart';
 import 'package:tekushare/screens/providers/account_link_provider.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
@@ -42,12 +43,21 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
     _appLinks.uriLinkStream.listen(_handleUri);
   }
 
-  /// 招待リンクを受け取り、ログイン済みなら即座に承認画面へ、
-  /// 未ログインなら pendingInviteTokenProvider に保持してログイン完了後に開く。
+  /// ディープリンクを受け取り、種別に応じて画面遷移する。
   /// 対応スキーム:
+  ///   - https://tekushare.web.app/__/auth/action?mode=resetPassword&oobCode=...
   ///   - tekushare://link/<token>
   ///   - https://tekushare.web.app/link/<token>
   void _handleUri(Uri uri) {
+    if (_isPasswordResetAction(uri)) {
+      final oobCode = uri.queryParameters['oobCode']!;
+      if (!_handledTokens.add('reset:$oobCode')) return;
+      navigatorKey.currentState?.push(
+        MaterialPageRoute(builder: (_) => PasswordSetPage(oobCode: oobCode)),
+      );
+      return;
+    }
+
     final token = _extractToken(uri);
     if (token == null) return;
     if (!_handledTokens.add(token)) return;
@@ -60,6 +70,14 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
     } else {
       ref.read(pendingInviteTokenProvider.notifier).state = token;
     }
+  }
+
+  bool _isPasswordResetAction(Uri uri) {
+    return uri.scheme == 'https' &&
+        uri.host == 'tekushare.web.app' &&
+        uri.path.startsWith('/__/auth/action') &&
+        uri.queryParameters['mode'] == 'resetPassword' &&
+        uri.queryParameters['oobCode'] != null;
   }
 
   String? _extractToken(Uri uri) {

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -138,17 +138,19 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
             const Scaffold(body: Center(child: CircularProgressIndicator())),
         error: (e, _) => Scaffold(body: Center(child: Text('DB初期化エラー: $e'))),
         data: (_) {
-          // 登録処理中はルーティングをブロックしてホームの一瞬表示を防ぐ
-          if (emailAuthState is EmailAuthLoading) {
-            return const Scaffold(
-              body: Center(child: CircularProgressIndicator()),
-            );
-          }
           return authState.when(
             loading: () => const Scaffold(
                 body: Center(child: CircularProgressIndicator())),
             error: (e, _) => Scaffold(body: Center(child: Text('認証エラー: $e'))),
             data: (user) {
+              // 登録処理中にアカウントが一時的に作成されてもホーム画面へのフラッシュを防ぐ。
+              // user == null のときはスピナーに差し替えず EmailAuthPage を生かし続けることで
+              // エラー時に _isRegisterMode などのローカル状態が失われるのを防ぐ。
+              if (emailAuthState is EmailAuthLoading && user != null) {
+                return const Scaffold(
+                  body: Center(child: CircularProgressIndicator()),
+                );
+              }
               if (user == null) return const EmailAuthPage();
               final name = user.displayName;
               // null は Firebase がプロフィールを同期中の一時状態。

--- a/lib/core/config/flavor.dart
+++ b/lib/core/config/flavor.dart
@@ -37,6 +37,18 @@ abstract class AppConfig {
     }
   }
 
+  /// Android パッケージ名 / iOS Bundle ID
+  static String get packageName {
+    switch (_flavor) {
+      case Flavor.dev:
+        return 'com.example.tekushare.dev';
+      case Flavor.stg:
+        return 'com.example.tekushare.stg';
+      case Flavor.prod:
+        return 'com.example.tekushare';
+    }
+  }
+
   /// dev環境かどうか
   static bool get isDev => _flavor == Flavor.dev;
 

--- a/lib/core/constants/app_spacing.dart
+++ b/lib/core/constants/app_spacing.dart
@@ -48,6 +48,7 @@ abstract class AppSize {
   static const double timerChipLabelFontSize = 11.0;
   static const double timerChipCountFontSize = 13.0;
   static const double appBarHeight = 56.0;
+  static const double appBarHeightTall = 72.0;
   static const double mapPinSize = 36.0;
   static const double cardElevation = 2.0;
   static const double photoGridItem = 80.0;

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -66,12 +66,6 @@ abstract class AppStrings {
   static const passwordSetInvalidCode = 'このリンクは無効か期限切れです。パスワードリセットを再度お試しください。';
   static const passwordMismatch = 'パスワードが一致しません';
 
-  // パスワード設定メール送信後（登録フロー）
-  static const emailAuthRegisteredMessage = 'パスワード設定メールをお送りしました';
-  static const emailAuthRegisteredDescription =
-      'にパスワード設定用のメールをお送りしました。\nメール内のリンクをタップしてパスワードを設定してください。\n設定後、メールアドレスとパスワードでログインできます。';
-  static const emailAuthRegisteredButton = 'ログインへ戻る';
-
   // パスワードリセット
   static const passwordResetPageTitle = 'パスワードリセット';
   static const passwordResetDescription = '登録したメールアドレスにリセット用のメールを送信します。';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -47,6 +47,15 @@ abstract class AppStrings {
   static const removePhoto = '写真を削除';
   static const titleHint = 'タイトルを設定する';
 
+  // メールアドレス確認
+  static const emailVerificationPageTitle = 'メールアドレスの確認';
+  static const emailVerificationSentMessage = '確認メールを送りました';
+  static const emailVerificationDescription =
+      'に確認メールを送りました。\nメール内のリンクをタップしてください。';
+  static const emailVerificationResendButton = '確認メールを再送信';
+  static const emailVerificationResendSuccess = '再送信しました';
+  static const emailVerificationChecking = 'メールを確認しています...';
+
   // パスワードリセット
   static const passwordResetPageTitle = 'パスワードリセット';
   static const passwordResetDescription = '登録したメールアドレスにリセット用のメールを送信します。';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -30,6 +30,13 @@ abstract class AppStrings {
   static const timerReset = 'リセット';
   static const timerFinishedTitle = '散歩タイマー';
   static const timerFinishedMessage = '設定した時間になりました。';
+  static const timerRoundTripNotificationTitle = '折り返しの時間です';
+  static const timerRoundTripNotificationBody = 'そろそろ折り返しましょう！';
+  static const gpsTimeoutTitle = 'GPS を取得できません';
+  static const gpsTimeoutMessage =
+      '30秒経過してもGPSが取得できませんでした。\n散歩をやり直す場合はリトライしてください。';
+  static const gpsTimeoutRetry = 'やり直す';
+  static const gpsTimeoutContinue = 'このまま続ける';
   static const safetyOk = '元気です';
   static const safetyConfirmTitle = '大丈夫ですか？';
   static const smsSendError = 'SMS送信に失敗しました';
@@ -46,6 +53,15 @@ abstract class AppStrings {
   static const addPhoto = '写真を追加';
   static const removePhoto = '写真を削除';
   static const titleHint = 'タイトルを設定する';
+
+  // ニックネーム設定（表示名）
+  static const displayNameTitle = 'ニックネームを設定';
+  static const displayNameSubtitle = 'アプリ内で表示される名前を入力してください';
+  static const displayNameSubmit = 'はじめる';
+  static const displayNameError = 'エラーが発生しました';
+  static const nicknameLabel = 'ニックネーム';
+  static const nicknameHint = '例：やまだたろう';
+  static const nicknameRequired = 'ニックネームを入力してください';
 
   // メールアドレス確認
   static const emailVerificationPageTitle = 'メールをご確認ください';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -63,6 +63,13 @@ abstract class AppStrings {
   static const nicknameHint = '例：やまだたろう';
   static const nicknameRequired = 'ニックネームを入力してください';
 
+  // メールアドレス認証フォーム
+  static const emailAuthPasswordLabel = 'パスワード（6文字以上）';
+  static const emailAuthPasswordHint = '6文字以上';
+  static const emailAuthRegisteredDescription =
+      'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。';
+  static const emailAuthLoginButton = 'ログインへ';
+
   // メールアドレス確認
   static const emailVerificationPageTitle = 'メールをご確認ください';
   static const emailVerificationSentMessage = '確認メールを送りました';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -47,14 +47,14 @@ abstract class AppStrings {
   static const removePhoto = '写真を削除';
   static const titleHint = 'タイトルを設定する';
 
-  // メールアドレス確認
-  static const emailVerificationPageTitle = 'メールアドレスの確認';
-  static const emailVerificationSentMessage = '確認メールを送りました';
+  // メールアドレス確認 / パスワード設定
+  static const emailVerificationPageTitle = 'メールをご確認ください';
+  static const emailVerificationSentMessage = 'パスワード設定メールを送りました';
   static const emailVerificationDescription =
-      'に確認メールを送りました。\nメール内のリンクをタップしてください。';
-  static const emailVerificationResendButton = '確認メールを再送信';
+      'にパスワード設定用のメールを送りました。\nメール内のリンクをタップしてパスワードを設定してください。';
+  static const emailVerificationResendButton = 'パスワード設定メールを再送信';
   static const emailVerificationResendSuccess = '再送信しました';
-  static const emailVerificationChecking = 'メールを確認しています...';
+  static const emailVerificationChecking = '確認しています...';
 
   // パスワードリセット
   static const passwordResetPageTitle = 'パスワードリセット';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -66,6 +66,12 @@ abstract class AppStrings {
   static const passwordSetInvalidCode = 'このリンクは無効か期限切れです。パスワードリセットを再度お試しください。';
   static const passwordMismatch = 'パスワードが一致しません';
 
+  // 登録完了（パスワード設定メール送信後）
+  static const emailAuthRegisteredMessage = '登録完了！パスワード設定メールを送りました';
+  static const emailAuthRegisteredDescription =
+      'メール内のリンクをタップしてパスワードを設定してください。\n設定後、メールアドレスとパスワードでログインできます。';
+  static const emailAuthRegisteredButton = 'ログインへ戻る';
+
   // パスワードリセット
   static const passwordResetPageTitle = 'パスワードリセット';
   static const passwordResetDescription = '登録したメールアドレスにリセット用のメールを送信します。';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -66,10 +66,10 @@ abstract class AppStrings {
   static const passwordSetInvalidCode = 'このリンクは無効か期限切れです。パスワードリセットを再度お試しください。';
   static const passwordMismatch = 'パスワードが一致しません';
 
-  // 登録完了（パスワード設定メール送信後）
-  static const emailAuthRegisteredMessage = '登録完了！パスワード設定メールを送りました';
+  // パスワード設定メール送信後（登録フロー）
+  static const emailAuthRegisteredMessage = 'パスワード設定メールをお送りしました';
   static const emailAuthRegisteredDescription =
-      'メール内のリンクをタップしてパスワードを設定してください。\n設定後、メールアドレスとパスワードでログインできます。';
+      'にパスワード設定用のメールをお送りしました。\nメール内のリンクをタップしてパスワードを設定してください。\n設定後、メールアドレスとパスワードでログインできます。';
   static const emailAuthRegisteredButton = 'ログインへ戻る';
 
   // パスワードリセット

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -47,14 +47,24 @@ abstract class AppStrings {
   static const removePhoto = '写真を削除';
   static const titleHint = 'タイトルを設定する';
 
-  // メールアドレス確認 / パスワード設定
+  // メールアドレス確認
   static const emailVerificationPageTitle = 'メールをご確認ください';
-  static const emailVerificationSentMessage = 'パスワード設定メールを送りました';
+  static const emailVerificationSentMessage = '確認メールを送りました';
   static const emailVerificationDescription =
-      'にパスワード設定用のメールを送りました。\nメール内のリンクをタップしてパスワードを設定してください。';
-  static const emailVerificationResendButton = 'パスワード設定メールを再送信';
+      'にメールアドレス確認用のメールを送りました。\nメール内のリンクをタップして確認を完了してください。';
+  static const emailVerificationResendButton = '確認メールを再送信';
   static const emailVerificationResendSuccess = '再送信しました';
   static const emailVerificationChecking = '確認しています...';
+
+  // パスワード設定（メールリンクから遷移）
+  static const passwordSetPageTitle = 'パスワードの設定';
+  static const passwordSetDescription =
+      '新しいパスワードを設定してください。\n英字と数字を両方含む6文字以上で設定してください。';
+  static const passwordSetLabel = 'パスワード（6文字以上・英数字含む）';
+  static const passwordSetConfirmLabel = 'パスワード（確認）';
+  static const passwordSetButton = 'パスワードを設定する';
+  static const passwordSetInvalidCode = 'このリンクは無効か期限切れです。パスワードリセットを再度お試しください。';
+  static const passwordMismatch = 'パスワードが一致しません';
 
   // パスワードリセット
   static const passwordResetPageTitle = 'パスワードリセット';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -47,6 +47,14 @@ abstract class AppStrings {
   static const removePhoto = '写真を削除';
   static const titleHint = 'タイトルを設定する';
 
+  // パスワードリセット
+  static const passwordResetPageTitle = 'パスワードリセット';
+  static const passwordResetDescription = '登録したメールアドレスにリセット用のメールを送信します。';
+  static const passwordResetEmailLabel = 'メールアドレス';
+  static const passwordResetSendButton = 'リセットメールを送信';
+  static const passwordResetSuccessMessage = 'リセット用メールを送信しました。\nメールをご確認ください。';
+  static const passwordResetLinkLabel = 'パスワードを忘れた方はこちら';
+
   // 共通
   static const noTitle = '（タイトルなし）';
   static const saved = '保存しました！';

--- a/lib/core/constants/app_text_style.dart
+++ b/lib/core/constants/app_text_style.dart
@@ -6,6 +6,7 @@ abstract class AppTextStyle {
   // サイズ定数
   static const double xxs = 9.0;
   static const double xs = 11.0;
+  static const double xs2 = 12.0;
   static const double sm = 13.0;
   static const double sm2 = 14.0;
   static const double md = 15.0;

--- a/lib/data/models/saved_route_model.dart
+++ b/lib/data/models/saved_route_model.dart
@@ -7,6 +7,9 @@ part 'saved_route_model.g.dart';
 class SavedRouteModel {
   Id id = Isar.autoIncrement;
 
+  @Index()
+  String userUid = '';
+
   late String name;
   late String date;
   late String distance;
@@ -24,8 +27,9 @@ class SavedRouteModel {
         walkSessionId: walkSessionId,
       );
 
-  static SavedRouteModel fromEntity(SavedRoute route) {
+  static SavedRouteModel fromEntity(SavedRoute route, String userUid) {
     final model = SavedRouteModel()
+      ..userUid = userUid
       ..name = route.name
       ..date = route.date
       ..distance = route.distance

--- a/lib/data/models/saved_route_model.g.dart
+++ b/lib/data/models/saved_route_model.g.dart
@@ -42,8 +42,13 @@ const SavedRouteModelSchema = CollectionSchema(
       name: r'time',
       type: IsarType.string,
     ),
-    r'walkSessionId': PropertySchema(
+    r'userUid': PropertySchema(
       id: 5,
+      name: r'userUid',
+      type: IsarType.string,
+    ),
+    r'walkSessionId': PropertySchema(
+      id: 6,
       name: r'walkSessionId',
       type: IsarType.string,
     )
@@ -53,7 +58,21 @@ const SavedRouteModelSchema = CollectionSchema(
   deserialize: _savedRouteModelDeserialize,
   deserializeProp: _savedRouteModelDeserializeProp,
   idName: r'id',
-  indexes: {},
+  indexes: {
+    r'userUid': IndexSchema(
+      id: 7924673654387171457,
+      name: r'userUid',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'userUid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
   links: {},
   embeddedSchemas: {},
   getId: _savedRouteModelGetId,
@@ -72,6 +91,7 @@ int _savedRouteModelEstimateSize(
   bytesCount += 3 + object.distance.length * 3;
   bytesCount += 3 + object.name.length * 3;
   bytesCount += 3 + object.time.length * 3;
+  bytesCount += 3 + object.userUid.length * 3;
   {
     final value = object.walkSessionId;
     if (value != null) {
@@ -92,7 +112,8 @@ void _savedRouteModelSerialize(
   writer.writeString(offsets[2], object.distance);
   writer.writeString(offsets[3], object.name);
   writer.writeString(offsets[4], object.time);
-  writer.writeString(offsets[5], object.walkSessionId);
+  writer.writeString(offsets[5], object.userUid);
+  writer.writeString(offsets[6], object.walkSessionId);
 }
 
 SavedRouteModel _savedRouteModelDeserialize(
@@ -108,7 +129,8 @@ SavedRouteModel _savedRouteModelDeserialize(
   object.id = id;
   object.name = reader.readString(offsets[3]);
   object.time = reader.readString(offsets[4]);
-  object.walkSessionId = reader.readStringOrNull(offsets[5]);
+  object.userUid = reader.readString(offsets[5]);
+  object.walkSessionId = reader.readStringOrNull(offsets[6]);
   return object;
 }
 
@@ -130,6 +152,8 @@ P _savedRouteModelDeserializeProp<P>(
     case 4:
       return (reader.readString(offset)) as P;
     case 5:
+      return (reader.readString(offset)) as P;
+    case 6:
       return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -225,6 +249,51 @@ extension SavedRouteModelQueryWhere
         upper: upperId,
         includeUpper: includeUpper,
       ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterWhereClause>
+      userUidEqualTo(String userUid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'userUid',
+        value: [userUid],
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterWhereClause>
+      userUidNotEqualTo(String userUid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [],
+              upper: [userUid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [userUid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [userUid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [],
+              upper: [userUid],
+              includeUpper: false,
+            ));
+      }
     });
   }
 }
@@ -888,6 +957,142 @@ extension SavedRouteModelQueryFilter
   }
 
   QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'userUid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'userUid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'userUid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
+      userUidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'userUid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterFilterCondition>
       walkSessionIdIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -1117,6 +1322,19 @@ extension SavedRouteModelQuerySortBy
     });
   }
 
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterSortBy> sortByUserUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterSortBy>
+      sortByUserUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.desc);
+    });
+  }
+
   QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterSortBy>
       sortByWalkSessionId() {
     return QueryBuilder.apply(this, (query) {
@@ -1213,6 +1431,19 @@ extension SavedRouteModelQuerySortThenBy
     });
   }
 
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterSortBy> thenByUserUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterSortBy>
+      thenByUserUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.desc);
+    });
+  }
+
   QueryBuilder<SavedRouteModel, SavedRouteModel, QAfterSortBy>
       thenByWalkSessionId() {
     return QueryBuilder.apply(this, (query) {
@@ -1265,6 +1496,13 @@ extension SavedRouteModelQueryWhereDistinct
     });
   }
 
+  QueryBuilder<SavedRouteModel, SavedRouteModel, QDistinct> distinctByUserUid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'userUid', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<SavedRouteModel, SavedRouteModel, QDistinct>
       distinctByWalkSessionId({bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -1310,6 +1548,12 @@ extension SavedRouteModelQueryProperty
   QueryBuilder<SavedRouteModel, String, QQueryOperations> timeProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'time');
+    });
+  }
+
+  QueryBuilder<SavedRouteModel, String, QQueryOperations> userUidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'userUid');
     });
   }
 

--- a/lib/data/models/walk_route_model.dart
+++ b/lib/data/models/walk_route_model.dart
@@ -16,6 +16,9 @@ class WalkRouteModel {
   @Index(unique: true)
   late String walkSessionId;
 
+  @Index()
+  String userUid = '';
+
   // List<LatLng> を JSON 文字列として保存
   late String pointsJson;
 
@@ -38,7 +41,7 @@ class WalkRouteModel {
     );
   }
 
-  static WalkRouteModel fromEntity(WalkRoute route) {
+  static WalkRouteModel fromEntity(WalkRoute route, String userUid) {
     final pointsJson = jsonEncode(
       route.points.map((p) => {'lat': p.latitude, 'lng': p.longitude}).toList(),
     );
@@ -46,6 +49,7 @@ class WalkRouteModel {
     return WalkRouteModel()
       ..uid = route.id
       ..walkSessionId = route.walkSessionId
+      ..userUid = userUid
       ..pointsJson = pointsJson
       ..createdAt = route.createdAt;
   }

--- a/lib/data/models/walk_route_model.g.dart
+++ b/lib/data/models/walk_route_model.g.dart
@@ -32,8 +32,13 @@ const WalkRouteModelSchema = CollectionSchema(
       name: r'uid',
       type: IsarType.string,
     ),
-    r'walkSessionId': PropertySchema(
+    r'userUid': PropertySchema(
       id: 3,
+      name: r'userUid',
+      type: IsarType.string,
+    ),
+    r'walkSessionId': PropertySchema(
+      id: 4,
       name: r'walkSessionId',
       type: IsarType.string,
     )
@@ -69,6 +74,19 @@ const WalkRouteModelSchema = CollectionSchema(
           caseSensitive: true,
         )
       ],
+    ),
+    r'userUid': IndexSchema(
+      id: 7924673654387171457,
+      name: r'userUid',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'userUid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
     )
   },
   links: {},
@@ -87,6 +105,7 @@ int _walkRouteModelEstimateSize(
   var bytesCount = offsets.last;
   bytesCount += 3 + object.pointsJson.length * 3;
   bytesCount += 3 + object.uid.length * 3;
+  bytesCount += 3 + object.userUid.length * 3;
   bytesCount += 3 + object.walkSessionId.length * 3;
   return bytesCount;
 }
@@ -100,7 +119,8 @@ void _walkRouteModelSerialize(
   writer.writeDateTime(offsets[0], object.createdAt);
   writer.writeString(offsets[1], object.pointsJson);
   writer.writeString(offsets[2], object.uid);
-  writer.writeString(offsets[3], object.walkSessionId);
+  writer.writeString(offsets[3], object.userUid);
+  writer.writeString(offsets[4], object.walkSessionId);
 }
 
 WalkRouteModel _walkRouteModelDeserialize(
@@ -114,7 +134,8 @@ WalkRouteModel _walkRouteModelDeserialize(
   object.id = id;
   object.pointsJson = reader.readString(offsets[1]);
   object.uid = reader.readString(offsets[2]);
-  object.walkSessionId = reader.readString(offsets[3]);
+  object.userUid = reader.readString(offsets[3]);
+  object.walkSessionId = reader.readString(offsets[4]);
   return object;
 }
 
@@ -132,6 +153,8 @@ P _walkRouteModelDeserializeProp<P>(
     case 2:
       return (reader.readString(offset)) as P;
     case 3:
+      return (reader.readString(offset)) as P;
+    case 4:
       return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -425,6 +448,51 @@ extension WalkRouteModelQueryWhere
               indexName: r'walkSessionId',
               lower: [],
               upper: [walkSessionId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause>
+      userUidEqualTo(String userUid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'userUid',
+        value: [userUid],
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterWhereClause>
+      userUidNotEqualTo(String userUid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [],
+              upper: [userUid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [userUid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [userUid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [],
+              upper: [userUid],
               includeUpper: false,
             ));
       }
@@ -818,6 +886,142 @@ extension WalkRouteModelQueryFilter
   }
 
   QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'userUid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'userUid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'userUid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
+      userUidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'userUid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterFilterCondition>
       walkSessionIdEqualTo(
     String value, {
     bool caseSensitive = true,
@@ -1001,6 +1205,19 @@ extension WalkRouteModelQuerySortBy
     });
   }
 
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> sortByUserUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      sortByUserUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.desc);
+    });
+  }
+
   QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
       sortByWalkSessionId() {
     return QueryBuilder.apply(this, (query) {
@@ -1069,6 +1286,19 @@ extension WalkRouteModelQuerySortThenBy
     });
   }
 
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy> thenByUserUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
+      thenByUserUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.desc);
+    });
+  }
+
   QueryBuilder<WalkRouteModel, WalkRouteModel, QAfterSortBy>
       thenByWalkSessionId() {
     return QueryBuilder.apply(this, (query) {
@@ -1107,6 +1337,13 @@ extension WalkRouteModelQueryWhereDistinct
     });
   }
 
+  QueryBuilder<WalkRouteModel, WalkRouteModel, QDistinct> distinctByUserUid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'userUid', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<WalkRouteModel, WalkRouteModel, QDistinct>
       distinctByWalkSessionId({bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -1139,6 +1376,12 @@ extension WalkRouteModelQueryProperty
   QueryBuilder<WalkRouteModel, String, QQueryOperations> uidProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'uid');
+    });
+  }
+
+  QueryBuilder<WalkRouteModel, String, QQueryOperations> userUidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'userUid');
     });
   }
 

--- a/lib/data/models/walk_session_model.dart
+++ b/lib/data/models/walk_session_model.dart
@@ -10,6 +10,9 @@ class WalkSessionModel {
   @Index(unique: true)
   late String uid;
 
+  @Index()
+  String userUid = '';
+
   @Enumerated(EnumType.name)
   late WalkStatus status;
 
@@ -27,9 +30,10 @@ class WalkSessionModel {
     );
   }
 
-  static WalkSessionModel fromEntity(WalkSession session) {
+  static WalkSessionModel fromEntity(WalkSession session, String userUid) {
     return WalkSessionModel()
       ..uid = session.id
+      ..userUid = userUid
       ..status = session.status
       ..startedAt = session.startedAt
       ..finishedAt = session.finishedAt

--- a/lib/data/models/walk_session_model.g.dart
+++ b/lib/data/models/walk_session_model.g.dart
@@ -42,6 +42,11 @@ const WalkSessionModelSchema = CollectionSchema(
       id: 4,
       name: r'uid',
       type: IsarType.string,
+    ),
+    r'userUid': PropertySchema(
+      id: 5,
+      name: r'userUid',
+      type: IsarType.string,
     )
   },
   estimateSize: _walkSessionModelEstimateSize,
@@ -58,6 +63,19 @@ const WalkSessionModelSchema = CollectionSchema(
       properties: [
         IndexPropertySchema(
           name: r'uid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    ),
+    r'userUid': IndexSchema(
+      id: 7924673654387171457,
+      name: r'userUid',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'userUid',
           type: IndexType.hash,
           caseSensitive: true,
         )
@@ -80,6 +98,7 @@ int _walkSessionModelEstimateSize(
   var bytesCount = offsets.last;
   bytesCount += 3 + object.status.name.length * 3;
   bytesCount += 3 + object.uid.length * 3;
+  bytesCount += 3 + object.userUid.length * 3;
   return bytesCount;
 }
 
@@ -94,6 +113,7 @@ void _walkSessionModelSerialize(
   writer.writeDateTime(offsets[2], object.startedAt);
   writer.writeString(offsets[3], object.status.name);
   writer.writeString(offsets[4], object.uid);
+  writer.writeString(offsets[5], object.userUid);
 }
 
 WalkSessionModel _walkSessionModelDeserialize(
@@ -111,6 +131,7 @@ WalkSessionModel _walkSessionModelDeserialize(
           reader.readStringOrNull(offsets[3])] ??
       WalkStatus.idle;
   object.uid = reader.readString(offsets[4]);
+  object.userUid = reader.readString(offsets[5]);
   return object;
 }
 
@@ -132,6 +153,8 @@ P _walkSessionModelDeserializeProp<P>(
               reader.readStringOrNull(offset)] ??
           WalkStatus.idle) as P;
     case 4:
+      return (reader.readString(offset)) as P;
+    case 5:
       return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -334,6 +357,51 @@ extension WalkSessionModelQueryWhere
               indexName: r'uid',
               lower: [],
               upper: [uid],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause>
+      userUidEqualTo(String userUid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'userUid',
+        value: [userUid],
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterWhereClause>
+      userUidNotEqualTo(String userUid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [],
+              upper: [userUid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [userUid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [userUid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'userUid',
+              lower: [],
+              upper: [userUid],
               includeUpper: false,
             ));
       }
@@ -874,6 +942,142 @@ extension WalkSessionModelQueryFilter
       ));
     });
   }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'userUid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'userUid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'userUid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'userUid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterFilterCondition>
+      userUidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'userUid',
+        value: '',
+      ));
+    });
+  }
 }
 
 extension WalkSessionModelQueryObject
@@ -950,6 +1154,20 @@ extension WalkSessionModelQuerySortBy
       sortByUidDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'uid', Sort.desc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByUserUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      sortByUserUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.desc);
     });
   }
 }
@@ -1037,6 +1255,20 @@ extension WalkSessionModelQuerySortThenBy
       return query.addSortBy(r'uid', Sort.desc);
     });
   }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByUserUid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QAfterSortBy>
+      thenByUserUidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'userUid', Sort.desc);
+    });
+  }
 }
 
 extension WalkSessionModelQueryWhereDistinct
@@ -1073,6 +1305,13 @@ extension WalkSessionModelQueryWhereDistinct
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'uid', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, WalkSessionModel, QDistinct> distinctByUserUid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'userUid', caseSensitive: caseSensitive);
     });
   }
 }
@@ -1116,6 +1355,12 @@ extension WalkSessionModelQueryProperty
   QueryBuilder<WalkSessionModel, String, QQueryOperations> uidProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'uid');
+    });
+  }
+
+  QueryBuilder<WalkSessionModel, String, QQueryOperations> userUidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'userUid');
     });
   }
 }

--- a/lib/data/repositories/route_repository_impl.dart
+++ b/lib/data/repositories/route_repository_impl.dart
@@ -25,10 +25,8 @@ class RouteRepositoryImpl implements RouteRepository {
 
   @override
   Future<List<WalkRoute>> getAllRoutes() async {
-    final models = await _isar.walkRouteModels
-        .filter()
-        .userUidEqualTo(_userUid)
-        .findAll();
+    final models =
+        await _isar.walkRouteModels.filter().userUidEqualTo(_userUid).findAll();
     return models.map((m) => m.toEntity()).toList();
   }
 }

--- a/lib/data/repositories/route_repository_impl.dart
+++ b/lib/data/repositories/route_repository_impl.dart
@@ -4,15 +4,16 @@ import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/repositories/route_repository.dart';
 
 class RouteRepositoryImpl implements RouteRepository {
-  RouteRepositoryImpl(this._isar);
+  RouteRepositoryImpl(this._isar, this._userUid);
 
   final Isar _isar;
+  final String _userUid;
 
   @override
   Future<void> saveRoute(WalkRoute route) async {
     await _isar.writeTxn(() async {
       await _isar.walkRouteModels
-          .putByWalkSessionId(WalkRouteModel.fromEntity(route));
+          .putByWalkSessionId(WalkRouteModel.fromEntity(route, _userUid));
     });
   }
 
@@ -24,7 +25,10 @@ class RouteRepositoryImpl implements RouteRepository {
 
   @override
   Future<List<WalkRoute>> getAllRoutes() async {
-    final models = await _isar.walkRouteModels.where().findAll();
+    final models = await _isar.walkRouteModels
+        .filter()
+        .userUidEqualTo(_userUid)
+        .findAll();
     return models.map((m) => m.toEntity()).toList();
   }
 }

--- a/lib/data/repositories/route_repository_impl.dart
+++ b/lib/data/repositories/route_repository_impl.dart
@@ -20,7 +20,8 @@ class RouteRepositoryImpl implements RouteRepository {
   @override
   Future<WalkRoute?> getRouteBySessionId(String sessionId) async {
     final model = await _isar.walkRouteModels.getByWalkSessionId(sessionId);
-    return model?.toEntity();
+    if (model == null || model.userUid != _userUid) return null;
+    return model.toEntity();
   }
 
   @override

--- a/lib/data/repositories/saved_route_repository_impl.dart
+++ b/lib/data/repositories/saved_route_repository_impl.dart
@@ -4,21 +4,26 @@ import 'package:tekushare/domain/entities/saved_route.dart';
 import 'package:tekushare/domain/repositories/saved_route_repository.dart';
 
 class SavedRouteRepositoryImpl implements SavedRouteRepository {
-  SavedRouteRepositoryImpl(this._isar);
+  SavedRouteRepositoryImpl(this._isar, this._userUid);
 
   final Isar _isar;
+  final String _userUid;
 
   @override
   Future<void> save(SavedRoute route) async {
     await _isar.writeTxn(() async {
-      await _isar.savedRouteModels.put(SavedRouteModel.fromEntity(route));
+      await _isar.savedRouteModels
+          .put(SavedRouteModel.fromEntity(route, _userUid));
     });
   }
 
   @override
   Future<List<SavedRoute>> getAll() async {
-    final models =
-        await _isar.savedRouteModels.where().sortByCreatedAt().findAll();
+    final models = await _isar.savedRouteModels
+        .filter()
+        .userUidEqualTo(_userUid)
+        .sortByCreatedAt()
+        .findAll();
     return models.map((m) => m.toEntity()).toList();
   }
 

--- a/lib/data/repositories/saved_route_repository_impl.dart
+++ b/lib/data/repositories/saved_route_repository_impl.dart
@@ -30,6 +30,8 @@ class SavedRouteRepositoryImpl implements SavedRouteRepository {
   @override
   Future<void> delete(int id) async {
     await _isar.writeTxn(() async {
+      final model = await _isar.savedRouteModels.get(id);
+      if (model == null || model.userUid != _userUid) return;
       await _isar.savedRouteModels.delete(id);
     });
   }

--- a/lib/data/repositories/walk_session_repository_impl.dart
+++ b/lib/data/repositories/walk_session_repository_impl.dart
@@ -4,21 +4,25 @@ import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/domain/repositories/walk_session_repository.dart';
 
 class WalkSessionRepositoryImpl implements WalkSessionRepository {
-  WalkSessionRepositoryImpl(this._isar);
+  WalkSessionRepositoryImpl(this._isar, this._userUid);
 
   final Isar _isar;
+  final String _userUid;
 
   @override
   Future<void> saveSession(WalkSession session) async {
     await _isar.writeTxn(() async {
       await _isar.walkSessionModels
-          .putByUid(WalkSessionModel.fromEntity(session));
+          .putByUid(WalkSessionModel.fromEntity(session, _userUid));
     });
   }
 
   @override
   Future<List<WalkSession>> getAllSessions() async {
-    final models = await _isar.walkSessionModels.where().findAll();
+    final models = await _isar.walkSessionModels
+        .filter()
+        .userUidEqualTo(_userUid)
+        .findAll();
     return models.map((m) => m.toEntity()).toList();
   }
 

--- a/lib/data/repositories/walk_session_repository_impl.dart
+++ b/lib/data/repositories/walk_session_repository_impl.dart
@@ -29,6 +29,7 @@ class WalkSessionRepositoryImpl implements WalkSessionRepository {
   @override
   Future<WalkSession?> getSessionById(String id) async {
     final model = await _isar.walkSessionModels.getByUid(id);
-    return model?.toEntity();
+    if (model == null || model.userUid != _userUid) return null;
+    return model.toEntity();
   }
 }

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
@@ -44,33 +42,19 @@ class FirebaseAuthServiceImpl implements AuthService {
     });
   }
 
-  static String _generateTempPassword() {
-    const chars =
-        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    final random = Random.secure();
-    return List.generate(24, (_) => chars[random.nextInt(chars.length)]).join();
-  }
-
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {
     try {
       final credential = await _auth.createUserWithEmailAndPassword(
         email: email,
-        password: _generateTempPassword(),
+        password: password,
       );
       await credential.user?.updateDisplayName(displayName);
       await credential.user?.reload();
       final uid = credential.user?.uid;
       if (uid != null) await _syncUserDoc(uid, displayName);
-      final settings = ActionCodeSettings(
-        url: 'https://tekushare.web.app',
-        handleCodeInApp: true,
-        androidPackageName: AppConfig.packageName,
-        androidInstallApp: true,
-        iOSBundleId: AppConfig.packageName,
-      );
-      await _auth.sendPasswordResetEmail(
-          email: email, actionCodeSettings: settings);
+      await credential.user?.sendEmailVerification();
       await _auth.signOut();
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
@@ -85,9 +69,16 @@ class FirebaseAuthServiceImpl implements AuthService {
         password: password,
       );
       final user = credential.user;
-      final name = user?.displayName;
-      if (user != null && name != null && name.isNotEmpty) {
-        await _syncUserDoc(user.uid, name);
+      if (user == null) return;
+      await user.reload();
+      final reloaded = _auth.currentUser;
+      if (reloaded == null || !reloaded.emailVerified) {
+        await _auth.signOut();
+        throw const AuthException('email-not-verified');
+      }
+      final name = reloaded.displayName;
+      if (name != null && name.isNotEmpty) {
+        await _syncUserDoc(reloaded.uid, name);
       }
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -6,7 +6,9 @@ import 'package:flutter/foundation.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
 
 class FirebaseAuthServiceImpl implements AuthService {
-  FirebaseAuthServiceImpl(this._auth, this._firestore);
+  FirebaseAuthServiceImpl(this._auth, this._firestore) {
+    _auth.setLanguageCode('ja');
+  }
   final FirebaseAuth _auth;
   final FirebaseFirestore _firestore;
 

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
@@ -39,19 +41,26 @@ class FirebaseAuthServiceImpl implements AuthService {
     });
   }
 
+  static String _generateTempPassword() {
+    const chars =
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    final random = Random.secure();
+    return List.generate(24, (_) => chars[random.nextInt(chars.length)]).join();
+  }
+
   @override
-  Future<void> registerWithEmail(
-      String email, String password, String displayName) async {
+  Future<void> registerWithEmail(String email, String displayName) async {
     try {
       final credential = await _auth.createUserWithEmailAndPassword(
         email: email,
-        password: password,
+        password: _generateTempPassword(),
       );
       await credential.user?.updateDisplayName(displayName);
-      await credential.user?.sendEmailVerification();
       await credential.user?.reload();
       final uid = credential.user?.uid;
       if (uid != null) await _syncUserDoc(uid, displayName);
+      // パスワード設定リンクをメール送信（Firebase がメール確認も兼ねる）
+      await _auth.sendPasswordResetEmail(email: email);
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
     }

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
+import 'package:tekushare/core/config/flavor.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
 
 class FirebaseAuthServiceImpl implements AuthService {
@@ -61,8 +62,7 @@ class FirebaseAuthServiceImpl implements AuthService {
       await credential.user?.reload();
       final uid = credential.user?.uid;
       if (uid != null) await _syncUserDoc(uid, displayName);
-      // パスワード設定リンクをメール送信（Firebase がメール確認も兼ねる）
-      await _auth.sendPasswordResetEmail(email: email);
+      await credential.user?.sendEmailVerification();
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
     }
@@ -110,7 +110,15 @@ class FirebaseAuthServiceImpl implements AuthService {
   @override
   Future<void> sendPasswordResetEmail(String email) async {
     try {
-      await _auth.sendPasswordResetEmail(email: email);
+      final settings = ActionCodeSettings(
+        url: 'https://tekushare.web.app',
+        handleCodeInApp: true,
+        androidPackageName: AppConfig.packageName,
+        androidInstallApp: true,
+        iOSBundleId: AppConfig.packageName,
+      );
+      await _auth.sendPasswordResetEmail(
+          email: email, actionCodeSettings: settings);
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
     }
@@ -129,6 +137,24 @@ class FirebaseAuthServiceImpl implements AuthService {
   Future<void> reloadCurrentUser() async {
     try {
       await _auth.currentUser?.reload();
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.code);
+    }
+  }
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async {
+    try {
+      return await _auth.verifyPasswordResetCode(code);
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.code);
+    }
+  }
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {
+    try {
+      await _auth.confirmPasswordReset(code: code, newPassword: newPassword);
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
     }

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -62,7 +62,16 @@ class FirebaseAuthServiceImpl implements AuthService {
       await credential.user?.reload();
       final uid = credential.user?.uid;
       if (uid != null) await _syncUserDoc(uid, displayName);
-      await credential.user?.sendEmailVerification();
+      final settings = ActionCodeSettings(
+        url: 'https://tekushare.web.app',
+        handleCodeInApp: true,
+        androidPackageName: AppConfig.packageName,
+        androidInstallApp: true,
+        iOSBundleId: AppConfig.packageName,
+      );
+      await _auth.sendPasswordResetEmail(
+          email: email, actionCodeSettings: settings);
+      await _auth.signOut();
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
     }

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -89,4 +89,13 @@ class FirebaseAuthServiceImpl implements AuthService {
     if (user == null) return;
     await user.delete();
   }
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {
+    try {
+      await _auth.sendPasswordResetEmail(email: email);
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.code);
+    }
+  }
 }

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -30,7 +30,12 @@ class FirebaseAuthServiceImpl implements AuthService {
   Stream<AuthUser?> watchAuthState() {
     return _auth.userChanges().map((user) {
       if (user == null) return null;
-      return AuthUser(uid: user.uid, displayName: user.displayName);
+      return AuthUser(
+        uid: user.uid,
+        displayName: user.displayName,
+        email: user.email,
+        emailVerified: user.emailVerified,
+      );
     });
   }
 
@@ -43,6 +48,7 @@ class FirebaseAuthServiceImpl implements AuthService {
         password: password,
       );
       await credential.user?.updateDisplayName(displayName);
+      await credential.user?.sendEmailVerification();
       await credential.user?.reload();
       final uid = credential.user?.uid;
       if (uid != null) await _syncUserDoc(uid, displayName);
@@ -94,6 +100,24 @@ class FirebaseAuthServiceImpl implements AuthService {
   Future<void> sendPasswordResetEmail(String email) async {
     try {
       await _auth.sendPasswordResetEmail(email: email);
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.code);
+    }
+  }
+
+  @override
+  Future<void> sendEmailVerification() async {
+    try {
+      await _auth.currentUser?.sendEmailVerification();
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.code);
+    }
+  }
+
+  @override
+  Future<void> reloadCurrentUser() async {
+    try {
+      await _auth.currentUser?.reload();
     } on FirebaseAuthException catch (e) {
       throw AuthException(e.code);
     }

--- a/lib/infrastructure/location_service.dart
+++ b/lib/infrastructure/location_service.dart
@@ -15,6 +15,15 @@ class LocationService {
   Stream<Position> positionStream() async* {
     await _ensurePermission();
 
+    // 散歩2回目以降は distanceFilter により getPositionStream が初回位置を配信しない
+    // ため、キャッシュ済みの最終位置を先に配信してマップ・GPS インジケーターを即時更新する。
+    try {
+      final last = await Geolocator.getLastKnownPosition();
+      if (last != null && last.accuracy <= _fallbackAccuracyMeters) {
+        yield last;
+      }
+    } catch (_) {}
+
     const settings = LocationSettings(
       accuracy: LocationAccuracy.bestForNavigation,
       distanceFilter: _distanceFilterMeters,

--- a/lib/infrastructure/notification_service.dart
+++ b/lib/infrastructure/notification_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
 
 class NotificationService {
   NotificationService._(this._plugin);
@@ -18,8 +19,9 @@ class NotificationService {
   static const _channelId = 'tekushare_walk';
   static const _channelName = '散歩通知';
 
-  static const _idInactivity = 1; // 10分無動作の安否確認通知
-  static const _idTurnaround = 2; // 15分折返し通知
+  static const _idInactivity = 1;
+  static const _idTurnaround = 2;
+  static const _idRoundTrip = 3;
 
   Future<void> initialize() async {
     const androidSettings =
@@ -48,11 +50,21 @@ class NotificationService {
     );
   }
 
-  /// タイマー通知を表示する
+  /// 往復タイマーの折り返し通知を表示する
+  Future<void> showRoundTripNotification() async {
+    await _plugin.show(
+      id: _idRoundTrip,
+      title: AppStrings.timerRoundTripNotificationTitle,
+      body: AppStrings.timerRoundTripNotificationBody,
+      notificationDetails: _notificationDetails(),
+    );
+  }
+
+  /// タイマー終了通知を表示する
   Future<void> showTurnaroundNotification() async {
     await _plugin.show(
       id: _idTurnaround,
-      title: 'タイマー終了',
+      title: AppStrings.timerFinishedTitle,
       body: '設定した時間になりました。',
       notificationDetails: _notificationDetails(),
     );

--- a/lib/infrastructure/notification_service.dart
+++ b/lib/infrastructure/notification_service.dart
@@ -65,7 +65,7 @@ class NotificationService {
     await _plugin.show(
       id: _idTurnaround,
       title: AppStrings.timerFinishedTitle,
-      body: '設定した時間になりました。',
+      body: AppStrings.timerFinishedMessage,
       notificationDetails: _notificationDetails(),
     );
   }

--- a/lib/infrastructure/sms_service.dart
+++ b/lib/infrastructure/sms_service.dart
@@ -14,7 +14,7 @@ abstract interface class SmsService {
 class SmsServiceImpl implements SmsService {
   const SmsServiceImpl();
 
-  static const _messageTemplate = '【てくしぇあ】{name}さんから10分以上連絡がありません。確認してください。';
+  static const _messageTemplate = '【てくしぇあ】{name}さんから連絡がありません。確認してください。';
 
   @override
   Future<void> sendInactivityAlert({

--- a/lib/screens/pages/account_link/view/accept_invite_page.dart
+++ b/lib/screens/pages/account_link/view/accept_invite_page.dart
@@ -29,6 +29,10 @@ class _AcceptInvitePageState extends ConsumerState<AcceptInvitePage> {
       await showDialog<void>(
         context: context,
         builder: (_) => Dialog(
+          insetPadding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.x4l,
+            vertical: AppSpacing.x2l,
+          ),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppRadius.lg),
           ),

--- a/lib/screens/pages/auth/view/display_name_page.dart
+++ b/lib/screens/pages/auth/view/display_name_page.dart
@@ -31,7 +31,9 @@ class _DisplayNamePageState extends ConsumerState<DisplayNamePage> {
     ref.listen<AsyncValue<void>>(displayNameProvider, (_, next) {
       if (next is AsyncError) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラーが発生しました: ${next.error}')),
+          SnackBar(
+            content: Text('${AppStrings.displayNameError}: ${next.error}'),
+          ),
         );
       }
       // 成功時は authStateProvider（userChanges）が自動的にホーム画面へ遷移させる
@@ -45,21 +47,24 @@ class _DisplayNamePageState extends ConsumerState<DisplayNamePage> {
         automaticallyImplyLeading: false,
         centerTitle: true,
         elevation: 0,
-        toolbarHeight: 72,
+        toolbarHeight: AppSize.appBarHeightTall,
         title: const Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
               AppStrings.appTitle,
               style: TextStyle(
-                fontSize: 20,
+                fontSize: AppTextStyle.xl,
                 fontWeight: FontWeight.bold,
                 color: Colors.white,
               ),
             ),
             Text(
               AppStrings.appTagline,
-              style: TextStyle(fontSize: 12, color: Colors.white),
+              style: TextStyle(
+                fontSize: AppTextStyle.xs2,
+                color: Colors.white,
+              ),
             ),
           ],
         ),
@@ -74,10 +79,11 @@ class _DisplayNamePageState extends ConsumerState<DisplayNamePage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              const Text('ニックネームを設定', style: AppTextStyle.titleLarge),
+              const Text(AppStrings.displayNameTitle,
+                  style: AppTextStyle.titleLarge),
               const SizedBox(height: AppSpacing.sm),
               Text(
-                'アプリ内で表示される名前を入力してください',
+                AppStrings.displayNameSubtitle,
                 style: AppTextStyle.bodyMedium.copyWith(
                   color: AppColors.textDisabled,
                 ),
@@ -86,8 +92,8 @@ class _DisplayNamePageState extends ConsumerState<DisplayNamePage> {
               TextField(
                 controller: _controller,
                 decoration: const InputDecoration(
-                  labelText: 'ニックネーム',
-                  hintText: '例：やまだたろう',
+                  labelText: AppStrings.nicknameLabel,
+                  hintText: AppStrings.nicknameHint,
                   border: OutlineInputBorder(),
                   prefixIcon: Icon(Icons.person_outline),
                 ),
@@ -116,7 +122,7 @@ class _DisplayNamePageState extends ConsumerState<DisplayNamePage> {
                           ),
                         )
                       : Text(
-                          'はじめる',
+                          AppStrings.displayNameSubmit,
                           style: AppTextStyle.titleMedium.copyWith(
                             color: AppColors.textOnPrimary,
                           ),
@@ -134,7 +140,7 @@ class _DisplayNamePageState extends ConsumerState<DisplayNamePage> {
     final name = _controller.text.trim();
     if (name.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('ニックネームを入力してください')),
+        const SnackBar(content: Text(AppStrings.nicknameRequired)),
       );
       return;
     }

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -35,7 +35,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
     final authState = ref.watch(emailAuthProvider);
 
     if (authState is EmailAuthRegistered) {
-      return _buildRegisteredScaffold();
+      return _buildRegisteredScaffold(authState.email);
     }
 
     final isLoading = authState is EmailAuthLoading;
@@ -206,7 +206,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
     );
   }
 
-  Widget _buildRegisteredScaffold() {
+  Widget _buildRegisteredScaffold(String email) {
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: _buildAppBar(),
@@ -232,9 +232,11 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                 style: AppTextStyle.titleLarge,
               ),
               const SizedBox(height: AppSpacing.sm),
-              const Text(
-                AppStrings.emailAuthRegisteredDescription,
+              Text(
+                '$email${AppStrings.emailAuthRegisteredDescription}',
                 textAlign: TextAlign.center,
+                style: AppTextStyle.bodyMedium
+                    .copyWith(color: AppColors.textDisabled),
               ),
               const SizedBox(height: AppSpacing.x4l),
               SizedBox(

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -18,14 +18,17 @@ class EmailAuthPage extends ConsumerStatefulWidget {
 class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
   final _nameController = TextEditingController();
   bool _isRegisterMode = false;
   bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
 
   @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
+    _confirmPasswordController.dispose();
     _nameController.dispose();
     super.dispose();
   }
@@ -35,7 +38,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
     final authState = ref.watch(emailAuthProvider);
 
     if (authState is EmailAuthRegistered) {
-      return _buildRegisteredScaffold(authState.email);
+      return _buildRegisteredScaffold();
     }
 
     final isLoading = authState is EmailAuthLoading;
@@ -61,7 +64,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
               const SizedBox(height: AppSpacing.sm),
               Text(
                 _isRegisterMode
-                    ? 'メールアドレスを入力してください。\nパスワード設定用のリンクをメールでお送りします。'
+                    ? 'メールアドレスとパスワードを入力してください。\n登録完了メールをお送りします。'
                     : 'メールアドレスとパスワードを入力してください',
                 style: AppTextStyle.bodyMedium
                     .copyWith(color: AppColors.textDisabled),
@@ -91,29 +94,45 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                   border: const OutlineInputBorder(),
                   prefixIcon: const Icon(Icons.mail_outline),
                 ),
-                textInputAction: _isRegisterMode
-                    ? TextInputAction.done
-                    : TextInputAction.next,
-                onSubmitted: _isRegisterMode ? (_) => _submit() : null,
+                textInputAction: TextInputAction.next,
               ),
-              if (!_isRegisterMode) ...[
+              const SizedBox(height: AppSpacing.lg),
+              TextField(
+                controller: _passwordController,
+                obscureText: _obscurePassword,
+                decoration: InputDecoration(
+                  labelText: 'パスワード（6文字以上）',
+                  hintText: '6文字以上',
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.lock_outline),
+                  suffixIcon: IconButton(
+                    icon: Icon(_obscurePassword
+                        ? Icons.visibility_off
+                        : Icons.visibility),
+                    onPressed: () =>
+                        setState(() => _obscurePassword = !_obscurePassword),
+                  ),
+                ),
+                textInputAction: _isRegisterMode
+                    ? TextInputAction.next
+                    : TextInputAction.done,
+                onSubmitted: _isRegisterMode ? null : (_) => _submit(),
+              ),
+              if (_isRegisterMode) ...[
                 const SizedBox(height: AppSpacing.lg),
                 TextField(
-                  controller: _passwordController,
-                  obscureText: _obscurePassword,
+                  controller: _confirmPasswordController,
+                  obscureText: _obscureConfirmPassword,
                   decoration: InputDecoration(
-                    labelText: 'パスワード',
-                    hintText: '6文字以上',
+                    labelText: 'パスワード（確認）',
                     border: const OutlineInputBorder(),
                     prefixIcon: const Icon(Icons.lock_outline),
                     suffixIcon: IconButton(
-                      icon: Icon(
-                        _obscurePassword
-                            ? Icons.visibility_off
-                            : Icons.visibility,
-                      ),
-                      onPressed: () =>
-                          setState(() => _obscurePassword = !_obscurePassword),
+                      icon: Icon(_obscureConfirmPassword
+                          ? Icons.visibility_off
+                          : Icons.visibility),
+                      onPressed: () => setState(() =>
+                          _obscureConfirmPassword = !_obscureConfirmPassword),
                     ),
                   ),
                   textInputAction: TextInputAction.done,
@@ -178,6 +197,62 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
     );
   }
 
+  Widget _buildRegisteredScaffold() {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: _buildAppBar(),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.x3l,
+            vertical: AppSpacing.x4l,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Icon(
+                Icons.mark_email_unread_outlined,
+                size: 64,
+                color: AppColors.primary,
+              ),
+              const SizedBox(height: AppSpacing.x3l),
+              const Text(
+                '確認メールを送りました',
+                textAlign: TextAlign.center,
+                style: AppTextStyle.titleLarge,
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              const Text(
+                'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。',
+                textAlign: TextAlign.center,
+                style: AppTextStyle.bodyMedium,
+              ),
+              const SizedBox(height: AppSpacing.x4l),
+              SizedBox(
+                height: AppSize.buttonHeight,
+                child: FilledButton(
+                  onPressed: () {
+                    ref.read(emailAuthProvider.notifier).reset();
+                    setState(() => _isRegisterMode = false);
+                  },
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: AppColors.textOnPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.lg),
+                    ),
+                  ),
+                  child: const Text('ログインへ'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   PreferredSizeWidget _buildAppBar() {
     return AppBar(
       backgroundColor: AppColors.primary,
@@ -206,69 +281,13 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
     );
   }
 
-  Widget _buildRegisteredScaffold(String email) {
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: _buildAppBar(),
-      body: SafeArea(
-        top: false,
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSpacing.x3l,
-            vertical: AppSpacing.x4l,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const Icon(
-                Icons.mark_email_unread_outlined,
-                size: 64,
-                color: AppColors.primary,
-              ),
-              const SizedBox(height: AppSpacing.x3l),
-              const Text(
-                AppStrings.emailAuthRegisteredMessage,
-                textAlign: TextAlign.center,
-                style: AppTextStyle.titleLarge,
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Text(
-                '$email${AppStrings.emailAuthRegisteredDescription}',
-                textAlign: TextAlign.center,
-                style: AppTextStyle.bodyMedium
-                    .copyWith(color: AppColors.textDisabled),
-              ),
-              const SizedBox(height: AppSpacing.x4l),
-              SizedBox(
-                height: AppSize.buttonHeight,
-                child: FilledButton(
-                  onPressed: () {
-                    ref.read(emailAuthProvider.notifier).reset();
-                    setState(() => _isRegisterMode = false);
-                  },
-                  style: FilledButton.styleFrom(
-                    backgroundColor: AppColors.primary,
-                    foregroundColor: AppColors.textOnPrimary,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(AppRadius.lg),
-                    ),
-                  ),
-                  child: const Text(AppStrings.emailAuthRegisteredButton),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   void _toggleMode() {
     ref.read(emailAuthProvider.notifier).reset();
     setState(() {
       _isRegisterMode = !_isRegisterMode;
       _emailController.clear();
       _passwordController.clear();
+      _confirmPasswordController.clear();
       _nameController.clear();
     });
   }
@@ -276,6 +295,24 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
   void _submit() {
     FocusScope.of(context).unfocus();
     final email = _emailController.text.trim();
+    final password = _passwordController.text;
+
+    if (email.isEmpty) {
+      _showSnack('メールアドレスを入力してください');
+      return;
+    }
+    if (!_isValidEmail(email)) {
+      _showSnack('メールアドレスの形式が正しくありません');
+      return;
+    }
+    if (password.isEmpty) {
+      _showSnack('パスワードを入力してください');
+      return;
+    }
+    if (password.length < 6) {
+      _showSnack('パスワードは6文字以上で入力してください');
+      return;
+    }
 
     if (_isRegisterMode) {
       final name = _nameController.text.trim();
@@ -283,33 +320,13 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
         _showSnack('ニックネームを入力してください');
         return;
       }
-      if (email.isEmpty) {
-        _showSnack('メールアドレスを入力してください');
+      final confirm = _confirmPasswordController.text;
+      if (password != confirm) {
+        _showSnack('パスワードが一致しません');
         return;
       }
-      if (!_isValidEmail(email)) {
-        _showSnack('メールアドレスの形式が正しくありません');
-        return;
-      }
-      ref.read(emailAuthProvider.notifier).register(email, name);
+      ref.read(emailAuthProvider.notifier).register(email, name, password);
     } else {
-      final password = _passwordController.text;
-      if (email.isEmpty) {
-        _showSnack('メールアドレスを入力してください');
-        return;
-      }
-      if (!_isValidEmail(email)) {
-        _showSnack('メールアドレスの形式が正しくありません');
-        return;
-      }
-      if (password.isEmpty) {
-        _showSnack('パスワードを入力してください');
-        return;
-      }
-      if (password.length < 6) {
-        _showSnack('パスワードは6文字以上で入力してください');
-        return;
-      }
       ref.read(emailAuthProvider.notifier).signIn(email, password);
     }
   }

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -74,8 +74,8 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                 TextField(
                   controller: _nameController,
                   decoration: const InputDecoration(
-                    labelText: 'ニックネーム',
-                    hintText: '例：やまだたろう',
+                    labelText: AppStrings.nicknameLabel,
+                    hintText: AppStrings.nicknameHint,
                     border: OutlineInputBorder(),
                     prefixIcon: Icon(Icons.person_outline),
                   ),
@@ -260,21 +260,21 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
       automaticallyImplyLeading: false,
       centerTitle: true,
       elevation: 0,
-      toolbarHeight: 72,
+      toolbarHeight: AppSize.appBarHeightTall,
       title: const Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
             AppStrings.appTitle,
             style: TextStyle(
-              fontSize: 20,
+              fontSize: AppTextStyle.xl,
               fontWeight: FontWeight.bold,
               color: Colors.white,
             ),
           ),
           Text(
             AppStrings.appTagline,
-            style: TextStyle(fontSize: 12, color: Colors.white),
+            style: TextStyle(fontSize: AppTextStyle.xs2, color: Colors.white),
           ),
         ],
       ),
@@ -317,7 +317,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
     if (_isRegisterMode) {
       final name = _nameController.text.trim();
       if (name.isEmpty) {
-        _showSnack('ニックネームを入力してください');
+        _showSnack(AppStrings.nicknameRequired);
         return;
       }
       final confirm = _confirmPasswordController.text;

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -4,6 +4,7 @@ import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/pages/auth/view/password_reset_page.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
 
 /// メールアドレス認証画面（ログイン / 新規登録）
@@ -169,6 +170,21 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                   style: const TextStyle(color: AppColors.primary),
                 ),
               ),
+              if (!_isRegisterMode)
+                TextButton(
+                  onPressed: isLoading
+                      ? null
+                      : () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const PasswordResetPage(),
+                            ),
+                          ),
+                  child: const Text(
+                    AppStrings.passwordResetLinkLabel,
+                    style: TextStyle(color: AppColors.textDisabled),
+                  ),
+                ),
             ],
           ),
         ),

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -217,8 +217,17 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
         _showSnack('メールアドレスを入力してください');
         return;
       }
+      if (!_isValidEmail(email)) {
+        _showSnack('メールアドレスの形式が正しくありません');
+        return;
+      }
       if (password.length < 6) {
         _showSnack('パスワードは6文字以上で入力してください');
+        return;
+      }
+      if (!password.contains(RegExp(r'[a-zA-Z]')) ||
+          !password.contains(RegExp(r'[0-9]'))) {
+        _showSnack('パスワードは英字と数字をどちらも含めてください');
         return;
       }
       ref.read(emailAuthProvider.notifier).register(email, password, name);
@@ -227,13 +236,24 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
         _showSnack('メールアドレスを入力してください');
         return;
       }
+      if (!_isValidEmail(email)) {
+        _showSnack('メールアドレスの形式が正しくありません');
+        return;
+      }
       if (password.isEmpty) {
         _showSnack('パスワードを入力してください');
+        return;
+      }
+      if (password.length < 6) {
+        _showSnack('パスワードは6文字以上で入力してください');
         return;
       }
       ref.read(emailAuthProvider.notifier).signIn(email, password);
     }
   }
+
+  bool _isValidEmail(String email) =>
+      RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$').hasMatch(email);
 
   void _showSnack(String message) {
     ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -101,8 +101,8 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                 controller: _passwordController,
                 obscureText: _obscurePassword,
                 decoration: InputDecoration(
-                  labelText: 'パスワード（6文字以上）',
-                  hintText: '6文字以上',
+                  labelText: AppStrings.emailAuthPasswordLabel,
+                  hintText: AppStrings.emailAuthPasswordHint,
                   border: const OutlineInputBorder(),
                   prefixIcon: const Icon(Icons.lock_outline),
                   suffixIcon: IconButton(
@@ -124,7 +124,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                   controller: _confirmPasswordController,
                   obscureText: _obscureConfirmPassword,
                   decoration: InputDecoration(
-                    labelText: 'パスワード（確認）',
+                    labelText: AppStrings.passwordSetConfirmLabel,
                     border: const OutlineInputBorder(),
                     prefixIcon: const Icon(Icons.lock_outline),
                     suffixIcon: IconButton(
@@ -218,13 +218,13 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
               ),
               const SizedBox(height: AppSpacing.x3l),
               const Text(
-                '確認メールを送りました',
+                AppStrings.emailVerificationSentMessage,
                 textAlign: TextAlign.center,
                 style: AppTextStyle.titleLarge,
               ),
               const SizedBox(height: AppSpacing.sm),
               const Text(
-                'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。',
+                AppStrings.emailAuthRegisteredDescription,
                 textAlign: TextAlign.center,
                 style: AppTextStyle.bodyMedium,
               ),
@@ -243,7 +243,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                       borderRadius: BorderRadius.circular(AppRadius.lg),
                     ),
                   ),
-                  child: const Text('ログインへ'),
+                  child: const Text(AppStrings.emailAuthLoginButton),
                 ),
               ),
             ],

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -33,36 +33,17 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
   @override
   Widget build(BuildContext context) {
     final authState = ref.watch(emailAuthProvider);
+
+    if (authState is EmailAuthRegistered) {
+      return _buildRegisteredScaffold();
+    }
+
     final isLoading = authState is EmailAuthLoading;
     final error = authState is EmailAuthError ? authState.message : null;
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.primary,
-        foregroundColor: Colors.white,
-        automaticallyImplyLeading: false,
-        centerTitle: true,
-        elevation: 0,
-        toolbarHeight: 72,
-        title: const Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              AppStrings.appTitle,
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-              ),
-            ),
-            Text(
-              AppStrings.appTagline,
-              style: TextStyle(fontSize: 12, color: Colors.white),
-            ),
-          ],
-        ),
-      ),
+      appBar: _buildAppBar(),
       body: SafeArea(
         top: false,
         child: SingleChildScrollView(
@@ -190,6 +171,89 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                     style: TextStyle(color: AppColors.textDisabled),
                   ),
                 ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  PreferredSizeWidget _buildAppBar() {
+    return AppBar(
+      backgroundColor: AppColors.primary,
+      foregroundColor: Colors.white,
+      automaticallyImplyLeading: false,
+      centerTitle: true,
+      elevation: 0,
+      toolbarHeight: 72,
+      title: const Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            AppStrings.appTitle,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          Text(
+            AppStrings.appTagline,
+            style: TextStyle(fontSize: 12, color: Colors.white),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRegisteredScaffold() {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: _buildAppBar(),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.x3l,
+            vertical: AppSpacing.x4l,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Icon(
+                Icons.mark_email_unread_outlined,
+                size: 64,
+                color: AppColors.primary,
+              ),
+              const SizedBox(height: AppSpacing.x3l),
+              const Text(
+                AppStrings.emailAuthRegisteredMessage,
+                textAlign: TextAlign.center,
+                style: AppTextStyle.titleLarge,
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              const Text(
+                AppStrings.emailAuthRegisteredDescription,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: AppSpacing.x4l),
+              SizedBox(
+                height: AppSize.buttonHeight,
+                child: FilledButton(
+                  onPressed: () {
+                    ref.read(emailAuthProvider.notifier).reset();
+                    setState(() => _isRegisterMode = false);
+                  },
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: AppColors.textOnPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.lg),
+                    ),
+                  ),
+                  child: const Text(AppStrings.emailAuthRegisteredButton),
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -80,7 +80,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
               const SizedBox(height: AppSpacing.sm),
               Text(
                 _isRegisterMode
-                    ? 'メールアドレスとパスワードを設定してください'
+                    ? 'メールアドレスを入力してください。\nパスワード設定用のリンクをメールでお送りします。'
                     : 'メールアドレスとパスワードを入力してください',
                 style: AppTextStyle.bodyMedium
                     .copyWith(color: AppColors.textDisabled),
@@ -110,30 +110,35 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                   border: const OutlineInputBorder(),
                   prefixIcon: const Icon(Icons.mail_outline),
                 ),
-                textInputAction: TextInputAction.next,
+                textInputAction: _isRegisterMode
+                    ? TextInputAction.done
+                    : TextInputAction.next,
+                onSubmitted: _isRegisterMode ? (_) => _submit() : null,
               ),
-              const SizedBox(height: AppSpacing.lg),
-              TextField(
-                controller: _passwordController,
-                obscureText: _obscurePassword,
-                decoration: InputDecoration(
-                  labelText: 'パスワード',
-                  hintText: '6文字以上',
-                  border: const OutlineInputBorder(),
-                  prefixIcon: const Icon(Icons.lock_outline),
-                  suffixIcon: IconButton(
-                    icon: Icon(
-                      _obscurePassword
-                          ? Icons.visibility_off
-                          : Icons.visibility,
+              if (!_isRegisterMode) ...[
+                const SizedBox(height: AppSpacing.lg),
+                TextField(
+                  controller: _passwordController,
+                  obscureText: _obscurePassword,
+                  decoration: InputDecoration(
+                    labelText: 'パスワード',
+                    hintText: '6文字以上',
+                    border: const OutlineInputBorder(),
+                    prefixIcon: const Icon(Icons.lock_outline),
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility,
+                      ),
+                      onPressed: () =>
+                          setState(() => _obscurePassword = !_obscurePassword),
                     ),
-                    onPressed: () =>
-                        setState(() => _obscurePassword = !_obscurePassword),
                   ),
+                  textInputAction: TextInputAction.done,
+                  onSubmitted: (_) => _submit(),
                 ),
-                textInputAction: TextInputAction.done,
-                onSubmitted: (_) => _submit(),
-              ),
+              ],
               const SizedBox(height: AppSpacing.x3l),
               SizedBox(
                 height: AppSize.buttonHeight,
@@ -205,7 +210,6 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
   void _submit() {
     FocusScope.of(context).unfocus();
     final email = _emailController.text.trim();
-    final password = _passwordController.text;
 
     if (_isRegisterMode) {
       final name = _nameController.text.trim();
@@ -221,17 +225,9 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
         _showSnack('メールアドレスの形式が正しくありません');
         return;
       }
-      if (password.length < 6) {
-        _showSnack('パスワードは6文字以上で入力してください');
-        return;
-      }
-      if (!password.contains(RegExp(r'[a-zA-Z]')) ||
-          !password.contains(RegExp(r'[0-9]'))) {
-        _showSnack('パスワードは英字と数字をどちらも含めてください');
-        return;
-      }
-      ref.read(emailAuthProvider.notifier).register(email, password, name);
+      ref.read(emailAuthProvider.notifier).register(email, name);
     } else {
+      final password = _passwordController.text;
       if (email.isEmpty) {
         _showSnack('メールアドレスを入力してください');
         return;

--- a/lib/screens/pages/auth/view/email_verification_page.dart
+++ b/lib/screens/pages/auth/view/email_verification_page.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_spacing.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+class EmailVerificationPage extends ConsumerStatefulWidget {
+  const EmailVerificationPage({super.key});
+
+  @override
+  ConsumerState<EmailVerificationPage> createState() =>
+      _EmailVerificationPageState();
+}
+
+class _EmailVerificationPageState extends ConsumerState<EmailVerificationPage> {
+  static const _pollInterval = Duration(seconds: 3);
+
+  Timer? _timer;
+  bool _isSending = false;
+  bool _resendSuccess = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(_pollInterval, (_) => _poll());
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _poll() async {
+    try {
+      await ref.read(authServiceProvider).reloadCurrentUser();
+    } catch (_) {
+      // ポーリング失敗は無視して次のタイミングで再試行
+    }
+  }
+
+  Future<void> _onResend() async {
+    setState(() {
+      _isSending = true;
+      _resendSuccess = false;
+      _error = null;
+    });
+    try {
+      await ref.read(authServiceProvider).sendEmailVerification();
+      if (!mounted) return;
+      setState(() {
+        _isSending = false;
+        _resendSuccess = true;
+      });
+    } on AuthException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isSending = false;
+        _error = _mapErrorCode(e.code);
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _isSending = false;
+        _error = AppStrings.operationError;
+      });
+    }
+  }
+
+  Future<void> _onLogout() async {
+    await ref.read(authServiceProvider).signOut();
+  }
+
+  String _mapErrorCode(String code) {
+    return switch (code) {
+      'too-many-requests' => 'しばらく時間をおいてから再度お試しください',
+      _ => AppStrings.operationError,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = ref.watch(authStateProvider).valueOrNull;
+    final email = user?.email ?? '';
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: const Text(AppStrings.emailVerificationPageTitle),
+        centerTitle: true,
+        elevation: 0,
+        automaticallyImplyLeading: false,
+      ),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.x3l,
+            vertical: AppSpacing.x4l,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Icon(
+                Icons.mark_email_unread_outlined,
+                size: 64,
+                color: AppColors.primary,
+              ),
+              const SizedBox(height: AppSpacing.x3l),
+              const Text(
+                AppStrings.emailVerificationSentMessage,
+                textAlign: TextAlign.center,
+                style: AppTextStyle.titleLarge,
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                '$email${AppStrings.emailVerificationDescription}',
+                textAlign: TextAlign.center,
+                style: AppTextStyle.bodyMedium
+                    .copyWith(color: AppColors.textDisabled),
+              ),
+              const SizedBox(height: AppSpacing.x4l),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const SizedBox(
+                    width: AppSize.iconSm,
+                    height: AppSize.iconSm,
+                    child: CircularProgressIndicator(
+                      strokeWidth: AppSize.borderThick,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(
+                    AppStrings.emailVerificationChecking,
+                    style: AppTextStyle.captionSecondary
+                        .copyWith(color: AppColors.textDisabled),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.x4l),
+              if (_resendSuccess)
+                Text(
+                  AppStrings.emailVerificationResendSuccess,
+                  textAlign: TextAlign.center,
+                  style: AppTextStyle.bodyMedium
+                      .copyWith(color: AppColors.primary),
+                ),
+              if (_error != null)
+                Text(
+                  _error!,
+                  textAlign: TextAlign.center,
+                  style: AppTextStyle.captionSecondary
+                      .copyWith(color: Theme.of(context).colorScheme.error),
+                ),
+              const SizedBox(height: AppSpacing.lg),
+              SizedBox(
+                height: AppSize.buttonHeight,
+                child: OutlinedButton(
+                  onPressed: _isSending ? null : _onResend,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppColors.primary,
+                    side: const BorderSide(color: AppColors.primary),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppRadius.lg),
+                    ),
+                  ),
+                  child: _isSending
+                      ? const SizedBox(
+                          width: AppSize.iconMd,
+                          height: AppSize.iconMd,
+                          child: CircularProgressIndicator(
+                            strokeWidth: AppSize.borderThick,
+                            color: AppColors.primary,
+                          ),
+                        )
+                      : const Text(AppStrings.emailVerificationResendButton),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.x2l),
+              TextButton(
+                onPressed: _onLogout,
+                child: const Text(
+                  AppStrings.settingsLogout,
+                  style: TextStyle(color: AppColors.textDisabled),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/pages/auth/view/email_verification_page.dart
+++ b/lib/screens/pages/auth/view/email_verification_page.dart
@@ -45,15 +45,13 @@ class _EmailVerificationPageState extends ConsumerState<EmailVerificationPage> {
   }
 
   Future<void> _onResend() async {
-    final user = ref.read(authStateProvider).valueOrNull;
-    final email = user?.email ?? '';
     setState(() {
       _isSending = true;
       _resendSuccess = false;
       _error = null;
     });
     try {
-      await ref.read(authServiceProvider).sendPasswordResetEmail(email);
+      await ref.read(authServiceProvider).sendEmailVerification();
       if (!mounted) return;
       setState(() {
         _isSending = false;

--- a/lib/screens/pages/auth/view/email_verification_page.dart
+++ b/lib/screens/pages/auth/view/email_verification_page.dart
@@ -45,13 +45,15 @@ class _EmailVerificationPageState extends ConsumerState<EmailVerificationPage> {
   }
 
   Future<void> _onResend() async {
+    final user = ref.read(authStateProvider).valueOrNull;
+    final email = user?.email ?? '';
     setState(() {
       _isSending = true;
       _resendSuccess = false;
       _error = null;
     });
     try {
-      await ref.read(authServiceProvider).sendEmailVerification();
+      await ref.read(authServiceProvider).sendPasswordResetEmail(email);
       if (!mounted) return;
       setState(() {
         _isSending = false;

--- a/lib/screens/pages/auth/view/password_reset_page.dart
+++ b/lib/screens/pages/auth/view/password_reset_page.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_spacing.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+/// パスワードリセットページ
+class PasswordResetPage extends ConsumerStatefulWidget {
+  const PasswordResetPage({super.key});
+
+  @override
+  ConsumerState<PasswordResetPage> createState() => _PasswordResetPageState();
+}
+
+class _PasswordResetPageState extends ConsumerState<PasswordResetPage> {
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _onSend() {
+    FocusScope.of(context).unfocus();
+    final email = _emailController.text.trim();
+    if (email.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('メールアドレスを入力してください')),
+      );
+      return;
+    }
+    ref.read(passwordResetProvider.notifier).send(email);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(passwordResetProvider);
+    final isLoading = state is PasswordResetLoading;
+    final isSuccess = state is PasswordResetSuccess;
+    final error = state is PasswordResetError ? state.message : null;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: const Text(AppStrings.passwordResetPageTitle),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      body: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.x3l,
+            vertical: AppSpacing.x4l,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                AppStrings.passwordResetDescription,
+                style: AppTextStyle.bodyMedium
+                    .copyWith(color: AppColors.textDisabled),
+              ),
+              const SizedBox(height: AppSpacing.x4l),
+              TextField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                enabled: !isSuccess,
+                decoration: InputDecoration(
+                  labelText: AppStrings.passwordResetEmailLabel,
+                  hintText: 'example@mail.com',
+                  errorText: error,
+                  errorMaxLines: 3,
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.mail_outline),
+                ),
+                textInputAction: TextInputAction.done,
+                onSubmitted: (_) => _onSend(),
+              ),
+              const SizedBox(height: AppSpacing.x3l),
+              if (isSuccess)
+                Text(
+                  AppStrings.passwordResetSuccessMessage,
+                  textAlign: TextAlign.center,
+                  style: AppTextStyle.bodyMedium
+                      .copyWith(color: AppColors.primary),
+                )
+              else
+                SizedBox(
+                  height: AppSize.buttonHeight,
+                  child: FilledButton(
+                    onPressed: isLoading ? null : _onSend,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: AppColors.textOnPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadius.lg),
+                      ),
+                    ),
+                    child: isLoading
+                        ? const SizedBox(
+                            width: AppSize.iconMd,
+                            height: AppSize.iconMd,
+                            child: CircularProgressIndicator(
+                              strokeWidth: AppSize.borderThick,
+                              color: AppColors.textOnPrimary,
+                            ),
+                          )
+                        : const Text(AppStrings.passwordResetSendButton),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/pages/auth/view/password_set_page.dart
+++ b/lib/screens/pages/auth/view/password_set_page.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
+import 'package:tekushare/core/constants/app_spacing.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/core/constants/app_text_style.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+/// パスワードリセットメールのリンクから遷移するパスワード設定画面
+class PasswordSetPage extends ConsumerStatefulWidget {
+  const PasswordSetPage({super.key, required this.oobCode});
+
+  final String oobCode;
+
+  @override
+  ConsumerState<PasswordSetPage> createState() => _PasswordSetPageState();
+}
+
+class _PasswordSetPageState extends ConsumerState<PasswordSetPage> {
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _obscureConfirm = true;
+  bool _isVerifying = true;
+  bool _isSending = false;
+  String? _email;
+  String? _codeError;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _verifyCode());
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _verifyCode() async {
+    try {
+      final email = await ref
+          .read(authServiceProvider)
+          .verifyPasswordResetCode(widget.oobCode);
+      if (!mounted) return;
+      setState(() {
+        _email = email;
+        _isVerifying = false;
+      });
+    } on AuthException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _codeError = _mapCodeError(e.code);
+        _isVerifying = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _codeError = AppStrings.operationError;
+        _isVerifying = false;
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    FocusScope.of(context).unfocus();
+    final password = _passwordController.text;
+    final confirm = _confirmController.text;
+
+    if (password.length < 6) {
+      setState(() => _error = 'パスワードは6文字以上で入力してください');
+      return;
+    }
+    if (!password.contains(RegExp(r'[a-zA-Z]')) ||
+        !password.contains(RegExp(r'[0-9]'))) {
+      setState(() => _error = 'パスワードは英字と数字を両方含めてください');
+      return;
+    }
+    if (password != confirm) {
+      setState(() => _error = AppStrings.passwordMismatch);
+      return;
+    }
+
+    setState(() {
+      _error = null;
+      _isSending = true;
+    });
+
+    try {
+      final service = ref.read(authServiceProvider);
+      await service.confirmPasswordReset(widget.oobCode, password);
+      await service.signInWithEmail(_email!, password);
+      if (!mounted) return;
+      Navigator.of(context).popUntil((route) => route.isFirst);
+    } on AuthException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = _mapError(e.code);
+        _isSending = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _error = AppStrings.operationError;
+        _isSending = false;
+      });
+    }
+  }
+
+  String _mapCodeError(String code) {
+    return switch (code) {
+      'invalid-action-code' ||
+      'expired-action-code' =>
+        AppStrings.passwordSetInvalidCode,
+      _ => AppStrings.operationError,
+    };
+  }
+
+  String _mapError(String code) {
+    return switch (code) {
+      'weak-password' => 'パスワードは6文字以上の英数字を含めてください',
+      'network-request-failed' => 'ネットワークエラーが発生しました。接続を確認してください',
+      _ => AppStrings.operationError,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: const Text(
+          AppStrings.passwordSetPageTitle,
+          style: TextStyle(color: Colors.white),
+        ),
+        automaticallyImplyLeading: false,
+      ),
+      body: SafeArea(
+        child: _isVerifying
+            ? const Center(child: CircularProgressIndicator())
+            : _codeError != null
+                ? _buildErrorBody()
+                : _buildForm(),
+      ),
+    );
+  }
+
+  Widget _buildErrorBody() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.x3l),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: 64,
+              color: AppColors.error,
+            ),
+            const SizedBox(height: AppSpacing.x2l),
+            Text(
+              _codeError!,
+              textAlign: TextAlign.center,
+              style: AppTextStyle.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.x3l),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('戻る'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x3l,
+        vertical: AppSpacing.x4l,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            AppStrings.passwordSetPageTitle,
+            style: AppTextStyle.titleLarge,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            AppStrings.passwordSetDescription,
+            style:
+                AppTextStyle.bodyMedium.copyWith(color: AppColors.textDisabled),
+          ),
+          const SizedBox(height: AppSpacing.x4l),
+          TextField(
+            controller: _passwordController,
+            obscureText: _obscurePassword,
+            decoration: InputDecoration(
+              labelText: AppStrings.passwordSetLabel,
+              border: const OutlineInputBorder(),
+              prefixIcon: const Icon(Icons.lock_outline),
+              suffixIcon: IconButton(
+                icon: Icon(
+                  _obscurePassword ? Icons.visibility_off : Icons.visibility,
+                ),
+                onPressed: () =>
+                    setState(() => _obscurePassword = !_obscurePassword),
+              ),
+            ),
+            textInputAction: TextInputAction.next,
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          TextField(
+            controller: _confirmController,
+            obscureText: _obscureConfirm,
+            decoration: InputDecoration(
+              labelText: AppStrings.passwordSetConfirmLabel,
+              border: const OutlineInputBorder(),
+              prefixIcon: const Icon(Icons.lock_outline),
+              suffixIcon: IconButton(
+                icon: Icon(
+                  _obscureConfirm ? Icons.visibility_off : Icons.visibility,
+                ),
+                onPressed: () =>
+                    setState(() => _obscureConfirm = !_obscureConfirm),
+              ),
+            ),
+            textInputAction: TextInputAction.done,
+            onSubmitted: (_) => _isSending ? null : _submit(),
+          ),
+          if (_error != null) ...[
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              _error!,
+              style: AppTextStyle.captionSecondary
+                  .copyWith(color: AppColors.error),
+            ),
+          ],
+          const SizedBox(height: AppSpacing.x3l),
+          SizedBox(
+            height: AppSize.buttonHeight,
+            child: FilledButton(
+              onPressed: _isSending ? null : _submit,
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                foregroundColor: AppColors.textOnPrimary,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppRadius.lg),
+                ),
+              ),
+              child: _isSending
+                  ? const SizedBox(
+                      width: AppSize.iconMd,
+                      height: AppSize.iconMd,
+                      child: CircularProgressIndicator(
+                        strokeWidth: AppSize.borderThick,
+                        color: AppColors.textOnPrimary,
+                      ),
+                    )
+                  : const Text(AppStrings.passwordSetButton),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/pages/map/view/walk_route_page.dart
+++ b/lib/screens/pages/map/view/walk_route_page.dart
@@ -1206,7 +1206,7 @@ class _SaveConfirmDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return Dialog(
       insetPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.x2l,
+        horizontal: AppSpacing.x4l,
         vertical: AppSpacing.x2l,
       ),
       shape: RoundedRectangleBorder(
@@ -1334,6 +1334,10 @@ class _SavedDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x4l,
+        vertical: AppSpacing.x2l,
+      ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
       ),

--- a/lib/screens/pages/map/viewmodel/walk_route_viewmodel.dart
+++ b/lib/screens/pages/map/viewmodel/walk_route_viewmodel.dart
@@ -130,7 +130,7 @@ class WalkRouteState {
       );
 }
 
-class WalkRouteViewModel extends Notifier<WalkRouteState> {
+class WalkRouteViewModel extends AutoDisposeNotifier<WalkRouteState> {
   @override
   WalkRouteState build() => const WalkRouteState();
 
@@ -176,6 +176,6 @@ class WalkRouteViewModel extends Notifier<WalkRouteState> {
 }
 
 final walkRouteViewModelProvider =
-    NotifierProvider<WalkRouteViewModel, WalkRouteState>(
+    NotifierProvider.autoDispose<WalkRouteViewModel, WalkRouteState>(
   WalkRouteViewModel.new,
 );

--- a/lib/screens/pages/settings/view/phone_register_page.dart
+++ b/lib/screens/pages/settings/view/phone_register_page.dart
@@ -253,6 +253,10 @@ class _RegisterConfirmDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x4l,
+        vertical: AppSpacing.x2l,
+      ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
       ),
@@ -340,6 +344,10 @@ class _RegisterSuccessDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x4l,
+        vertical: AppSpacing.x2l,
+      ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
       ),

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -631,6 +631,10 @@ class _ContactsListDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final remaining = _maxContacts - contacts.length;
     return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x4l,
+        vertical: AppSpacing.x2l,
+      ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
       ),

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -528,7 +528,7 @@ class _InactivityCard extends StatelessWidget {
                     Text(
                       AppStrings.settingsInactivitySubtitle,
                       style: TextStyle(
-                        fontSize: AppTextStyle.xs,
+                        fontSize: AppTextStyle.xxs,
                         color: AppColors.textDisabled,
                       ),
                     ),

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -692,7 +692,7 @@ class _DeletedDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return Dialog(
       insetPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.x2l,
+        horizontal: AppSpacing.x4l,
         vertical: AppSpacing.x2l,
       ),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),

--- a/lib/screens/pages/spot/view/spot_detail_page.dart
+++ b/lib/screens/pages/spot/view/spot_detail_page.dart
@@ -190,7 +190,7 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
     );
   }
 
-  /// 確認ダイアログを閉じ→ローディング表示→操作完了→ページバック+SnackBar
+  /// 確認ダイアログを閉じ→ローディング表示→操作完了→保存完了ダイアログ表示→ページバック
   Future<void> _runWithLoading(
     Future<void> Function() operation,
     String message,
@@ -215,10 +215,18 @@ class _SpotDetailPageState extends ConsumerState<SpotDetailPage> {
       return;
     }
     if (!mounted) return;
-    final messenger = ScaffoldMessenger.of(context);
     Navigator.pop(context); // ローディングを閉じる
-    Navigator.pop(context); // 詳細ページから戻る
-    messenger.showSnackBar(SnackBar(content: Text(message)));
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => _SavedDialog(
+        message: message,
+        onClose: () {
+          Navigator.pop(context); // 完了ダイアログを閉じる
+          Navigator.pop(context); // 詳細ページから戻る
+        },
+      ),
+    );
   }
 
   @override
@@ -673,6 +681,67 @@ class _SaveButton extends StatelessWidget {
             fontSize: sizing.detailBtnFontSize,
             fontWeight: FontWeight.w500,
           ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────
+// 保存完了ダイアログ
+// ──────────────────────────────────────────
+
+class _SavedDialog extends StatelessWidget {
+  const _SavedDialog({required this.message, required this.onClose});
+
+  final String message;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x4l,
+        vertical: AppSpacing.x2l,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          28,
+          AppSpacing.lg,
+          AppSpacing.xl,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: AppTextStyle.lg2,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.x2l),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: onClose,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(AppRadius.sm),
+                  ),
+                ),
+                child: const Text(AppStrings.closeButton),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -496,7 +496,7 @@ class _SavedDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return Dialog(
       insetPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.x2l,
+        horizontal: AppSpacing.x4l,
         vertical: AppSpacing.x2l,
       ),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
@@ -559,7 +559,7 @@ class _ConfirmDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return Dialog(
       insetPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.x2l,
+        horizontal: AppSpacing.x4l,
         vertical: AppSpacing.x2l,
       ),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -6,7 +6,6 @@ import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/theme/app_sizing_theme.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
-import 'package:tekushare/domain/entities/lat_lng.dart' as domain;
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/screens/pages/map/view/walk_route_page.dart';
 import 'package:tekushare/screens/pages/settings/view/settings_page.dart';
@@ -14,15 +13,14 @@ import 'package:tekushare/screens/providers/walk_history_provider.dart';
 import 'package:tekushare/screens/providers/walk_routes_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/providers/walk_timer_provider.dart';
+import 'package:tekushare/screens/providers/walk_track_points_provider.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 
 /// 散歩終了確認ページ
 class EndWalkPage extends ConsumerStatefulWidget {
-  const EndWalkPage({super.key, this.trackPoints = const []});
-
-  final List<domain.LatLng> trackPoints;
+  const EndWalkPage({super.key});
 
   @override
   ConsumerState<EndWalkPage> createState() => _EndWalkPageState();
@@ -81,10 +79,11 @@ class _EndWalkPageState extends ConsumerState<EndWalkPage>
     if (_isProcessing) return;
     _isProcessing = true;
     final session = ref.read(walkSessionProvider);
+    final trackPoints = ref.read(walkTrackPointsProvider);
     final route = WalkRoute(
       id: session.id,
       walkSessionId: session.id,
-      points: widget.trackPoints,
+      points: trackPoints,
       createdAt: DateTime.now(),
     );
     await ref.read(walkSessionProvider.notifier).endWalk(route);

--- a/lib/screens/pages/walk/view/end_walk_page.dart
+++ b/lib/screens/pages/walk/view/end_walk_page.dart
@@ -203,7 +203,7 @@ class _ConfirmCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.symmetric(horizontal: AppSpacing.x2l),
+      margin: const EdgeInsets.symmetric(horizontal: AppSpacing.x4l),
       padding: const EdgeInsets.fromLTRB(
         AppSpacing.x2l,
         AppSpacing.x3l,

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -9,7 +9,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:geolocator/geolocator.dart' show Position;
 import 'package:latlong2/latlong.dart';
-import 'package:tekushare/domain/entities/lat_lng.dart' as domain;
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -23,14 +22,18 @@ import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
 import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/providers/location_provider.dart';
 import 'package:tekushare/screens/providers/spot_provider.dart';
 import 'package:tekushare/screens/providers/walk_timer_provider.dart';
+import 'package:tekushare/screens/providers/walk_track_points_provider.dart';
 import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 import 'package:tekushare/screens/widgets/common/primary_button.dart';
+
+const _gpsTimeoutSeconds = 30;
 
 /// 散歩モード画面
 class WalkPage extends ConsumerStatefulWidget {
@@ -42,7 +45,6 @@ class WalkPage extends ConsumerStatefulWidget {
 
 class _WalkPageState extends ConsumerState<WalkPage> {
   final _mapController = MapController();
-  final _trackPoints = <LatLng>[];
   final _photoMarkers = <({LatLng point, String imagePath})>[];
   LatLng? _currentPosition;
   LatLng? _lastMovedPosition;
@@ -50,6 +52,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
   bool _mapControllerAttached = false;
 
   Timer? _tickTimer;
+  Timer? _gpsTimeoutTimer;
 
   @override
   void initState() {
@@ -60,14 +63,17 @@ class _WalkPageState extends ConsumerState<WalkPage> {
       final settings = ref.read(settingsViewModelProvider);
       ref.read(walkTimerProvider.notifier).initializeIfNeeded(
             timerEnabled: settings.timerEnabled,
-            timerMinutes: settings.timerRoundTrip
-                ? settings.timerMinutes ~/ 2
-                : settings.timerMinutes,
+            timerMinutes: settings.timerMinutes,
+            timerRoundTrip: settings.timerRoundTrip,
             inactivityEnabled: settings.inactivityEnabled,
             inactivityMinutes: settings.inactivityMinutes,
           );
     });
     _tickTimer = Timer.periodic(const Duration(seconds: 1), _onTick);
+    _gpsTimeoutTimer = Timer(
+      const Duration(seconds: _gpsTimeoutSeconds),
+      _onGpsTimeout,
+    );
   }
 
   void _onTick(Timer _) {
@@ -79,6 +85,14 @@ class _WalkPageState extends ConsumerState<WalkPage> {
   Future<void> _fireNotificationsIfNeeded() async {
     final svc = ref.read(notificationServiceProvider);
     final ts = ref.read(walkTimerProvider);
+    // 往復タイマーの折り返し通知（全体の半分の時間になったとき）
+    final midpoint = ts.midpointSeconds;
+    if (midpoint != null &&
+        ts.turnSecondsLeft == midpoint &&
+        !ts.midpointFired) {
+      ref.read(walkTimerProvider.notifier).markMidpointFired();
+      await svc.showRoundTripNotification();
+    }
     if (ts.turnSecondsLeft == 0 && !ts.turnFired) {
       ref.read(walkTimerProvider.notifier).markTurnFired();
       await svc.showTurnaroundNotification();
@@ -159,8 +173,37 @@ class _WalkPageState extends ConsumerState<WalkPage> {
   @override
   void dispose() {
     _tickTimer?.cancel();
+    _gpsTimeoutTimer?.cancel();
     _mapController.dispose();
     super.dispose();
+  }
+
+  void _onGpsTimeout() {
+    if (!mounted || _currentPosition != null) return;
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => AlertDialog(
+        title: const Text(AppStrings.gpsTimeoutTitle),
+        content: const Text(AppStrings.gpsTimeoutMessage),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              ref.read(notificationServiceProvider).cancelAll();
+              ref.read(walkTimerProvider.notifier).reset();
+              ref.read(walkSessionProvider.notifier).resetWalk();
+              Navigator.popUntil(context, (route) => route.isFirst);
+            },
+            child: const Text(AppStrings.gpsTimeoutRetry),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text(AppStrings.gpsTimeoutContinue),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _onTakePhotoPressed(
@@ -198,10 +241,11 @@ class _WalkPageState extends ConsumerState<WalkPage> {
     // エラー時は _GpsStatusIndicator（ref.watch 側）がフィードバックを担う
     ref.listen<AsyncValue<Position>>(locationProvider, (_, next) {
       next.whenData((pos) {
+        _gpsTimeoutTimer?.cancel();
+        _gpsTimeoutTimer = null;
         final point = LatLng(pos.latitude, pos.longitude);
         setState(() {
           _currentPosition = point;
-          _trackPoints.add(point);
           // heading < 0 は「取得不可」を示すので最後の有効値を維持する
           if (pos.heading >= 0) _currentHeading = pos.heading;
         });
@@ -291,17 +335,23 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                                     'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                                 userAgentPackageName: 'com.example.tekushare',
                               ),
-                              if (_trackPoints.length >= 2)
-                                PolylineLayer(
+                              Builder(builder: (context) {
+                                final pts = ref
+                                    .watch(walkTrackPointsProvider)
+                                    .map((p) => LatLng(p.latitude, p.longitude))
+                                    .toList();
+                                if (pts.length < 2) return const SizedBox();
+                                return PolylineLayer(
                                   polylines: [
                                     Polyline(
-                                      points: _trackPoints,
+                                      points: pts,
                                       color: AppColors.primary,
                                       strokeWidth:
                                           MapConstants.polylineStrokeWidth,
                                     ),
                                   ],
-                                ),
+                                );
+                              }),
                               MarkerLayer(
                                 markers: [
                                   Marker(
@@ -476,13 +526,10 @@ class _WalkPageState extends ConsumerState<WalkPage> {
                   height: sizing.largeBtnHeight,
                   onPressed: () {
                     ref.read(notificationServiceProvider).cancelAll();
-                    final domainPoints = _trackPoints
-                        .map((p) => domain.LatLng(p.latitude, p.longitude))
-                        .toList();
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => EndWalkPage(trackPoints: domainPoints),
+                        builder: (_) => const EndWalkPage(),
                       ),
                     );
                   },

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -183,13 +183,13 @@ class _WalkPageState extends ConsumerState<WalkPage> {
     showDialog<void>(
       context: context,
       barrierDismissible: false,
-      builder: (_) => AlertDialog(
+      builder: (dialogContext) => AlertDialog(
         title: const Text(AppStrings.gpsTimeoutTitle),
         content: const Text(AppStrings.gpsTimeoutMessage),
         actions: [
           TextButton(
             onPressed: () {
-              Navigator.pop(context);
+              Navigator.pop(dialogContext);
               ref.read(notificationServiceProvider).cancelAll();
               ref.read(walkTimerProvider.notifier).reset();
               ref.read(walkSessionProvider.notifier).resetWalk();
@@ -198,7 +198,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
             child: const Text(AppStrings.gpsTimeoutRetry),
           ),
           TextButton(
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => Navigator.pop(dialogContext),
             child: const Text(AppStrings.gpsTimeoutContinue),
           ),
         ],

--- a/lib/screens/providers/account_link_provider.dart
+++ b/lib/screens/providers/account_link_provider.dart
@@ -1,9 +1,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tekushare/domain/entities/linked_account.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
 
 /// 自分と連携済みのアカウント一覧
+///
+/// authStateProvider を watch することで、ログアウト・別アカウントでのログイン時に
+/// 自動的に再購読し、前ユーザーのデータが残らないようにする。
 final linkedAccountsProvider = StreamProvider<List<LinkedAccount>>((ref) {
+  final user = ref.watch(authStateProvider).valueOrNull;
+  if (user == null) return Stream.value([]);
   return ref.watch(accountLinkRepositoryProvider).watchLinkedAccounts();
 });
 

--- a/lib/screens/providers/app_providers.dart
+++ b/lib/screens/providers/app_providers.dart
@@ -59,7 +59,8 @@ final routeRepositoryProvider = Provider<RouteRepository>((ref) {
 });
 
 final savedRouteRepositoryProvider = Provider<SavedRouteRepository>((ref) {
-  return SavedRouteRepositoryImpl(ref.watch(isarProvider).requireValue);
+  final uid = ref.watch(authStateProvider).value?.uid ?? '';
+  return SavedRouteRepositoryImpl(ref.watch(isarProvider).requireValue, uid);
 });
 
 final photoRepositoryProvider = Provider<PhotoRepository>((ref) {

--- a/lib/screens/providers/app_providers.dart
+++ b/lib/screens/providers/app_providers.dart
@@ -49,11 +49,13 @@ final spotRepositoryProvider = Provider<SpotRepository>((ref) {
 });
 
 final walkSessionRepositoryProvider = Provider<WalkSessionRepository>((ref) {
-  return WalkSessionRepositoryImpl(ref.watch(isarProvider).requireValue);
+  final uid = ref.watch(authStateProvider).value?.uid ?? '';
+  return WalkSessionRepositoryImpl(ref.watch(isarProvider).requireValue, uid);
 });
 
 final routeRepositoryProvider = Provider<RouteRepository>((ref) {
-  return RouteRepositoryImpl(ref.watch(isarProvider).requireValue);
+  final uid = ref.watch(authStateProvider).value?.uid ?? '';
+  return RouteRepositoryImpl(ref.watch(isarProvider).requireValue, uid);
 });
 
 final savedRouteRepositoryProvider = Provider<SavedRouteRepository>((ref) {

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -46,15 +46,15 @@ class EmailAuthError extends EmailAuthState {
 }
 
 class EmailAuthRegistered extends EmailAuthState {
-  const EmailAuthRegistered({required this.email});
-  final String email;
+  const EmailAuthRegistered();
 }
 
 // ── Auth service interface ────────────────────────────────────────────────────
 
 abstract interface class AuthService {
   Stream<AuthUser?> watchAuthState();
-  Future<void> registerWithEmail(String email, String displayName);
+  Future<void> registerWithEmail(
+      String email, String displayName, String password);
   Future<void> signInWithEmail(String email, String password);
   Future<void> setDisplayName(String name);
   Future<void> signOut();
@@ -86,6 +86,8 @@ String _mapErrorCode(String code) {
     'invalid-credential' => 'メールアドレスまたはパスワードが間違っています',
     'too-many-requests' => 'しばらく時間をおいてから再度お試しください',
     'network-request-failed' => 'ネットワークエラーが発生しました。接続を確認してください',
+    'email-not-verified' =>
+      'メールアドレスの確認が完了していません。\nお届けしたメール内のリンクをクリックしてからログインしてください。',
     _ => '認証エラーが発生しました（$code）',
   };
 }
@@ -95,11 +97,12 @@ class EmailAuthNotifier extends StateNotifier<EmailAuthState> {
 
   final AuthService _service;
 
-  Future<void> register(String email, String displayName) async {
+  Future<void> register(
+      String email, String displayName, String password) async {
     state = const EmailAuthLoading();
     try {
-      await _service.registerWithEmail(email, displayName);
-      state = EmailAuthRegistered(email: email);
+      await _service.registerWithEmail(email, displayName, password);
+      state = const EmailAuthRegistered();
     } on AuthException catch (e) {
       state = EmailAuthError(_mapErrorCode(e.code));
     } catch (_) {

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -3,9 +3,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 // ── ドメイン型 ─────────────────────────────────────────────────────────────────
 
 class AuthUser {
-  const AuthUser({required this.uid, this.displayName});
+  const AuthUser({
+    required this.uid,
+    this.displayName,
+    this.email,
+    this.emailVerified = false,
+  });
   final String uid;
   final String? displayName;
+  final String? email;
+  final bool emailVerified;
 }
 
 class AuthException implements Exception {
@@ -49,6 +56,8 @@ abstract interface class AuthService {
   Future<void> signOut();
   Future<void> deleteUser();
   Future<void> sendPasswordResetEmail(String email);
+  Future<void> sendEmailVerification();
+  Future<void> reloadCurrentUser();
 }
 
 // ── Provider declaration ──────────────────────────────────────────────────────

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -48,6 +48,7 @@ abstract interface class AuthService {
   Future<void> setDisplayName(String name);
   Future<void> signOut();
   Future<void> deleteUser();
+  Future<void> sendPasswordResetEmail(String email);
 }
 
 // ── Provider declaration ──────────────────────────────────────────────────────
@@ -109,6 +110,54 @@ class EmailAuthNotifier extends StateNotifier<EmailAuthState> {
 final emailAuthProvider =
     StateNotifierProvider<EmailAuthNotifier, EmailAuthState>((ref) {
   return EmailAuthNotifier(ref.watch(authServiceProvider));
+});
+
+// ── Password reset notifier ───────────────────────────────────────────────────
+
+sealed class PasswordResetState {
+  const PasswordResetState();
+}
+
+class PasswordResetIdle extends PasswordResetState {
+  const PasswordResetIdle();
+}
+
+class PasswordResetLoading extends PasswordResetState {
+  const PasswordResetLoading();
+}
+
+class PasswordResetSuccess extends PasswordResetState {
+  const PasswordResetSuccess();
+}
+
+class PasswordResetError extends PasswordResetState {
+  const PasswordResetError(this.message);
+  final String message;
+}
+
+class PasswordResetNotifier extends StateNotifier<PasswordResetState> {
+  PasswordResetNotifier(this._service) : super(const PasswordResetIdle());
+
+  final AuthService _service;
+
+  Future<void> send(String email) async {
+    state = const PasswordResetLoading();
+    try {
+      await _service.sendPasswordResetEmail(email);
+      state = const PasswordResetSuccess();
+    } on AuthException catch (e) {
+      state = PasswordResetError(_mapErrorCode(e.code));
+    } catch (_) {
+      state = const PasswordResetError('エラーが発生しました');
+    }
+  }
+
+  void reset() => state = const PasswordResetIdle();
+}
+
+final passwordResetProvider =
+    StateNotifierProvider<PasswordResetNotifier, PasswordResetState>((ref) {
+  return PasswordResetNotifier(ref.watch(authServiceProvider));
 });
 
 // ── Display name notifier ─────────────────────────────────────────────────────

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -49,8 +49,7 @@ class EmailAuthError extends EmailAuthState {
 
 abstract interface class AuthService {
   Stream<AuthUser?> watchAuthState();
-  Future<void> registerWithEmail(
-      String email, String password, String displayName);
+  Future<void> registerWithEmail(String email, String displayName);
   Future<void> signInWithEmail(String email, String password);
   Future<void> setDisplayName(String name);
   Future<void> signOut();
@@ -89,11 +88,10 @@ class EmailAuthNotifier extends StateNotifier<EmailAuthState> {
 
   final AuthService _service;
 
-  Future<void> register(
-      String email, String password, String displayName) async {
+  Future<void> register(String email, String displayName) async {
     state = const EmailAuthLoading();
     try {
-      await _service.registerWithEmail(email, password, displayName);
+      await _service.registerWithEmail(email, displayName);
       state = const EmailAuthIdle();
     } on AuthException catch (e) {
       state = EmailAuthError(_mapErrorCode(e.code));

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -57,6 +57,8 @@ abstract interface class AuthService {
   Future<void> sendPasswordResetEmail(String email);
   Future<void> sendEmailVerification();
   Future<void> reloadCurrentUser();
+  Future<String> verifyPasswordResetCode(String code);
+  Future<void> confirmPasswordReset(String code, String newPassword);
 }
 
 // ── Provider declaration ──────────────────────────────────────────────────────

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -46,7 +46,8 @@ class EmailAuthError extends EmailAuthState {
 }
 
 class EmailAuthRegistered extends EmailAuthState {
-  const EmailAuthRegistered();
+  const EmailAuthRegistered({required this.email});
+  final String email;
 }
 
 // ── Auth service interface ────────────────────────────────────────────────────
@@ -98,7 +99,7 @@ class EmailAuthNotifier extends StateNotifier<EmailAuthState> {
     state = const EmailAuthLoading();
     try {
       await _service.registerWithEmail(email, displayName);
-      state = const EmailAuthRegistered();
+      state = EmailAuthRegistered(email: email);
     } on AuthException catch (e) {
       state = EmailAuthError(_mapErrorCode(e.code));
     } catch (_) {

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -79,6 +79,7 @@ String _mapErrorCode(String code) {
     'wrong-password' => 'パスワードが間違っています',
     'invalid-credential' => 'メールアドレスまたはパスワードが間違っています',
     'too-many-requests' => 'しばらく時間をおいてから再度お試しください',
+    'network-request-failed' => 'ネットワークエラーが発生しました。接続を確認してください',
     _ => '認証エラーが発生しました（$code）',
   };
 }

--- a/lib/screens/providers/auth_provider.dart
+++ b/lib/screens/providers/auth_provider.dart
@@ -45,6 +45,10 @@ class EmailAuthError extends EmailAuthState {
   final String message;
 }
 
+class EmailAuthRegistered extends EmailAuthState {
+  const EmailAuthRegistered();
+}
+
 // ── Auth service interface ────────────────────────────────────────────────────
 
 abstract interface class AuthService {
@@ -94,7 +98,7 @@ class EmailAuthNotifier extends StateNotifier<EmailAuthState> {
     state = const EmailAuthLoading();
     try {
       await _service.registerWithEmail(email, displayName);
-      state = const EmailAuthIdle();
+      state = const EmailAuthRegistered();
     } on AuthException catch (e) {
       state = EmailAuthError(_mapErrorCode(e.code));
     } catch (_) {

--- a/lib/screens/providers/walk_timer_provider.dart
+++ b/lib/screens/providers/walk_timer_provider.dart
@@ -3,16 +3,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class WalkTimerState {
   const WalkTimerState({
     this.turnSecondsLeft,
+    this.midpointSeconds,
     this.inactSecondsLeft,
     this.turnFired = false,
+    this.midpointFired = false,
     this.inactFired = false,
     this.turnAlertShown = false,
     this.initialized = false,
   });
 
   final int? turnSecondsLeft;
+
+  /// 往復モード時に折り返し通知を出す残り秒数（全体の半分）
+  final int? midpointSeconds;
   final int? inactSecondsLeft;
   final bool turnFired;
+  final bool midpointFired;
   final bool inactFired;
   final bool turnAlertShown;
   final bool initialized;
@@ -25,12 +31,16 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
   void initializeIfNeeded({
     required bool timerEnabled,
     required int timerMinutes,
+    required bool timerRoundTrip,
     required bool inactivityEnabled,
     required int inactivityMinutes,
   }) {
     if (state.initialized) return;
+    final totalSeconds = timerEnabled ? timerMinutes * 60 : null;
     state = WalkTimerState(
-      turnSecondsLeft: timerEnabled ? timerMinutes * 60 : null,
+      turnSecondsLeft: totalSeconds,
+      midpointSeconds:
+          totalSeconds != null && timerRoundTrip ? totalSeconds ~/ 2 : null,
       inactSecondsLeft: inactivityEnabled ? inactivityMinutes * 60 : null,
       initialized: true,
     );
@@ -42,10 +52,12 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       turnSecondsLeft: s.turnSecondsLeft != null && s.turnSecondsLeft! > 0
           ? s.turnSecondsLeft! - 1
           : s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
       inactSecondsLeft: s.inactSecondsLeft != null && s.inactSecondsLeft! > 0
           ? s.inactSecondsLeft! - 1
           : s.inactSecondsLeft,
       turnFired: s.turnFired,
+      midpointFired: s.midpointFired,
       inactFired: s.inactFired,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
@@ -56,8 +68,24 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
     final s = state;
     state = WalkTimerState(
       turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
       inactSecondsLeft: s.inactSecondsLeft,
       turnFired: true,
+      midpointFired: s.midpointFired,
+      inactFired: s.inactFired,
+      turnAlertShown: s.turnAlertShown,
+      initialized: s.initialized,
+    );
+  }
+
+  void markMidpointFired() {
+    final s = state;
+    state = WalkTimerState(
+      turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
+      inactSecondsLeft: s.inactSecondsLeft,
+      turnFired: s.turnFired,
+      midpointFired: true,
       inactFired: s.inactFired,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
@@ -68,8 +96,10 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
     final s = state;
     state = WalkTimerState(
       turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
       inactSecondsLeft: s.inactSecondsLeft,
       turnFired: s.turnFired,
+      midpointFired: s.midpointFired,
       inactFired: true,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
@@ -80,8 +110,10 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
     final s = state;
     state = WalkTimerState(
       turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
       inactSecondsLeft: s.inactSecondsLeft,
       turnFired: s.turnFired,
+      midpointFired: s.midpointFired,
       inactFired: s.inactFired,
       turnAlertShown: true,
       initialized: s.initialized,
@@ -92,8 +124,10 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
     final s = state;
     state = WalkTimerState(
       turnSecondsLeft: minutes * 60,
+      midpointSeconds: s.midpointSeconds,
       inactSecondsLeft: s.inactSecondsLeft,
       turnFired: false,
+      midpointFired: false,
       inactFired: s.inactFired,
       turnAlertShown: false,
       initialized: s.initialized,
@@ -104,8 +138,10 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
     final s = state;
     state = WalkTimerState(
       turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
       inactSecondsLeft: minutes * 60,
       turnFired: s.turnFired,
+      midpointFired: s.midpointFired,
       inactFired: false,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,

--- a/lib/screens/providers/walk_timer_provider.dart
+++ b/lib/screens/providers/walk_timer_provider.dart
@@ -122,9 +122,10 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
 
   void resetTurn(int minutes) {
     final s = state;
+    final totalSeconds = minutes * 60;
     state = WalkTimerState(
-      turnSecondsLeft: minutes * 60,
-      midpointSeconds: s.midpointSeconds,
+      turnSecondsLeft: totalSeconds,
+      midpointSeconds: s.midpointSeconds != null ? totalSeconds ~/ 2 : null,
       inactSecondsLeft: s.inactSecondsLeft,
       turnFired: false,
       midpointFired: false,

--- a/lib/screens/providers/walk_track_points_provider.dart
+++ b/lib/screens/providers/walk_track_points_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart' show Position;
+import 'package:tekushare/domain/entities/lat_lng.dart' as domain;
+import 'package:tekushare/domain/entities/walk_session.dart';
+import 'package:tekushare/screens/providers/location_provider.dart';
+import 'package:tekushare/screens/providers/walk_session_provider.dart';
+
+/// 散歩中に蓄積した GPS トラックポイントを保持するプロバイダー。
+/// 散歩中でない場合は空リストを返し、散歩終了や別ページへの遷移があっても
+/// ウォーキング中はデータが消えない。
+class WalkTrackPointsNotifier extends Notifier<List<domain.LatLng>> {
+  @override
+  List<domain.LatLng> build() {
+    final status = ref.watch(walkSessionProvider.select((s) => s.status));
+    if (status != WalkStatus.walking) return [];
+
+    // プロバイダー初期化時点で locationProvider がすでに GPS 位置を持っている場合
+    // （FlutterMap が表示されてから本プロバイダーが初めてアクセスされるケース）は
+    // キャッシュ値を初期点として取り込む。
+    final cached = ref.read(locationProvider).valueOrNull;
+    final initial = cached != null
+        ? [domain.LatLng(cached.latitude, cached.longitude)]
+        : <domain.LatLng>[];
+
+    ref.listen<AsyncValue<Position>>(locationProvider, (_, next) {
+      next.whenData((pos) {
+        final p = domain.LatLng(pos.latitude, pos.longitude);
+        // 初期点と重複する場合は追加しない
+        if (state.isNotEmpty &&
+            state.last.latitude == p.latitude &&
+            state.last.longitude == p.longitude) {
+          return;
+        }
+        state = [...state, p];
+      });
+    });
+
+    return initial;
+  }
+}
+
+final walkTrackPointsProvider =
+    NotifierProvider<WalkTrackPointsNotifier, List<domain.LatLng>>(
+  WalkTrackPointsNotifier.new,
+);

--- a/lib/screens/widgets/common/app_confirm_dialog.dart
+++ b/lib/screens/widgets/common/app_confirm_dialog.dart
@@ -48,6 +48,10 @@ class _AppConfirmDialogState extends State<AppConfirmDialog> {
   @override
   Widget build(BuildContext context) {
     return Dialog(
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.x4l,
+        vertical: AppSpacing.x2l,
+      ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
       ),

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -2,6 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/app.dart';
+import 'package:tekushare/core/config/flavor.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+class _FakeAuthService implements AuthService {
+  @override
+  Stream<AuthUser?> watchAuthState() => const Stream.empty();
+  @override
+  Future<void> registerWithEmail(String email, String displayName) async {}
+  @override
+  Future<void> signInWithEmail(String email, String password) async {}
+  @override
+  Future<void> setDisplayName(String name) async {}
+  @override
+  Future<void> signOut() async {}
+  @override
+  Future<void> deleteUser() async {}
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
+  @override
+  Future<void> sendEmailVerification() async {}
+  @override
+  Future<void> reloadCurrentUser() async {}
+  @override
+  Future<String> verifyPasswordResetCode(String code) async => '';
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
+}
 
 void main() {
   group('TekuShareApp', () {
@@ -11,8 +39,15 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
+      AppConfig.setFlavor(Flavor.dev);
       await tester.pumpWidget(
-        const ProviderScope(child: TekuShareApp()),
+        ProviderScope(
+          overrides: [
+            appReadyProvider.overrideWith((ref) async {}),
+            authServiceProvider.overrideWithValue(_FakeAuthService()),
+          ],
+          child: const TekuShareApp(),
+        ),
       );
       await tester.pump(const Duration(seconds: 3));
 

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -10,7 +10,7 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName, String password) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -10,7 +10,8 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(String email, String displayName, String password) async {}
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override

--- a/test/data/models/walk_route_model_test.dart
+++ b/test/data/models/walk_route_model_test.dart
@@ -21,16 +21,17 @@ void main() {
 
   group('WalkRouteModel', () {
     test('fromEntity でエンティティからモデルに変換できる', () {
-      final model = WalkRouteModel.fromEntity(makeRoute());
+      final model = WalkRouteModel.fromEntity(makeRoute(), 'user-1');
 
       expect(model.uid, 'route-1');
       expect(model.walkSessionId, 'session-1');
+      expect(model.userUid, 'user-1');
       expect(model.createdAt, createdAt);
       expect(model.pointsJson, isNotEmpty);
     });
 
     test('toEntity でモデルからエンティティに変換できる', () {
-      final model = WalkRouteModel.fromEntity(makeRoute());
+      final model = WalkRouteModel.fromEntity(makeRoute(), 'user-1');
       final route = model.toEntity();
 
       expect(route.id, 'route-1');
@@ -39,7 +40,7 @@ void main() {
     });
 
     test('ポイントリストが正しく変換される', () {
-      final model = WalkRouteModel.fromEntity(makeRoute());
+      final model = WalkRouteModel.fromEntity(makeRoute(), 'user-1');
       final route = model.toEntity();
 
       expect(route.points.length, 2);
@@ -56,7 +57,7 @@ void main() {
         points: [],
         createdAt: createdAt,
       );
-      final model = WalkRouteModel.fromEntity(emptyRoute);
+      final model = WalkRouteModel.fromEntity(emptyRoute, 'user-1');
       final route = model.toEntity();
 
       expect(route.points, isEmpty);

--- a/test/data/models/walk_session_model_test.dart
+++ b/test/data/models/walk_session_model_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('WalkSessionModel', () {
     test('fromEntity で idle セッションを変換できる', () {
       const session = WalkSession(id: 'session-1', status: WalkStatus.idle);
-      final model = WalkSessionModel.fromEntity(session);
+      final model = WalkSessionModel.fromEntity(session, 'user-1');
 
       expect(model.uid, 'session-1');
       expect(model.status, WalkStatus.idle);
@@ -25,7 +25,7 @@ void main() {
         finishedAt: finishedAt,
         elapsedSeconds: 1800,
       );
-      final model = WalkSessionModel.fromEntity(session);
+      final model = WalkSessionModel.fromEntity(session, 'user-1');
 
       expect(model.status, WalkStatus.finished);
       expect(model.startedAt, startedAt);
@@ -41,7 +41,7 @@ void main() {
         startedAt: startedAt,
         elapsedSeconds: 300,
       );
-      final model = WalkSessionModel.fromEntity(session);
+      final model = WalkSessionModel.fromEntity(session, 'user-1');
       final restored = model.toEntity();
 
       expect(restored.id, 'session-1');

--- a/test/data/repositories/route_repository_impl_test.dart
+++ b/test/data/repositories/route_repository_impl_test.dart
@@ -16,7 +16,7 @@ void main() {
   setUp(() async {
     final dir = Directory.systemTemp.createTempSync('isar_route_');
     isar = await Isar.open([WalkRouteModelSchema], directory: dir.path);
-    repo = RouteRepositoryImpl(isar);
+    repo = RouteRepositoryImpl(isar, 'user-1');
   });
 
   tearDown(() async {

--- a/test/data/repositories/walk_session_repository_impl_test.dart
+++ b/test/data/repositories/walk_session_repository_impl_test.dart
@@ -15,7 +15,7 @@ void main() {
   setUp(() async {
     final dir = Directory.systemTemp.createTempSync('isar_session_');
     isar = await Isar.open([WalkSessionModelSchema], directory: dir.path);
-    repo = WalkSessionRepositoryImpl(isar);
+    repo = WalkSessionRepositoryImpl(isar, 'user-1');
   });
 
   tearDown(() async {

--- a/test/screens/pages/auth/email_verification_page_test.dart
+++ b/test/screens/pages/auth/email_verification_page_test.dart
@@ -36,7 +36,10 @@ class _FakeAuthService implements AuthService {
   Future<void> deleteUser() async {}
 
   @override
-  Future<void> sendPasswordResetEmail(String email) async {
+  Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {
     if (resendShouldThrow) {
       throw AuthException(resendErrorCode ?? 'unknown');
     }
@@ -44,12 +47,15 @@ class _FakeAuthService implements AuthService {
   }
 
   @override
-  Future<void> sendEmailVerification() async {}
-
-  @override
   Future<void> reloadCurrentUser() async {
     reloadCalled = true;
   }
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async => 'test@example.com';
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
 }
 
 Widget _buildPage(_FakeAuthService service) {
@@ -69,7 +75,7 @@ void main() {
       expect(find.text(AppStrings.emailVerificationPageTitle), findsOneWidget);
     });
 
-    // 送信済みメッセージが表示される
+    // 送信済みメッセージが表示される（確認メール）
     testWidgets('shows sent message', (tester) async {
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       expect(
@@ -99,7 +105,7 @@ void main() {
           find.text(AppStrings.emailVerificationResendButton), findsOneWidget);
     });
 
-    // 再送信ボタンを押すと sendEmailVerification が呼ばれる
+    // 再送信ボタンを押すと sendEmailVerification が呼ばれる（パスワードリセットではなくメール確認）
     testWidgets('calls sendEmailVerification on resend tap', (tester) async {
       final service = _FakeAuthService();
       await tester.pumpWidget(_buildPage(service));

--- a/test/screens/pages/auth/email_verification_page_test.dart
+++ b/test/screens/pages/auth/email_verification_page_test.dart
@@ -71,14 +71,23 @@ Widget _buildPage(_FakeAuthService service) {
 
 void main() {
   group('EmailVerificationPage', () {
+    void setDisplaySize(WidgetTester tester) {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+    }
+
     // ページタイトルが表示される
     testWidgets('shows page title', (tester) async {
+      setDisplaySize(tester);
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       expect(find.text(AppStrings.emailVerificationPageTitle), findsOneWidget);
     });
 
     // 送信済みメッセージが表示される（確認メール）
     testWidgets('shows sent message', (tester) async {
+      setDisplaySize(tester);
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       expect(
           find.text(AppStrings.emailVerificationSentMessage), findsOneWidget);
@@ -86,6 +95,7 @@ void main() {
 
     // メールアドレスが表示される
     testWidgets('shows email address in description', (tester) async {
+      setDisplaySize(tester);
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       await tester.pump();
       expect(
@@ -96,12 +106,14 @@ void main() {
 
     // 確認中インジケーターが表示される
     testWidgets('shows checking indicator', (tester) async {
+      setDisplaySize(tester);
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       expect(find.text(AppStrings.emailVerificationChecking), findsOneWidget);
     });
 
     // 再送信ボタンが表示される
     testWidgets('shows resend button', (tester) async {
+      setDisplaySize(tester);
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       expect(
           find.text(AppStrings.emailVerificationResendButton), findsOneWidget);
@@ -109,6 +121,7 @@ void main() {
 
     // 再送信ボタンを押すと sendEmailVerification が呼ばれる（パスワードリセットではなくメール確認）
     testWidgets('calls sendEmailVerification on resend tap', (tester) async {
+      setDisplaySize(tester);
       final service = _FakeAuthService();
       await tester.pumpWidget(_buildPage(service));
       await tester.tap(find.text(AppStrings.emailVerificationResendButton));
@@ -118,6 +131,7 @@ void main() {
 
     // 再送信成功後に完了メッセージが表示される
     testWidgets('shows resend success message after resend', (tester) async {
+      setDisplaySize(tester);
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       await tester.tap(find.text(AppStrings.emailVerificationResendButton));
       await tester.pump();
@@ -127,6 +141,7 @@ void main() {
 
     // too-many-requests エラー時にエラーメッセージが表示される
     testWidgets('shows error message on too-many-requests', (tester) async {
+      setDisplaySize(tester);
       final service = _FakeAuthService()
         ..resendShouldThrow = true
         ..resendErrorCode = 'too-many-requests';
@@ -138,6 +153,7 @@ void main() {
 
     // その他エラー時に汎用メッセージが表示される
     testWidgets('shows generic error message on unknown error', (tester) async {
+      setDisplaySize(tester);
       final service = _FakeAuthService()
         ..resendShouldThrow = true
         ..resendErrorCode = 'unknown';
@@ -149,6 +165,7 @@ void main() {
 
     // ログアウトボタンが表示される
     testWidgets('shows logout button', (tester) async {
+      setDisplaySize(tester);
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       expect(find.text(AppStrings.settingsLogout), findsOneWidget);
     });

--- a/test/screens/pages/auth/email_verification_page_test.dart
+++ b/test/screens/pages/auth/email_verification_page_test.dart
@@ -21,7 +21,7 @@ class _FakeAuthService implements AuthService {
       );
 
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}

--- a/test/screens/pages/auth/email_verification_page_test.dart
+++ b/test/screens/pages/auth/email_verification_page_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/screens/pages/auth/view/email_verification_page.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+class _FakeAuthService implements AuthService {
+  bool resendCalled = false;
+  bool reloadCalled = false;
+  bool resendShouldThrow = false;
+  String? resendErrorCode;
+
+  @override
+  Stream<AuthUser?> watchAuthState() => Stream.value(
+        const AuthUser(
+          uid: 'uid',
+          email: 'test@example.com',
+          emailVerified: false,
+        ),
+      );
+
+  @override
+  Future<void> registerWithEmail(
+      String email, String password, String displayName) async {}
+
+  @override
+  Future<void> signInWithEmail(String email, String password) async {}
+
+  @override
+  Future<void> setDisplayName(String name) async {}
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<void> deleteUser() async {}
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {
+    if (resendShouldThrow) {
+      throw AuthException(resendErrorCode ?? 'unknown');
+    }
+    resendCalled = true;
+  }
+
+  @override
+  Future<void> reloadCurrentUser() async {
+    reloadCalled = true;
+  }
+}
+
+Widget _buildPage(_FakeAuthService service) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(service),
+    ],
+    child: const MaterialApp(home: EmailVerificationPage()),
+  );
+}
+
+void main() {
+  group('EmailVerificationPage', () {
+    // ページタイトルが表示される
+    testWidgets('shows page title', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(find.text(AppStrings.emailVerificationPageTitle), findsOneWidget);
+    });
+
+    // 送信済みメッセージが表示される
+    testWidgets('shows sent message', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(
+          find.text(AppStrings.emailVerificationSentMessage), findsOneWidget);
+    });
+
+    // メールアドレスが表示される
+    testWidgets('shows email address in description', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.pump();
+      expect(
+        find.textContaining('test@example.com'),
+        findsOneWidget,
+      );
+    });
+
+    // 確認中インジケーターが表示される
+    testWidgets('shows checking indicator', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(find.text(AppStrings.emailVerificationChecking), findsOneWidget);
+    });
+
+    // 再送信ボタンが表示される
+    testWidgets('shows resend button', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(
+          find.text(AppStrings.emailVerificationResendButton), findsOneWidget);
+    });
+
+    // 再送信ボタンを押すと sendEmailVerification が呼ばれる
+    testWidgets('calls sendEmailVerification on resend tap', (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      await tester.tap(find.text(AppStrings.emailVerificationResendButton));
+      await tester.pump();
+      expect(service.resendCalled, isTrue);
+    });
+
+    // 再送信成功後に完了メッセージが表示される
+    testWidgets('shows resend success message after resend', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.tap(find.text(AppStrings.emailVerificationResendButton));
+      await tester.pump();
+      expect(
+          find.text(AppStrings.emailVerificationResendSuccess), findsOneWidget);
+    });
+
+    // too-many-requests エラー時にエラーメッセージが表示される
+    testWidgets('shows error message on too-many-requests', (tester) async {
+      final service = _FakeAuthService()
+        ..resendShouldThrow = true
+        ..resendErrorCode = 'too-many-requests';
+      await tester.pumpWidget(_buildPage(service));
+      await tester.tap(find.text(AppStrings.emailVerificationResendButton));
+      await tester.pump();
+      expect(find.text('しばらく時間をおいてから再度お試しください'), findsOneWidget);
+    });
+
+    // その他エラー時に汎用メッセージが表示される
+    testWidgets('shows generic error message on unknown error', (tester) async {
+      final service = _FakeAuthService()
+        ..resendShouldThrow = true
+        ..resendErrorCode = 'unknown';
+      await tester.pumpWidget(_buildPage(service));
+      await tester.tap(find.text(AppStrings.emailVerificationResendButton));
+      await tester.pump();
+      expect(find.text(AppStrings.operationError), findsOneWidget);
+    });
+
+    // ログアウトボタンが表示される
+    testWidgets('shows logout button', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(find.text(AppStrings.settingsLogout), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/pages/auth/email_verification_page_test.dart
+++ b/test/screens/pages/auth/email_verification_page_test.dart
@@ -21,8 +21,7 @@ class _FakeAuthService implements AuthService {
       );
 
   @override
-  Future<void> registerWithEmail(
-      String email, String password, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}
@@ -37,15 +36,15 @@ class _FakeAuthService implements AuthService {
   Future<void> deleteUser() async {}
 
   @override
-  Future<void> sendPasswordResetEmail(String email) async {}
-
-  @override
-  Future<void> sendEmailVerification() async {
+  Future<void> sendPasswordResetEmail(String email) async {
     if (resendShouldThrow) {
       throw AuthException(resendErrorCode ?? 'unknown');
     }
     resendCalled = true;
   }
+
+  @override
+  Future<void> sendEmailVerification() async {}
 
   @override
   Future<void> reloadCurrentUser() async {

--- a/test/screens/pages/auth/email_verification_page_test.dart
+++ b/test/screens/pages/auth/email_verification_page_test.dart
@@ -21,7 +21,8 @@ class _FakeAuthService implements AuthService {
       );
 
   @override
-  Future<void> registerWithEmail(String email, String displayName, String password) async {}
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}
@@ -52,7 +53,8 @@ class _FakeAuthService implements AuthService {
   }
 
   @override
-  Future<String> verifyPasswordResetCode(String code) async => 'test@example.com';
+  Future<String> verifyPasswordResetCode(String code) async =>
+      'test@example.com';
 
   @override
   Future<void> confirmPasswordReset(String code, String newPassword) async {}

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -40,6 +40,12 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> reloadCurrentUser() async {}
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async => 'test@example.com';
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
 }
 
 Widget _buildPage(_FakeAuthService service) {

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/screens/pages/auth/view/password_reset_page.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+class _FakeAuthService implements AuthService {
+  bool sendCalled = false;
+  String? sentEmail;
+  bool shouldThrow = false;
+
+  @override
+  Stream<AuthUser?> watchAuthState() => const Stream.empty();
+
+  @override
+  Future<void> registerWithEmail(
+      String email, String password, String displayName) async {}
+
+  @override
+  Future<void> signInWithEmail(String email, String password) async {}
+
+  @override
+  Future<void> setDisplayName(String name) async {}
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<void> deleteUser() async {}
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {
+    if (shouldThrow) throw const AuthException('user-not-found');
+    sendCalled = true;
+    sentEmail = email;
+  }
+}
+
+Widget _buildPage(_FakeAuthService service) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(service),
+    ],
+    child: const MaterialApp(home: PasswordResetPage()),
+  );
+}
+
+void main() {
+  group('PasswordResetPage', () {
+    // ページタイトルが表示される
+    testWidgets('shows page title', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(find.text(AppStrings.passwordResetPageTitle), findsOneWidget);
+    });
+
+    // 説明文が表示される
+    testWidgets('shows description', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(find.text(AppStrings.passwordResetDescription), findsOneWidget);
+    });
+
+    // 送信ボタンが表示される
+    testWidgets('shows send button', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      expect(find.text(AppStrings.passwordResetSendButton), findsOneWidget);
+    });
+
+    // メール未入力で送信するとSnackBarが表示される
+    testWidgets('shows snackbar when email is empty', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.tap(find.text(AppStrings.passwordResetSendButton));
+      await tester.pump();
+      expect(find.text('メールアドレスを入力してください'), findsOneWidget);
+    });
+
+    // メールを入力して送信すると sendPasswordResetEmail が呼ばれる
+    testWidgets('calls sendPasswordResetEmail with entered email',
+        (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      await tester.enterText(find.byType(TextField), 'test@example.com');
+      await tester.tap(find.text(AppStrings.passwordResetSendButton));
+      await tester.pumpAndSettle();
+      expect(service.sendCalled, isTrue);
+      expect(service.sentEmail, 'test@example.com');
+    });
+
+    // 送信成功後に完了メッセージが表示される
+    testWidgets('shows success message after send', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.enterText(find.byType(TextField), 'test@example.com');
+      await tester.tap(find.text(AppStrings.passwordResetSendButton));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.passwordResetSuccessMessage), findsOneWidget);
+    });
+
+    // 送信成功後は送信ボタンが非表示になる
+    testWidgets('hides send button after success', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.enterText(find.byType(TextField), 'test@example.com');
+      await tester.tap(find.text(AppStrings.passwordResetSendButton));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.passwordResetSendButton), findsNothing);
+    });
+
+    // エラー時にエラーメッセージが表示される
+    testWidgets('shows error message on failure', (tester) async {
+      final service = _FakeAuthService()..shouldThrow = true;
+      await tester.pumpWidget(_buildPage(service));
+      await tester.enterText(find.byType(TextField), 'notfound@example.com');
+      await tester.tap(find.text(AppStrings.passwordResetSendButton));
+      await tester.pumpAndSettle();
+      expect(find.text('このメールアドレスは登録されていません'), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -14,7 +14,7 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -14,7 +14,8 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(String email, String displayName, String password) async {}
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}
@@ -42,7 +43,8 @@ class _FakeAuthService implements AuthService {
   Future<void> reloadCurrentUser() async {}
 
   @override
-  Future<String> verifyPasswordResetCode(String code) async => 'test@example.com';
+  Future<String> verifyPasswordResetCode(String code) async =>
+      'test@example.com';
 
   @override
   Future<void> confirmPasswordReset(String code, String newPassword) async {}

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -14,8 +14,7 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(
-      String email, String password, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -35,6 +35,12 @@ class _FakeAuthService implements AuthService {
     sendCalled = true;
     sentEmail = email;
   }
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> reloadCurrentUser() async {}
 }
 
 Widget _buildPage(_FakeAuthService service) {

--- a/test/screens/pages/auth/password_set_page_test.dart
+++ b/test/screens/pages/auth/password_set_page_test.dart
@@ -77,7 +77,7 @@ void main() {
     testWidgets('shows page title after code verification', (tester) async {
       await tester.pumpWidget(_buildPage(_FakeAuthService()));
       await tester.pump();
-      expect(find.text(AppStrings.passwordSetPageTitle), findsWidgets);
+      expect(find.text(AppStrings.passwordSetPageTitle), findsNWidgets(2));
     });
 
     // コード検証中はローディングが表示される

--- a/test/screens/pages/auth/password_set_page_test.dart
+++ b/test/screens/pages/auth/password_set_page_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
+import 'package:tekushare/screens/pages/auth/view/password_set_page.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+class _FakeAuthService implements AuthService {
+  bool verifyCodeCalled = false;
+  bool confirmCalled = false;
+  bool signInCalled = false;
+  bool verifyShouldThrow = false;
+  bool confirmShouldThrow = false;
+  String? verifyErrorCode;
+  String? confirmErrorCode;
+
+  @override
+  Stream<AuthUser?> watchAuthState() => const Stream.empty();
+
+  @override
+  Future<void> registerWithEmail(String email, String displayName) async {}
+
+  @override
+  Future<void> signInWithEmail(String email, String password) async {
+    signInCalled = true;
+  }
+
+  @override
+  Future<void> setDisplayName(String name) async {}
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<void> deleteUser() async {}
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> reloadCurrentUser() async {}
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async {
+    verifyCodeCalled = true;
+    if (verifyShouldThrow) {
+      throw AuthException(verifyErrorCode ?? 'invalid-action-code');
+    }
+    return 'test@example.com';
+  }
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {
+    confirmCalled = true;
+    if (confirmShouldThrow) {
+      throw AuthException(confirmErrorCode ?? 'unknown');
+    }
+  }
+}
+
+Widget _buildPage(_FakeAuthService service, {String oobCode = 'test-code'}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(service),
+    ],
+    child: MaterialApp(home: PasswordSetPage(oobCode: oobCode)),
+  );
+}
+
+void main() {
+  group('PasswordSetPage', () {
+    // ページタイトルが表示される
+    testWidgets('shows page title after code verification', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.pump();
+      expect(find.text(AppStrings.passwordSetPageTitle), findsWidgets);
+    });
+
+    // コード検証中はローディングが表示される
+    testWidgets('shows loading indicator while verifying code', (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    // 検証完了後にパスワードフォームが表示される
+    testWidgets('shows password form after code is verified', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.pump();
+      expect(find.text(AppStrings.passwordSetLabel), findsOneWidget);
+      expect(find.text(AppStrings.passwordSetConfirmLabel), findsOneWidget);
+      expect(find.text(AppStrings.passwordSetButton), findsOneWidget);
+    });
+
+    // コードが無効なときエラー画面が表示される
+    testWidgets('shows error body when code is invalid', (tester) async {
+      final service = _FakeAuthService()
+        ..verifyShouldThrow = true
+        ..verifyErrorCode = 'invalid-action-code';
+      await tester.pumpWidget(_buildPage(service));
+      await tester.pump();
+      expect(find.text(AppStrings.passwordSetInvalidCode), findsOneWidget);
+      expect(find.text('戻る'), findsOneWidget);
+    });
+
+    // 短いパスワードでエラーが表示される
+    testWidgets('shows error when password is too short', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.pump();
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetLabel), 'abc1');
+      await tester.tap(find.text(AppStrings.passwordSetButton));
+      await tester.pump();
+      expect(find.text('パスワードは6文字以上で入力してください'), findsOneWidget);
+    });
+
+    // 英数字を含まないパスワードでエラーが表示される
+    testWidgets('shows error when password lacks letters or digits',
+        (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.pump();
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetLabel),
+          'abcdefgh');
+      await tester.tap(find.text(AppStrings.passwordSetButton));
+      await tester.pump();
+      expect(find.text('パスワードは英字と数字を両方含めてください'), findsOneWidget);
+    });
+
+    // パスワードが一致しないときエラーが表示される
+    testWidgets('shows error when passwords do not match', (tester) async {
+      await tester.pumpWidget(_buildPage(_FakeAuthService()));
+      await tester.pump();
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetLabel),
+          'abc123');
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetConfirmLabel),
+          'abc456');
+      await tester.tap(find.text(AppStrings.passwordSetButton));
+      await tester.pump();
+      expect(find.text(AppStrings.passwordMismatch), findsOneWidget);
+    });
+
+    // 正しいパスワードで confirmPasswordReset と signIn が呼ばれる
+    testWidgets('calls confirmPasswordReset and signIn on valid submit',
+        (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      await tester.pump();
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetLabel),
+          'abc123');
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetConfirmLabel),
+          'abc123');
+      await tester.tap(find.text(AppStrings.passwordSetButton));
+      await tester.pump();
+      expect(service.confirmCalled, isTrue);
+      expect(service.signInCalled, isTrue);
+    });
+
+    // confirmPasswordReset 失敗時にエラーメッセージが表示される
+    testWidgets('shows error message when confirmPasswordReset fails',
+        (tester) async {
+      final service = _FakeAuthService()..confirmShouldThrow = true;
+      await tester.pumpWidget(_buildPage(service));
+      await tester.pump();
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetLabel),
+          'abc123');
+      await tester.enterText(
+          find.widgetWithText(TextField, AppStrings.passwordSetConfirmLabel),
+          'abc123');
+      await tester.tap(find.text(AppStrings.passwordSetButton));
+      await tester.pump();
+      expect(find.text(AppStrings.operationError), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/pages/auth/password_set_page_test.dart
+++ b/test/screens/pages/auth/password_set_page_test.dart
@@ -18,7 +18,7 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {

--- a/test/screens/pages/auth/password_set_page_test.dart
+++ b/test/screens/pages/auth/password_set_page_test.dart
@@ -18,7 +18,8 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(String email, String displayName, String password) async {}
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -53,6 +53,9 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> deleteUser() async => deletedUser = true;
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
 }
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -38,7 +38,8 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(String email, String displayName, String password) async {}
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -38,7 +38,7 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName, String password) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -60,6 +60,12 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> reloadCurrentUser() async {}
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async => '';
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
 }
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -56,6 +56,12 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> reloadCurrentUser() async {}
 }
 
 class _FakeWalkSessionRepository implements WalkSessionRepository {

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -38,9 +38,7 @@ class _FakeAuthService implements AuthService {
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
 
   @override
-  Future<void> registerWithEmail(
-          String email, String password, String displayName) async =>
-      {};
+  Future<void> registerWithEmail(String email, String displayName) async {}
 
   @override
   Future<void> signInWithEmail(String email, String password) async {}

--- a/test/screens/pages/spot/spot_detail_page_test.dart
+++ b/test/screens/pages/spot/spot_detail_page_test.dart
@@ -369,8 +369,8 @@ void main() {
           findsOneWidget);
     });
 
-    // 行った！確認でSnackBarにメッセージが表示される
-    testWidgets('confirming move to went shows snackbar', (tester) async {
+    // 行った！確認で保存完了ダイアログが表示される
+    testWidgets('confirming move to went shows saved dialog', (tester) async {
       await pumpPage(tester, isWantToGo: true);
 
       await tester.tap(find.text(AppStrings.spotDetailMoveToWentButton));
@@ -381,12 +381,18 @@ void main() {
           matching: find.text(AppStrings.spotDetailMoveToWentConfirmLabel),
         ),
       );
-      await tester.pump();
+      await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.spotDetailMoveToWentDone), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text(AppStrings.spotDetailMoveToWentDone),
+        ),
+        findsOneWidget,
+      );
     });
 
-    // 行った！確認で詳細ページから離れる
+    // 行った！保存完了ダイアログを閉じると詳細ページから離れる
     testWidgets('confirming move to went leaves the page', (tester) async {
       await pumpPushedPage(tester, isWantToGo: true);
 
@@ -398,6 +404,8 @@ void main() {
           matching: find.text(AppStrings.spotDetailMoveToWentConfirmLabel),
         ),
       );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(SpotDetailPage), findsNothing);
@@ -578,25 +586,33 @@ void main() {
       expect(find.text(AppStrings.spotDetailSaveConfirmMessage), findsNothing);
     });
 
-    // 保存確認でSnackBarにメッセージが表示される
-    testWidgets('confirming save shows snackbar', (tester) async {
+    // 保存確認で保存完了ダイアログが表示される
+    testWidgets('confirming save shows saved dialog', (tester) async {
       await pumpPage(tester);
 
       await tester.tap(find.text(AppStrings.spotDetailSaveButton));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
-      expect(find.text(AppStrings.saved), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text(AppStrings.saved),
+        ),
+        findsOneWidget,
+      );
     });
 
-    // 保存確認で詳細ページから離れる
+    // 保存完了ダイアログを閉じると詳細ページから離れる
     testWidgets('confirming save leaves the page', (tester) async {
       await pumpPushedPage(tester);
 
       await tester.tap(find.text(AppStrings.spotDetailSaveButton));
       await tester.pumpAndSettle();
       await tester.tap(find.text(AppStrings.saveButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(AppStrings.closeButton));
       await tester.pumpAndSettle();
 
       expect(find.byType(SpotDetailPage), findsNothing);

--- a/test/screens/pages/walk/walk_page_test.dart
+++ b/test/screens/pages/walk/walk_page_test.dart
@@ -22,6 +22,10 @@ import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.da
 import 'package:tekushare/screens/providers/contact_provider.dart';
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
+import 'package:tekushare/domain/entities/walk_session.dart';
+import 'package:tekushare/domain/repositories/route_repository.dart';
+import 'package:tekushare/domain/repositories/walk_session_repository.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
 import 'package:tekushare/screens/pages/walk/view/walk_page.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
@@ -83,6 +87,29 @@ class _FakeDeleteSpot implements DeleteSpot {
   @override
   Future<void> call(String id) async {}
 }
+
+class _FakeWalkSessionRepository implements WalkSessionRepository {
+  @override
+  Future<void> saveSession(WalkSession session) async {}
+  @override
+  Future<List<WalkSession>> getAllSessions() async => [];
+  @override
+  Future<WalkSession?> getSessionById(String id) async => null;
+}
+
+class _FakeRouteRepository implements RouteRepository {
+  @override
+  Future<void> saveRoute(WalkRoute route) async {}
+  @override
+  Future<WalkRoute?> getRouteBySessionId(String sessionId) async => null;
+  @override
+  Future<List<WalkRoute>> getAllRoutes() async => [];
+}
+
+final _walkSessionRepoOverride = walkSessionRepositoryProvider
+    .overrideWithValue(_FakeWalkSessionRepository());
+final _routeRepoOverride =
+    routeRepositoryProvider.overrideWithValue(_FakeRouteRepository());
 
 final _spotOverride = spotProvider.overrideWith(
   (ref) => SpotNotifier(
@@ -212,6 +239,8 @@ void main() {
           (ref) => locationStream ?? const Stream.empty(),
         ),
         _notificationOverride,
+        _walkSessionRepoOverride,
+        _routeRepoOverride,
         contactProvider.overrideWith((ref) => Stream.value([])),
         if (camera != null) cameraServiceProvider.overrideWith((ref) => camera),
       ];

--- a/test/screens/providers/auth_provider_test.dart
+++ b/test/screens/providers/auth_provider_test.dart
@@ -34,7 +34,6 @@ void main() {
         mockAuthService.registerWithEmail(
           argThat(isA<String>()),
           argThat(isA<String>()),
-          argThat(isA<String>()),
         ),
       ).thenAnswer((_) async => Future<void>.value());
 
@@ -43,7 +42,7 @@ void main() {
 
       await container
           .read(emailAuthProvider.notifier)
-          .register('test@example.com', 'password123', 'テストユーザー');
+          .register('test@example.com', 'テストユーザー');
 
       expect(container.read(emailAuthProvider), isNot(isA<EmailAuthError>()));
     });
@@ -51,7 +50,6 @@ void main() {
     test('register でメールが重複すると EmailAuthError に遷移する', () async {
       when(
         mockAuthService.registerWithEmail(
-          argThat(isA<String>()),
           argThat(isA<String>()),
           argThat(isA<String>()),
         ),
@@ -62,7 +60,7 @@ void main() {
 
       await container
           .read(emailAuthProvider.notifier)
-          .register('existing@example.com', 'password123', 'テストユーザー');
+          .register('existing@example.com', 'テストユーザー');
 
       final state = container.read(emailAuthProvider);
       expect(state, isA<EmailAuthError>());

--- a/test/screens/providers/auth_provider_test.dart
+++ b/test/screens/providers/auth_provider_test.dart
@@ -34,6 +34,7 @@ void main() {
         mockAuthService.registerWithEmail(
           argThat(isA<String>()),
           argThat(isA<String>()),
+          argThat(isA<String>()),
         ),
       ).thenAnswer((_) async => Future<void>.value());
 
@@ -42,7 +43,7 @@ void main() {
 
       await container
           .read(emailAuthProvider.notifier)
-          .register('test@example.com', 'テストユーザー');
+          .register('test@example.com', 'テストユーザー', 'password123');
 
       expect(container.read(emailAuthProvider), isNot(isA<EmailAuthError>()));
     });
@@ -50,6 +51,7 @@ void main() {
     test('register でメールが重複すると EmailAuthError に遷移する', () async {
       when(
         mockAuthService.registerWithEmail(
+          argThat(isA<String>()),
           argThat(isA<String>()),
           argThat(isA<String>()),
         ),
@@ -60,7 +62,7 @@ void main() {
 
       await container
           .read(emailAuthProvider.notifier)
-          .register('existing@example.com', 'テストユーザー');
+          .register('existing@example.com', 'テストユーザー', 'password123');
 
       final state = container.read(emailAuthProvider);
       expect(state, isA<EmailAuthError>());

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -30,7 +30,7 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(String email, String displayName) async {}
+  Future<void> registerWithEmail(String email, String displayName, String password) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -48,6 +48,12 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> reloadCurrentUser() async {}
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async => '';
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
 }
 
 class _FakePhotoRepository implements PhotoRepository {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -30,7 +30,8 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(String email, String displayName, String password) async {}
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -46,6 +46,12 @@ class _FakeAuthService implements AuthService {
 
   @override
   Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> reloadCurrentUser() async {}
 }
 
 class _FakePhotoRepository implements PhotoRepository {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -43,6 +43,9 @@ class _FakeAuthService implements AuthService {
   Future<void> signOut() async {}
   @override
   Future<void> deleteUser() async {}
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
 }
 
 class _FakePhotoRepository implements PhotoRepository {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -30,11 +30,7 @@ class _FakeAuthService implements AuthService {
   @override
   Stream<AuthUser?> watchAuthState() => const Stream.empty();
   @override
-  Future<void> registerWithEmail(
-    String email,
-    String password,
-    String displayName,
-  ) async {}
+  Future<void> registerWithEmail(String email, String displayName) async {}
   @override
   Future<void> signInWithEmail(String email, String password) async {}
   @override


### PR DESCRIPTION
## 📝 説明

メールアドレス＋パスワード認証フローの刷新と、アカウント切り替え時のデータ漏洩修正をまとめて対応。

## 🔗 関連 Issue

closes #105
closes #104

## 📋 変更内容

- [x] 機能追加
- [x] UI 作成
- [x] バグ修正
- [ ] ドキュメント更新
- [ ] その他：

### 機能追加
- パスワードリセット機能（メールリンクからアプリ内でパスワード再設定）
- メールアドレス確認フロー（登録後に確認メール送信 → 未確認ユーザーは EmailVerificationPage へ分岐）
- 往復タイマーの折り返し通知（全体時間の半分で「折り返しの時間です」プッシュ通知）
- GPS 取得タイムアウト機能（30 秒で「やり直す／このまま続ける」ダイアログ）

### バグ修正
- 2 回目以降の散歩で GPS 取得中から進まない問題（`getLastKnownPosition()` で初回位置を即時配信）
- アカウント切り替え後に前ユーザーの散歩ルート・セッション・保存ルートが残る問題（Isar モデルに `userUid` を追加しユーザーごとにスコープ化）
- ログアウト後に前ユーザーのシェアデータが残る問題
- 上書き保存・「行った！」保存後に完了ダイアログが表示されない問題
- 散歩マップに軌跡が表示されない問題（`walkTrackPointsProvider` を追加）

### UI 整備
- 全 Dialog の `insetPadding` を `horizontal: x4l(40px)` に統一
- 散歩終了確認カードの横マージンも `x4l(40px)` に統一
- 上書き保存・「行った！」保存後の完了ダイアログを追加
- 各種文字列を `AppStrings` 定数に移行（マジックナンバー・ハードコード除去）

### セキュリティ
- リポジトリの ID 指定取得・削除時に `userUid` 検証を追加（他ユーザーデータへのアクセス防止）
- `WalkRouteViewModel` を `autoDispose` 化し、アカウント切り替え時の UI 状態リークを防止

## ✅ チェックリスト

- [x] コードレビュー済み
- [x] ユニットテスト実施済み
- [ ] ドキュメント更新済み
- [x] 自分でテスト確認済み

## 📸 スクリーンショット（UI変更の場合）

<!-- 変更前後の画像を貼り付けてください -->

## 🚀 備考

- `flutter test`：全 395 テスト通過確認済み
- Firebase Auth メール送信を日本語化済み
- `.well-known/assetlinks.json` を Firebase Hosting デプロイ対象に追加
