### PR TITLE
[Fix] 新規登録パスワードバリデーション・パスワードリセットページ状態リセット

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -66,6 +66,7 @@ abstract class AppStrings {
   // メールアドレス認証フォーム
   static const emailAuthPasswordLabel = 'パスワード（6文字以上）';
   static const emailAuthPasswordHint = '6文字以上';
+  static const emailAuthPasswordAlphanumericError = 'パスワードは英字と数字を両方含めてください';
   static const emailAuthRegisteredDescription =
       'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。';
   static const emailAuthLoginButton = 'ログインへ';

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -322,7 +322,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
       }
       if (!password.contains(RegExp(r'[a-zA-Z]')) ||
           !password.contains(RegExp(r'[0-9]'))) {
-        _showSnack('パスワードは英字と数字を両方含めてください');
+        _showSnack(AppStrings.emailAuthPasswordAlphanumericError);
         return;
       }
       final confirm = _confirmPasswordController.text;

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -320,6 +320,11 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
         _showSnack(AppStrings.nicknameRequired);
         return;
       }
+      if (!password.contains(RegExp(r'[a-zA-Z]')) ||
+          !password.contains(RegExp(r'[0-9]'))) {
+        _showSnack('パスワードは英字と数字を両方含めてください');
+        return;
+      }
       final confirm = _confirmPasswordController.text;
       if (password != confirm) {
         _showSnack('パスワードが一致しません');

--- a/lib/screens/pages/auth/view/password_reset_page.dart
+++ b/lib/screens/pages/auth/view/password_reset_page.dart
@@ -18,6 +18,14 @@ class _PasswordResetPageState extends ConsumerState<PasswordResetPage> {
   final _emailController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) ref.read(passwordResetProvider.notifier).reset();
+    });
+  }
+
+  @override
   void dispose() {
     _emailController.dispose();
     super.dispose();

--- a/test/screens/pages/auth/email_auth_page_test.dart
+++ b/test/screens/pages/auth/email_auth_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/screens/pages/auth/view/email_auth_page.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
 
@@ -79,6 +80,11 @@ Future<void> _fillRegisterForm(
 void main() {
   group('EmailAuthPage - 新規登録バリデーション', () {
     testWidgets('数字のみのパスワードは登録できない', (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       final service = _FakeAuthService();
       await tester.pumpWidget(_buildPage(service));
       await _fillRegisterForm(tester, password: '123456');
@@ -86,11 +92,17 @@ void main() {
       await tester.tap(find.text('登録する'));
       await tester.pump();
 
-      expect(find.text('パスワードは英字と数字を両方含めてください'), findsOneWidget);
+      expect(find.text(AppStrings.emailAuthPasswordAlphanumericError),
+          findsOneWidget);
       expect(service.registerCalled, isFalse);
     });
 
     testWidgets('英字のみのパスワードは登録できない', (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       final service = _FakeAuthService();
       await tester.pumpWidget(_buildPage(service));
       await _fillRegisterForm(tester, password: 'abcdefg');
@@ -98,11 +110,17 @@ void main() {
       await tester.tap(find.text('登録する'));
       await tester.pump();
 
-      expect(find.text('パスワードは英字と数字を両方含めてください'), findsOneWidget);
+      expect(find.text(AppStrings.emailAuthPasswordAlphanumericError),
+          findsOneWidget);
       expect(service.registerCalled, isFalse);
     });
 
     testWidgets('英数字混在のパスワードは登録できる', (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       final service = _FakeAuthService();
       await tester.pumpWidget(_buildPage(service));
       await _fillRegisterForm(tester, password: 'abc123');
@@ -110,11 +128,17 @@ void main() {
       await tester.tap(find.text('登録する'));
       await tester.pump();
 
-      expect(find.text('パスワードは英字と数字を両方含めてください'), findsNothing);
+      expect(find.text(AppStrings.emailAuthPasswordAlphanumericError),
+          findsNothing);
       expect(service.registerCalled, isTrue);
     });
 
     testWidgets('6文字未満のパスワードは登録できない', (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       final service = _FakeAuthService();
       await tester.pumpWidget(_buildPage(service));
       await _fillRegisterForm(tester, password: 'ab1');

--- a/test/screens/pages/auth/email_auth_page_test.dart
+++ b/test/screens/pages/auth/email_auth_page_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/screens/pages/auth/view/email_auth_page.dart';
+import 'package:tekushare/screens/providers/auth_provider.dart';
+
+class _FakeAuthService implements AuthService {
+  bool registerCalled = false;
+  bool signInCalled = false;
+
+  @override
+  Stream<AuthUser?> watchAuthState() => const Stream.empty();
+
+  @override
+  Future<void> registerWithEmail(
+      String email, String displayName, String password) async {
+    registerCalled = true;
+  }
+
+  @override
+  Future<void> signInWithEmail(String email, String password) async {
+    signInCalled = true;
+  }
+
+  @override
+  Future<void> setDisplayName(String name) async {}
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<void> deleteUser() async {}
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> reloadCurrentUser() async {}
+
+  @override
+  Future<String> verifyPasswordResetCode(String code) async => '';
+
+  @override
+  Future<void> confirmPasswordReset(String code, String newPassword) async {}
+
+  @override
+  Future<void> applyEmailVerificationCode(String oobCode) async {}
+}
+
+Widget _buildPage(_FakeAuthService service) {
+  return ProviderScope(
+    overrides: [authServiceProvider.overrideWithValue(service)],
+    child: const MaterialApp(home: EmailAuthPage()),
+  );
+}
+
+/// 新規登録モードに切り替えてフォームを埋めるヘルパー
+/// フィールド順: [0]=ニックネーム [1]=メール [2]=パスワード [3]=確認
+Future<void> _fillRegisterForm(
+  WidgetTester tester, {
+  String name = 'テスト太郎',
+  String email = 'test@example.com',
+  String password = 'abc123',
+  String? confirm,
+}) async {
+  await tester.tap(find.text('アカウントをお持ちでない方はこちら'));
+  await tester.pumpAndSettle();
+
+  final fields = find.byType(TextField);
+  await tester.enterText(fields.at(0), name);
+  await tester.enterText(fields.at(1), email);
+  await tester.enterText(fields.at(2), password);
+  await tester.enterText(fields.at(3), confirm ?? password);
+}
+
+void main() {
+  group('EmailAuthPage - 新規登録バリデーション', () {
+    testWidgets('数字のみのパスワードは登録できない', (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      await _fillRegisterForm(tester, password: '123456');
+
+      await tester.tap(find.text('登録する'));
+      await tester.pump();
+
+      expect(find.text('パスワードは英字と数字を両方含めてください'), findsOneWidget);
+      expect(service.registerCalled, isFalse);
+    });
+
+    testWidgets('英字のみのパスワードは登録できない', (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      await _fillRegisterForm(tester, password: 'abcdefg');
+
+      await tester.tap(find.text('登録する'));
+      await tester.pump();
+
+      expect(find.text('パスワードは英字と数字を両方含めてください'), findsOneWidget);
+      expect(service.registerCalled, isFalse);
+    });
+
+    testWidgets('英数字混在のパスワードは登録できる', (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      await _fillRegisterForm(tester, password: 'abc123');
+
+      await tester.tap(find.text('登録する'));
+      await tester.pump();
+
+      expect(find.text('パスワードは英字と数字を両方含めてください'), findsNothing);
+      expect(service.registerCalled, isTrue);
+    });
+
+    testWidgets('6文字未満のパスワードは登録できない', (tester) async {
+      final service = _FakeAuthService();
+      await tester.pumpWidget(_buildPage(service));
+      await _fillRegisterForm(tester, password: 'ab1');
+
+      await tester.tap(find.text('登録する'));
+      await tester.pump();
+
+      expect(find.text('パスワードは6文字以上で入力してください'), findsOneWidget);
+      expect(service.registerCalled, isFalse);
+    });
+  });
+}

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -129,5 +129,49 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('このメールアドレスは登録されていません'), findsOneWidget);
     });
+
+    // ページを再度開いたとき Success 状態がリセットされる
+    testWidgets('resets to idle when page is reopened after success',
+        (tester) async {
+      final service = _FakeAuthService();
+      // Navigator で push/pop を使い、initState が2回呼ばれることを確認する
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [authServiceProvider.overrideWithValue(service)],
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => const PasswordResetPage()),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // 1回目: ページを開いてメール送信 → Success 状態
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'test@example.com');
+      await tester.tap(find.text(AppStrings.passwordResetSendButton));
+      await tester.pumpAndSettle();
+      expect(find.text(AppStrings.passwordResetSuccessMessage), findsOneWidget);
+
+      // ページを閉じる
+      final NavigatorState navigator = tester.state(find.byType(Navigator));
+      navigator.pop();
+      await tester.pumpAndSettle();
+
+      // 2回目: ページを再度開く → initState でリセットされ Idle 状態になる
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(AppStrings.passwordResetSuccessMessage), findsNothing);
+      expect(find.text(AppStrings.passwordResetSendButton), findsOneWidget);
+    });
   });
 }

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -133,6 +133,11 @@ void main() {
     // ページを再度開いたとき Success 状態がリセットされる
     testWidgets('resets to idle when page is reopened after success',
         (tester) async {
+      tester.view.physicalSize = const Size(1170, 2532);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       final service = _FakeAuthService();
       // Navigator で push/pop を使い、initState が2回呼ばれることを確認する
       await tester.pumpWidget(

--- a/test/screens/pages/auth/password_reset_page_test.dart
+++ b/test/screens/pages/auth/password_reset_page_test.dart
@@ -143,8 +143,7 @@ void main() {
               builder: (context) => TextButton(
                 onPressed: () => Navigator.push(
                   context,
-                  MaterialPageRoute(
-                      builder: (_) => const PasswordResetPage()),
+                  MaterialPageRoute(builder: (_) => const PasswordResetPage()),
                 ),
                 child: const Text('open'),
               ),


### PR DESCRIPTION
﻿## 概要

認証画面で発見された2つのバグを修正。

## 修正内容

### 1. 新規登録でパスワードの英数字バリデーションがなかった
パスワードリセット画面では「英字と数字を両方含む」バリデーションがあったが、新規登録画面では数字のみ・英字のみのパスワードで登録できてしまっていた。

**対応:** `email_auth_page.dart` の登録フローに英数字チェックを追加。

### 2. パスワードリセット後に再度リセットしようとすると入力できない
パスワードリセットメール送信後にログイン → ログアウト → 再度パスワードリセットページを開くと、前回の「送信完了」状態が残りメールアドレスを入力できなかった。

**対応:** `password_reset_page.dart` の `initState` で `passwordResetProvider` をリセットするよう修正。

## テスト

- `email_auth_page_test.dart` を新規作成（パスワードバリデーション4ケース）
- `password_reset_page_test.dart` に再オープン時のリセット確認テストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 新規登録時、パスワードに英字と数字の両方が含まれているか確認するようになりました。
  * 条件を満たさない場合、分かりやすいエラーメッセージを表示します。

* **不具合修正**
  * パスワード再設定画面を開き直した際、前回の成功状態がリセットされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->