### PR TITLE
[Chore] プライバシーポリシーページの追加とアプリ内リンク設置

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -204,6 +204,8 @@ abstract class AppStrings {
       'アカウントを消去しますか？\nこの操作は取り消せません。';
   static const settingsLogoutConfirmButton = 'ログアウト';
   static const settingsDeleteAccountConfirmButton = '消去する';
+  static const settingsPrivacyPolicy = 'プライバシーポリシー';
+  static const privacyPolicyUrl = 'https://tekushare.web.app/privacy.html';
 
   // アカウント連携（シェアカード内）
   static const accountLinkInviteDescription =

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -132,6 +132,22 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 onLogout: _showLogoutConfirmDialog,
                 onDeleteAccount: _showDeleteAccountConfirmDialog,
               ),
+              const SizedBox(height: AppSpacing.sm),
+              TextButton(
+                onPressed: () async {
+                  final uri = Uri.parse(AppStrings.privacyPolicyUrl);
+                  if (await canLaunchUrl(uri)) {
+                    await launchUrl(uri, mode: LaunchMode.externalApplication);
+                  }
+                },
+                child: const Text(
+                  AppStrings.settingsPrivacyPolicy,
+                  style: TextStyle(
+                    fontSize: AppTextStyle.xs,
+                    color: AppColors.textDisabled,
+                  ),
+                ),
+              ),
               const SizedBox(height: AppSpacing.lg),
             ],
           ),

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,163 @@
+<title>プライバシーポリシー | てくしぇあ</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --surface: #f8f8f8;
+    --text: #1a1a1a;
+    --text-sub: #555555;
+    --accent: #3d8c6e;
+    --border: #e0e0e0;
+    --font: 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', 'Meiryo', sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #111111;
+      --surface: #1e1e1e;
+      --text: #f0f0f0;
+      --text-sub: #aaaaaa;
+      --border: #333333;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #111111;
+    --surface: #1e1e1e;
+    --text: #f0f0f0;
+    --text-sub: #aaaaaa;
+    --border: #333333;
+  }
+  :root[data-theme="light"] {
+    --bg: #ffffff;
+    --surface: #f8f8f8;
+    --text: #1a1a1a;
+    --text-sub: #555555;
+    --border: #e0e0e0;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font);
+    font-size: 15px;
+    line-height: 1.8;
+  }
+  header {
+    background: var(--accent);
+    color: #fff;
+    padding: 32px 24px;
+    text-align: center;
+  }
+  header h1 { font-size: 22px; font-weight: bold; }
+  header p { font-size: 13px; opacity: 0.85; margin-top: 4px; }
+  main {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+  }
+  section { margin-bottom: 40px; }
+  h2 {
+    font-size: 17px;
+    font-weight: bold;
+    color: var(--accent);
+    border-left: 4px solid var(--accent);
+    padding-left: 12px;
+    margin-bottom: 16px;
+  }
+  p { color: var(--text); margin-bottom: 12px; }
+  ul {
+    padding-left: 20px;
+    margin-bottom: 12px;
+  }
+  ul li { margin-bottom: 6px; color: var(--text); }
+  .note {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px 20px;
+    font-size: 14px;
+    color: var(--text-sub);
+  }
+  footer {
+    text-align: center;
+    padding: 24px;
+    font-size: 13px;
+    color: var(--text-sub);
+    border-top: 1px solid var(--border);
+  }
+</style>
+
+<header>
+  <h1>プライバシーポリシー</h1>
+  <p>てくしぇあ（TekuShare）</p>
+</header>
+
+<main>
+  <section>
+    <p>てくしぇあ（以下「本アプリ」）は、ユーザーのプライバシーを尊重し、個人情報の適切な管理に努めます。本ポリシーは、本アプリが収集する情報とその利用方法について説明します。</p>
+  </section>
+
+  <section>
+    <h2>1. 収集する情報</h2>
+    <p>本アプリは以下の情報を収集します。</p>
+    <ul>
+      <li><strong>メールアドレス</strong>：アカウント登録・認証のため</li>
+      <li><strong>位置情報</strong>：散歩ルートの記録のため（アプリ使用中および一部バックグラウンドでの取得）</li>
+      <li><strong>ユーザーが作成したコンテンツ</strong>：スポット情報・散歩ルートのデータ</li>
+      <li><strong>表示名（ニックネーム）</strong>：アプリ内でのユーザー識別のため</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>2. 情報の利用目的</h2>
+    <ul>
+      <li>アカウントの作成・認証・管理</li>
+      <li>散歩ルートおよびスポット情報の記録・表示</li>
+      <li>家族・友人との記録共有機能の提供</li>
+      <li>見守り機能（連携ユーザーへの通知）の提供</li>
+      <li>アプリの改善および不具合の修正</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>3. 第三者サービスへの情報提供</h2>
+    <p>本アプリは以下の第三者サービスを利用しており、各サービスのプライバシーポリシーに従いデータが処理されます。</p>
+    <ul>
+      <li><strong>Firebase（Google LLC）</strong>：認証・データベース・ホスティング</li>
+      <li><strong>Google Maps Platform</strong>：地図表示・ルート案内</li>
+    </ul>
+    <div class="note">収集した情報を広告目的で第三者に販売することはありません。</div>
+  </section>
+
+  <section>
+    <h2>4. 位置情報について</h2>
+    <p>本アプリは散歩中のルート記録のために位置情報を取得します。位置情報の取得はユーザーの許可を得た場合のみ行い、許可はいつでも端末の設定から変更できます。</p>
+  </section>
+
+  <section>
+    <h2>5. データの保存と削除</h2>
+    <p>ユーザーのデータはFirebase（Google LLC）のサーバーに保存されます。アカウントを削除すると、ユーザーに紐づくすべてのデータが削除されます。アカウントの削除はアプリ内の設定画面から行えます。</p>
+  </section>
+
+  <section>
+    <h2>6. お子様のプライバシー</h2>
+    <p>本アプリは13歳未満のお子様を対象としていません。13歳未満のお子様から意図せず個人情報を収集した場合は、速やかに削除します。</p>
+  </section>
+
+  <section>
+    <h2>7. プライバシーポリシーの変更</h2>
+    <p>本ポリシーは必要に応じて更新することがあります。重要な変更がある場合はアプリ内でお知らせします。最新のポリシーは常にこのページに掲載されます。</p>
+  </section>
+
+  <section>
+    <h2>8. お問い合わせ</h2>
+    <p>プライバシーに関するご質問は以下までお問い合わせください。</p>
+    <div class="note">メールアドレス：kinnotarakame@gmail.com</div>
+  </section>
+
+  <section>
+    <p style="color: var(--text-sub); font-size: 13px;">制定日：2026年7月17日</p>
+  </section>
+</main>
+
+<footer>
+  &copy; 2026 てくしぇあ（TekuShare）
+</footer>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,89 +1,96 @@
-<title>プライバシーポリシー | てくしぇあ</title>
-<style>
-  :root {
-    --bg: #ffffff;
-    --surface: #f8f8f8;
-    --text: #1a1a1a;
-    --text-sub: #555555;
-    --accent: #3d8c6e;
-    --border: #e0e0e0;
-    --font: 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', 'Meiryo', sans-serif;
-  }
-  @media (prefers-color-scheme: dark) {
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>プライバシーポリシー | てくしぇあ</title>
+  <style>
     :root {
+      --bg: #ffffff;
+      --surface: #f8f8f8;
+      --text: #1a1a1a;
+      --text-sub: #555555;
+      --accent: #3d8c6e;
+      --border: #e0e0e0;
+      --font: 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', 'Meiryo', sans-serif;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #111111;
+        --surface: #1e1e1e;
+        --text: #f0f0f0;
+        --text-sub: #aaaaaa;
+        --border: #333333;
+      }
+    }
+    :root[data-theme="dark"] {
       --bg: #111111;
       --surface: #1e1e1e;
       --text: #f0f0f0;
       --text-sub: #aaaaaa;
       --border: #333333;
     }
-  }
-  :root[data-theme="dark"] {
-    --bg: #111111;
-    --surface: #1e1e1e;
-    --text: #f0f0f0;
-    --text-sub: #aaaaaa;
-    --border: #333333;
-  }
-  :root[data-theme="light"] {
-    --bg: #ffffff;
-    --surface: #f8f8f8;
-    --text: #1a1a1a;
-    --text-sub: #555555;
-    --border: #e0e0e0;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body {
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--font);
-    font-size: 15px;
-    line-height: 1.8;
-  }
-  header {
-    background: var(--accent);
-    color: #fff;
-    padding: 32px 24px;
-    text-align: center;
-  }
-  header h1 { font-size: 22px; font-weight: bold; }
-  header p { font-size: 13px; opacity: 0.85; margin-top: 4px; }
-  main {
-    max-width: 720px;
-    margin: 0 auto;
-    padding: 40px 24px 80px;
-  }
-  section { margin-bottom: 40px; }
-  h2 {
-    font-size: 17px;
-    font-weight: bold;
-    color: var(--accent);
-    border-left: 4px solid var(--accent);
-    padding-left: 12px;
-    margin-bottom: 16px;
-  }
-  p { color: var(--text); margin-bottom: 12px; }
-  ul {
-    padding-left: 20px;
-    margin-bottom: 12px;
-  }
-  ul li { margin-bottom: 6px; color: var(--text); }
-  .note {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px 20px;
-    font-size: 14px;
-    color: var(--text-sub);
-  }
-  footer {
-    text-align: center;
-    padding: 24px;
-    font-size: 13px;
-    color: var(--text-sub);
-    border-top: 1px solid var(--border);
-  }
-</style>
+    :root[data-theme="light"] {
+      --bg: #ffffff;
+      --surface: #f8f8f8;
+      --text: #1a1a1a;
+      --text-sub: #555555;
+      --border: #e0e0e0;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--font);
+      font-size: 15px;
+      line-height: 1.8;
+    }
+    header {
+      background: var(--accent);
+      color: #fff;
+      padding: 32px 24px;
+      text-align: center;
+    }
+    header h1 { font-size: 22px; font-weight: bold; }
+    header p { font-size: 13px; opacity: 0.85; margin-top: 4px; }
+    main {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 40px 24px 80px;
+    }
+    section { margin-bottom: 40px; }
+    h2 {
+      font-size: 17px;
+      font-weight: bold;
+      color: var(--accent);
+      border-left: 4px solid var(--accent);
+      padding-left: 12px;
+      margin-bottom: 16px;
+    }
+    p { color: var(--text); margin-bottom: 12px; }
+    ul {
+      padding-left: 20px;
+      margin-bottom: 12px;
+    }
+    ul li { margin-bottom: 6px; color: var(--text); }
+    .note {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px 20px;
+      font-size: 14px;
+      color: var(--text-sub);
+    }
+    footer {
+      text-align: center;
+      padding: 24px;
+      font-size: 13px;
+      color: var(--text-sub);
+      border-top: 1px solid var(--border);
+    }
+  </style>
+</head>
+<body>
 
 <header>
   <h1>プライバシーポリシー</h1>
@@ -161,3 +168,6 @@
 <footer>
   &copy; 2026 てくしぇあ（TekuShare）
 </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## 概要
- Firebase Hosting にプライバシーポリシーページを追加（`public/privacy.html`）
- HTML の基本構造（DOCTYPE・charset・viewport）を修正
- 設定画面のアカウントカード下にプライバシーポリシーへのリンクを追加

## 変更内容
- `public/privacy.html`：プライバシーポリシーページを新規追加、HTML 基本構造を修正
- `lib/core/constants/app_strings.dart`：プライバシーポリシー用の文字列定数・URL を追加
- `lib/screens/pages/settings/view/settings_page.dart`：設定画面下部にリンクを追加

## 確認事項
- [ ] 設定画面の最下部に「プライバシーポリシー」リンクが表示される
- [ ] タップするとブラウザで https://tekushare.web.app/privacy.html が開く
- [ ] マージ後に `firebase deploy --only hosting` を実行してページを公開する