### PR TITLE
[Fix] Firebase Auth メールリンクの App Links 対応を firebaseapp.com ドメインに修正

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,12 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="https" android:host="tekushare.web.app" android:pathPrefix="/auth/action"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="tekushare.firebaseapp.com" android:pathPrefix="/__/auth/action"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:tekushare.web.app</string>
+		<string>applinks:tekushare.firebaseapp.com</string>
 	</array>
 </dict>
 </plist>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -45,8 +45,9 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
 
   /// ディープリンクを受け取り、種別に応じて画面遷移する。
   /// 対応スキーム:
-  ///   - https://tekushare.web.app/auth/action?mode=resetPassword&oobCode=...
-  ///   - https://tekushare.web.app/auth/action?mode=verifyEmail&oobCode=...
+  ///   - https://tekushare.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=...
+  ///   - https://tekushare.firebaseapp.com/__/auth/action?mode=verifyEmail&oobCode=...
+  ///   - https://tekushare.web.app/auth/action?mode=...  (カスタムパス、将来用)
   ///   - tekushare://link/<token>
   ///   - https://tekushare.web.app/link/<token>
   void _handleUri(Uri uri) {
@@ -80,20 +81,23 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
     }
   }
 
-  bool _isPasswordResetAction(Uri uri) {
+  bool _isAuthActionUri(Uri uri) {
     return uri.scheme == 'https' &&
-        uri.host == 'tekushare.web.app' &&
-        uri.path.startsWith('/auth/action') &&
-        uri.queryParameters['mode'] == 'resetPassword' &&
-        uri.queryParameters['oobCode'] != null;
+        uri.queryParameters['oobCode'] != null &&
+        ((uri.host == 'tekushare.web.app' &&
+                uri.path.startsWith('/auth/action')) ||
+            (uri.host == 'tekushare.firebaseapp.com' &&
+                uri.path.startsWith('/__/auth/action')));
+  }
+
+  bool _isPasswordResetAction(Uri uri) {
+    return _isAuthActionUri(uri) &&
+        uri.queryParameters['mode'] == 'resetPassword';
   }
 
   bool _isEmailVerificationAction(Uri uri) {
-    return uri.scheme == 'https' &&
-        uri.host == 'tekushare.web.app' &&
-        uri.path.startsWith('/auth/action') &&
-        uri.queryParameters['mode'] == 'verifyEmail' &&
-        uri.queryParameters['oobCode'] != null;
+    return _isAuthActionUri(uri) &&
+        uri.queryParameters['mode'] == 'verifyEmail';
   }
 
   Future<void> _applyEmailVerification(String oobCode) async {

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -8,7 +8,8 @@
           "REPLACE_WITH_TEAM_ID.com.example.tekushare.stg"
         ],
         "components": [
-          { "/": "/auth/action*", "comment": "Firebase Auth action links (password reset, email verification)" },
+          { "/": "/auth/action*", "comment": "Firebase Auth action links via custom path" },
+          { "/": "/__/auth/action*", "comment": "Firebase Auth action links via default path (firebaseapp.com)" },
           { "/": "/link/*", "comment": "Invite deep links" }
         ]
       }


### PR DESCRIPTION
## 📝 説明

Firebase Console で `tekushare.web.app/auth/action` へのアクション URL 変更が API レベルで拒否されるため（`*.web.app` は Firebase 管理ドメインのため上書き不可）、Firebase デフォルトの `tekushare.firebaseapp.com/__/auth/action` のまま App Links / Universal Links が動作するよう修正。

## 🔗 関連 Issue

closes #108

## 📋 変更内容

- [x] バグ修正
- [ ] 機能追加
- [ ] UI 作成
- [ ] ドキュメント更新

### 変更内容

- `AndroidManifest.xml`: `tekushare.firebaseapp.com/__/auth/action` の Intent Filter を追加
- `app.dart`: URL マッチングを両ドメイン対応に変更
  - `tekushare.firebaseapp.com/__/auth/action`（現行の Firebase デフォルト URL）
  - `tekushare.web.app/auth/action`（将来のカスタム URL 用に維持）
- `apple-app-site-association`: `/__/auth/action*` パスを追加
- `ios/Runner/Runner.entitlements`: `applinks:tekushare.firebaseapp.com` を追加

### 動作フロー（Android）

1. Firebase がパスワードリセット／メール確認メールを送信
2. メール内リンク（`tekushare.firebaseapp.com/__/auth/action?mode=...&oobCode=...`）をタップ
3. Android App Links がインターセプト → アプリが起動
4. `app.dart._handleUri` が `oobCode` を処理 → パスワード再設定 or メール確認完了

### `assetlinks.json` の共有について

`tekushare.web.app` と `tekushare.firebaseapp.com` は同じ Firebase Hosting ファイルを配信するため、`assetlinks.json` はコードを変更せず両ドメインで有効。

## ✅ チェックリスト

- [x] コードレビュー済み
- [x] ユニットテスト実施済み（395件通過）
- [ ] ドキュメント更新済み
- [x] 自分でテスト確認済み

## 📸 スクリーンショット（UI変更の場合）

<!-- 変更なし -->

## 🚀 備考

- Firebase Console のアクション URL 変更は不要（デフォルトのまま）
- iOS の Universal Links は Team ID を `apple-app-site-association` に設定後 Xcode で Associated Domains を追加する必要あり