### PR TITLE
[Feature] app_providers.dart を Firebase 非依存に分割して CI カバレッジを拡大

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
       #     firebase_auth / cloud_firestore を直接・間接 import するファイルは
       #     Linux でコンパイル不可のため除外する。
       #     Isar の FFI ランタイムを必要とする *_repository_impl_test.dart も除外する。
-      #     （phone_register_page_test → contact_provider → app_providers → Firebase も除外）
       - name: Run unit tests
         run: |
           xvfb-run flutter test -d linux --reporter expanded \
@@ -85,12 +84,16 @@ jobs:
             test/data/models/ \
             test/firebase_options_test.dart \
             test/infrastructure/ \
+            test/screens/widgets/common/app_bottom_nav_test.dart \
             test/screens/widgets/common/category_chip_group_test.dart \
             test/screens/widgets/common/dashed_border_painter_test.dart \
             test/screens/widgets/common/primary_button_test.dart \
             test/screens/providers/auth_provider_test.dart \
             test/screens/providers/inactivity_provider_test.dart \
+            test/screens/pages/history/history_page_test.dart \
+            test/screens/pages/settings/phone_register_page_test.dart \
             test/screens/pages/spot/spot_detail_viewmodel_test.dart \
+            test/screens/pages/spot/spot_list_page_test.dart \
             test/screens/pages/spot/want_to_go_viewmodel_test.dart \
             test/screens/pages/map/walk_route_viewmodel_test.dart \
             test/screens/pages/walk/walk_session_viewmodel_test.dart

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,15 +1,12 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:tekushare/app.dart';
 import 'package:tekushare/core/config/flavor.dart';
-import 'package:tekushare/data/services/firebase_auth_service_impl.dart';
 import 'package:tekushare/firebase_options.dart';
 import 'package:tekushare/infrastructure/notification_service.dart';
-import 'package:tekushare/screens/providers/auth_provider.dart';
+import 'package:tekushare/screens/providers/firebase_providers.dart';
 
 /// dev環境のエントリーポイント
 void main() async {
@@ -21,14 +18,7 @@ void main() async {
   AppConfig.setFlavor(Flavor.dev);
   runApp(
     ProviderScope(
-      overrides: [
-        authServiceProvider.overrideWithValue(
-          FirebaseAuthServiceImpl(
-            FirebaseAuth.instance,
-            FirebaseFirestore.instance,
-          ),
-        ),
-      ],
+      overrides: firebaseProviderOverrides(),
       child: const TekuShareApp(),
     ),
   );

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -1,15 +1,12 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:tekushare/app.dart';
 import 'package:tekushare/core/config/flavor.dart';
-import 'package:tekushare/data/services/firebase_auth_service_impl.dart';
 import 'package:tekushare/firebase_options.dart';
 import 'package:tekushare/infrastructure/notification_service.dart';
-import 'package:tekushare/screens/providers/auth_provider.dart';
+import 'package:tekushare/screens/providers/firebase_providers.dart';
 
 /// prod（リリース）環境のエントリーポイント
 void main() async {
@@ -21,14 +18,7 @@ void main() async {
   AppConfig.setFlavor(Flavor.prod);
   runApp(
     ProviderScope(
-      overrides: [
-        authServiceProvider.overrideWithValue(
-          FirebaseAuthServiceImpl(
-            FirebaseAuth.instance,
-            FirebaseFirestore.instance,
-          ),
-        ),
-      ],
+      overrides: firebaseProviderOverrides(),
       child: const TekuShareApp(),
     ),
   );

--- a/lib/main_stg.dart
+++ b/lib/main_stg.dart
@@ -1,15 +1,12 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:tekushare/app.dart';
 import 'package:tekushare/core/config/flavor.dart';
-import 'package:tekushare/data/services/firebase_auth_service_impl.dart';
 import 'package:tekushare/firebase_options.dart';
 import 'package:tekushare/infrastructure/notification_service.dart';
-import 'package:tekushare/screens/providers/auth_provider.dart';
+import 'package:tekushare/screens/providers/firebase_providers.dart';
 
 /// stg（テスト）環境のエントリーポイント
 void main() async {
@@ -21,14 +18,7 @@ void main() async {
   AppConfig.setFlavor(Flavor.stg);
   runApp(
     ProviderScope(
-      overrides: [
-        authServiceProvider.overrideWithValue(
-          FirebaseAuthServiceImpl(
-            FirebaseAuth.instance,
-            FirebaseFirestore.instance,
-          ),
-        ),
-      ],
+      overrides: firebaseProviderOverrides(),
       child: const TekuShareApp(),
     ),
   );

--- a/lib/screens/providers/app_providers.dart
+++ b/lib/screens/providers/app_providers.dart
@@ -1,6 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
@@ -8,10 +5,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tekushare/data/models/saved_route_model.dart';
 import 'package:tekushare/data/models/walk_route_model.dart';
 import 'package:tekushare/data/models/walk_session_model.dart';
-import 'package:tekushare/data/repositories/account_link_repository_impl.dart';
-import 'package:tekushare/data/repositories/firestore_contact_repository_impl.dart';
-import 'package:tekushare/data/repositories/firestore_photo_repository_impl.dart';
-import 'package:tekushare/data/repositories/firestore_spot_repository_impl.dart';
 import 'package:tekushare/data/repositories/route_repository_impl.dart';
 import 'package:tekushare/data/repositories/saved_route_repository_impl.dart';
 import 'package:tekushare/data/repositories/walk_session_repository_impl.dart';
@@ -43,9 +36,10 @@ final isarProvider = FutureProvider<Isar>((ref) async {
   return isar;
 });
 
+// 実装は firebase_providers.dart の firebaseProviderOverrides() で注入する。
 final spotRepositoryProvider = Provider<SpotRepository>((ref) {
-  final uid = ref.watch(authStateProvider).value?.uid ?? '';
-  return FirestoreSpotRepositoryImpl(FirebaseFirestore.instance, uid);
+  throw UnimplementedError(
+      'spotRepositoryProvider must be overridden in ProviderScope');
 });
 
 final walkSessionRepositoryProvider = Provider<WalkSessionRepository>((ref) {
@@ -64,17 +58,13 @@ final savedRouteRepositoryProvider = Provider<SavedRouteRepository>((ref) {
 });
 
 final photoRepositoryProvider = Provider<PhotoRepository>((ref) {
-  final uid = ref.watch(authStateProvider).value?.uid ?? '';
-  return FirestorePhotoRepositoryImpl(
-    FirebaseFirestore.instance,
-    FirebaseStorage.instance,
-    uid,
-  );
+  throw UnimplementedError(
+      'photoRepositoryProvider must be overridden in ProviderScope');
 });
 
 final contactRepositoryProvider = Provider<ContactRepository>((ref) {
-  final uid = ref.watch(authStateProvider).value?.uid ?? '';
-  return FirestoreContactRepositoryImpl(FirebaseFirestore.instance, uid);
+  throw UnimplementedError(
+      'contactRepositoryProvider must be overridden in ProviderScope');
 });
 
 final cameraServiceProvider = Provider<CameraService>((ref) {
@@ -86,10 +76,8 @@ final smsServiceProvider = Provider<SmsService>((ref) {
 });
 
 final accountLinkRepositoryProvider = Provider<AccountLinkRepository>((ref) {
-  return AccountLinkRepositoryImpl(
-    FirebaseFirestore.instance,
-    FirebaseAuth.instance,
-  );
+  throw UnimplementedError(
+      'accountLinkRepositoryProvider must be overridden in ProviderScope');
 });
 
 final sharedPrefsProvider = FutureProvider<SharedPreferences>((ref) async {

--- a/lib/screens/providers/firebase_providers.dart
+++ b/lib/screens/providers/firebase_providers.dart
@@ -1,0 +1,44 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tekushare/data/repositories/account_link_repository_impl.dart';
+import 'package:tekushare/data/repositories/firestore_contact_repository_impl.dart';
+import 'package:tekushare/data/repositories/firestore_photo_repository_impl.dart';
+import 'package:tekushare/data/repositories/firestore_spot_repository_impl.dart';
+import 'package:tekushare/data/services/firebase_auth_service_impl.dart';
+import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+/// Firebase 実装を ProviderScope.overrides に渡すためのリスト。
+/// main_*.dart の ProviderScope(overrides: firebaseProviderOverrides()) で使用する。
+List<Override> firebaseProviderOverrides() => [
+      authServiceProvider.overrideWithValue(
+        FirebaseAuthServiceImpl(
+          fb_auth.FirebaseAuth.instance,
+          FirebaseFirestore.instance,
+        ),
+      ),
+      spotRepositoryProvider.overrideWith((ref) {
+        final uid = ref.watch(authStateProvider).value?.uid ?? '';
+        return FirestoreSpotRepositoryImpl(FirebaseFirestore.instance, uid);
+      }),
+      photoRepositoryProvider.overrideWith((ref) {
+        final uid = ref.watch(authStateProvider).value?.uid ?? '';
+        return FirestorePhotoRepositoryImpl(
+          FirebaseFirestore.instance,
+          FirebaseStorage.instance,
+          uid,
+        );
+      }),
+      contactRepositoryProvider.overrideWith((ref) {
+        final uid = ref.watch(authStateProvider).value?.uid ?? '';
+        return FirestoreContactRepositoryImpl(FirebaseFirestore.instance, uid);
+      }),
+      accountLinkRepositoryProvider.overrideWith((_) {
+        return AccountLinkRepositoryImpl(
+          FirebaseFirestore.instance,
+          fb_auth.FirebaseAuth.instance,
+        );
+      }),
+    ];


### PR DESCRIPTION
## 📝 説明

`app_providers.dart` が Firebase パッケージを直接 import していたため、
Firebase が Linux ビルド非対応であることが原因で CI から4テストが除外されていた。
Firebase 実装を `firebase_providers.dart` に分離し、除外テストを CI に追加する。

## 🔗 関連 Issue

closes #107

## 📋 変更内容

- [x] 機能追加
- [ ] UI 作成
- [ ] バグ修正
- [ ] ドキュメント更新
- [ ] その他：

### リファクタリング

- `app_providers.dart` から `cloud_firestore` / `firebase_auth` / `firebase_storage` import を除去
- Firebase 依存の4プロバイダー（`spotRepositoryProvider`, `photoRepositoryProvider`, `contactRepositoryProvider`, `accountLinkRepositoryProvider`）を `throw UnimplementedError(...)` 宣言に変更（`authServiceProvider` と同パターン）
- `firebase_providers.dart` を新規作成し、Firebase 実装を `List<Override> firebaseProviderOverrides()` として一元管理
- `main_dev.dart` / `main_stg.dart` / `main_prod.dart` で手書きの override リストを `firebaseProviderOverrides()` 呼び出しに統一

### CI 拡大

CI から除外されていた以下4テストを有効化:

| テストファイル | 除外理由（修正前） |
|---|---|
| `app_bottom_nav_test.dart` | `app_bottom_nav` → `app_providers` → Firebase |
| `history_page_test.dart` | `walk_history_provider` → `app_providers` → Firebase |
| `phone_register_page_test.dart` | `contact_provider` → `app_providers` → Firebase |
| `spot_list_page_test.dart` | `contact_provider` → `app_providers` → Firebase |

## ✅ チェックリスト

- [x] コードレビュー済み
- [x] ユニットテスト実施済み
- [ ] ドキュメント更新済み
- [x] 自分でテスト確認済み

## 📸 スクリーンショット（UI変更の場合）

<!-- 変更なし -->

## 🚀 備考

- `flutter test`：全 395 テスト通過確認済み（除外テスト4件を含む）
- 実行時動作は変わらない（ProviderScope.overrides で同じ実装が注入される）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 開発・ステージング・本番環境で、Firebase関連サービスの構成を統一しました。
  * Firebase機能の初期化とデータアクセス設定を一元化し、環境ごとの動作を安定させました。

* **テスト**
  * 履歴、電話番号登録、スポット一覧に関する単体テストをCI実行対象へ追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->