### PR TITLE
mail.tekushare.com をカスタムアクション URL ドメインとして追加 (#108)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,6 +51,12 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="https" android:host="tekushare.firebaseapp.com" android:pathPrefix="/__/auth/action"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="mail.tekushare.com" android:pathPrefix="/auth/action"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -6,6 +6,7 @@
 	<array>
 		<string>applinks:tekushare.web.app</string>
 		<string>applinks:tekushare.firebaseapp.com</string>
+		<string>applinks:mail.tekushare.com</string>
 	</array>
 </dict>
 </plist>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -45,9 +45,9 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
 
   /// ディープリンクを受け取り、種別に応じて画面遷移する。
   /// 対応スキーム:
-  ///   - https://tekushare.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=...
-  ///   - https://tekushare.firebaseapp.com/__/auth/action?mode=verifyEmail&oobCode=...
-  ///   - https://tekushare.web.app/auth/action?mode=...  (カスタムパス、将来用)
+  ///   - https://mail.tekushare.com/auth/action?mode=resetPassword&oobCode=...
+  ///   - https://mail.tekushare.com/auth/action?mode=verifyEmail&oobCode=...
+  ///   - https://tekushare.firebaseapp.com/__/auth/action?mode=...  (フォールバック)
   ///   - tekushare://link/<token>
   ///   - https://tekushare.web.app/link/<token>
   void _handleUri(Uri uri) {
@@ -87,7 +87,9 @@ class _TekuShareAppState extends ConsumerState<TekuShareApp> {
         ((uri.host == 'tekushare.web.app' &&
                 uri.path.startsWith('/auth/action')) ||
             (uri.host == 'tekushare.firebaseapp.com' &&
-                uri.path.startsWith('/__/auth/action')));
+                uri.path.startsWith('/__/auth/action')) ||
+            (uri.host == 'mail.tekushare.com' &&
+                uri.path.startsWith('/auth/action')));
   }
 
   bool _isPasswordResetAction(Uri uri) {

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -111,7 +111,7 @@ class FirebaseAuthServiceImpl implements AuthService {
   Future<void> sendPasswordResetEmail(String email) async {
     try {
       final settings = ActionCodeSettings(
-        url: 'https://tekushare.web.app',
+        url: 'https://mail.tekushare.com',
         handleCodeInApp: true,
         androidPackageName: AppConfig.packageName,
         androidInstallApp: true,
@@ -128,7 +128,7 @@ class FirebaseAuthServiceImpl implements AuthService {
   Future<void> sendEmailVerification() async {
     try {
       final settings = ActionCodeSettings(
-        url: 'https://tekushare.web.app',
+        url: 'https://mail.tekushare.com',
         handleCodeInApp: true,
         androidPackageName: AppConfig.packageName,
         androidInstallApp: true,


### PR DESCRIPTION
﻿## 概要

`mail.tekushare.com` をディープリンクのカスタムドメインとして使用するための対応。

Firebase Console でアクション URL を `https://mail.tekushare.com/auth/action` に設定することで、カスタムのフォールバックページ表示とカスタムドメイン経由のディープリンク処理が可能になる。

## 変更内容

- `firebase_auth_service_impl.dart`: `ActionCodeSettings.url` を `mail.tekushare.com` に変更（パスワードリセット・メール確認の両メソッド）
- `app.dart`: `_isAuthActionUri()` に `mail.tekushare.com/auth/action` を追加
- `AndroidManifest.xml`: `mail.tekushare.com` の App Links Intent Filter を追加（`autoVerify="true"`）
- `Runner.entitlements`: `applinks:mail.tekushare.com` を Associated Domains に追加

## DNS・コンソール側の残タスク（コード外）

- [ ] `mail.tekushare.com` の DNS 伝播完了を待つ（Firebase Hosting が検出済みになるまで最大24時間）
- [ ] Firebase Console → Authentication → メールテンプレート → アクション URL を `https://mail.tekushare.com/auth/action` に変更
- [ ] `apple-app-site-association` の `REPLACE_WITH_TEAM_ID` を実際の Apple Developer Team ID に差し替え
- [ ] Xcode で Associated Domains エンタイトルメントの設定確認（Mac 作業）

## 関連 Issue

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)