### PR TITLE
[Fix] 登録完了画面に迷惑メールフォルダの確認案内を追加

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -68,7 +68,7 @@ abstract class AppStrings {
   static const emailAuthPasswordHint = '6文字以上';
   static const emailAuthPasswordAlphanumericError = 'パスワードは英字と数字を両方含めてください';
   static const emailAuthRegisteredDescription =
-      'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。';
+      'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。\n届いていない場合は迷惑メールフォルダもご確認ください。';
   static const emailAuthLoginButton = 'ログインへ';
 
   // メールアドレス確認


### PR DESCRIPTION
## 概要
新規登録後の確認メール送信画面に、迷惑メールフォルダの確認を促す文言を追加。

## 変更内容
- `lib/core/constants/app_strings.dart`：`emailAuthRegisteredDescription` に「届いていない場合は迷惑メールフォルダもご確認ください。」を追記

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * メール認証の案内文に、確認メールが届かない場合は迷惑メールフォルダも確認するよう追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->