### PR TITLE
[Fix] Robo テスト用にログインフォームのフィールドに key を追加

### DIFF
--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -84,6 +84,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                 const SizedBox(height: AppSpacing.lg),
               ],
               TextField(
+                key: const Key('email_field'),
                 controller: _emailController,
                 keyboardType: TextInputType.emailAddress,
                 decoration: InputDecoration(
@@ -98,6 +99,7 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
               ),
               const SizedBox(height: AppSpacing.lg),
               TextField(
+                key: const Key('password_field'),
                 controller: _passwordController,
                 obscureText: _obscurePassword,
                 decoration: InputDecoration(


### PR DESCRIPTION
## 📝 説明
Firebase App Distribution 自動テスト（Robo テスト）がログインフォームのメール・パスワードフィールドを認識できるよう `key` を追加。

## 🔗 関連 Issue
なし

## 📋 変更内容
- [ ] 機能追加
- [ ] UI 作成
- [x] バグ修正
- [ ] ドキュメント更新
- [ ] その他：

## ✅ チェックリスト
- [ ] コードレビュー済み
- [ ] ユニットテスト実施済み
- [ ] ドキュメント更新済み
- [ ] 自分でテスト確認済み

## 📸 スクリーンショット（UI変更の場合）
なし

## 🚀 備考
マージ・APK 再ビルド後、以下のコマンドでテスト実行：
```
firebase appdistribution:distribute build/app/outputs/apk/prod/debug/app-prod-debug.apk --app 1:607979997790:android:90cc88922b5358cb5742cf --test-devices "model=oriole,version=33,locale=ja,orientation=portrait" --test-username "fantaworld117@gmail.com" --test-password "test001" --test-username-resource "email_field" --test-password-resource "password_field"
```
