### PR TITLE
[Fix] applicationId を com.tekushare.app に変更

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,7 +41,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "tekushare.app"
+        applicationId = "com.tekushare.app"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -7,9 +7,9 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:607979997790:android:1d1f1528a392b6825742cf",
+        "mobilesdk_app_id": "1:607979997790:android:b71382402c5b29ac5742cf",
         "android_client_info": {
-          "package_name": "com.example.tekushare"
+          "package_name": "com.tekushare.app"
         }
       },
       "oauth_client": [],
@@ -26,9 +26,9 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:607979997790:android:90148ba83b7680ec5742cf",
+        "mobilesdk_app_id": "1:607979997790:android:c26fe9971643ff225742cf",
         "android_client_info": {
-          "package_name": "com.example.tekushare.dev"
+          "package_name": "com.tekushare.app.dev"
         }
       },
       "oauth_client": [],
@@ -45,9 +45,9 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:607979997790:android:ec4f743cbf5e0b125742cf",
+        "mobilesdk_app_id": "1:607979997790:android:99b5edd4d1832e9b5742cf",
         "android_client_info": {
-          "package_name": "com.example.tekushare.stg"
+          "package_name": "com.tekushare.app.stg"
         }
       },
       "oauth_client": [],

--- a/lib/core/config/flavor.dart
+++ b/lib/core/config/flavor.dart
@@ -37,7 +37,7 @@ abstract class AppConfig {
     }
   }
 
-  /// Android パッケージ名 / iOS Bundle ID
+  /// Android パッケージ名
   static String get packageName {
     switch (_flavor) {
       case Flavor.dev:
@@ -46,6 +46,18 @@ abstract class AppConfig {
         return 'com.tekushare.app.stg';
       case Flavor.prod:
         return 'com.tekushare.app';
+    }
+  }
+
+  /// iOS Bundle ID
+  static String get iosBundleId {
+    switch (_flavor) {
+      case Flavor.dev:
+        return 'com.example.tekushare.dev';
+      case Flavor.stg:
+        return 'com.example.tekushare.stg';
+      case Flavor.prod:
+        return 'com.example.tekushare';
     }
   }
 

--- a/lib/core/config/flavor.dart
+++ b/lib/core/config/flavor.dart
@@ -41,11 +41,11 @@ abstract class AppConfig {
   static String get packageName {
     switch (_flavor) {
       case Flavor.dev:
-        return 'tekushare.app.dev';
+        return 'com.tekushare.app.dev';
       case Flavor.stg:
-        return 'tekushare.app.stg';
+        return 'com.tekushare.app.stg';
       case Flavor.prod:
-        return 'tekushare.app';
+        return 'com.tekushare.app';
     }
   }
 

--- a/lib/data/services/firebase_auth_service_impl.dart
+++ b/lib/data/services/firebase_auth_service_impl.dart
@@ -115,7 +115,7 @@ class FirebaseAuthServiceImpl implements AuthService {
         handleCodeInApp: true,
         androidPackageName: AppConfig.packageName,
         androidInstallApp: true,
-        iOSBundleId: AppConfig.packageName,
+        iOSBundleId: AppConfig.iosBundleId,
       );
       await _auth.sendPasswordResetEmail(
           email: email, actionCodeSettings: settings);
@@ -132,7 +132,7 @@ class FirebaseAuthServiceImpl implements AuthService {
         handleCodeInApp: true,
         androidPackageName: AppConfig.packageName,
         androidInstallApp: true,
-        iOSBundleId: AppConfig.packageName,
+        iOSBundleId: AppConfig.iosBundleId,
       );
       await _auth.currentUser?.sendEmailVerification(settings);
     } on FirebaseAuthException catch (e) {

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -3,7 +3,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "tekushare.app",
+      "package_name": "com.tekushare.app",
       "sha256_cert_fingerprints": [
         "8C:57:66:69:BC:F2:56:D7:41:40:08:CA:4E:2F:55:47:CC:64:B5:37:B3:01:4E:BF:7C:67:AA:51:75:C8:50:28",
         "19:A9:C6:3A:BD:71:B6:2B:20:F1:57:30:ED:E9:69:A2:97:0A:24:E6:50:E7:01:06:A9:4D:F0:94:4C:86:66:3C"
@@ -14,7 +14,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "tekushare.app.dev",
+      "package_name": "com.tekushare.app.dev",
       "sha256_cert_fingerprints": [
         "8C:57:66:69:BC:F2:56:D7:41:40:08:CA:4E:2F:55:47:CC:64:B5:37:B3:01:4E:BF:7C:67:AA:51:75:C8:50:28"
       ]
@@ -24,7 +24,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "tekushare.app.stg",
+      "package_name": "com.tekushare.app.stg",
       "sha256_cert_fingerprints": [
         "8C:57:66:69:BC:F2:56:D7:41:40:08:CA:4E:2F:55:47:CC:64:B5:37:B3:01:4E:BF:7C:67:AA:51:75:C8:50:28"
       ]


### PR DESCRIPTION
## 概要
Google Play Console に登録したパッケージ名 `com.tekushare.app` に合わせて applicationId を変更。

## 変更内容
- `android/app/build.gradle.kts`：applicationId `tekushare.app` → `com.tekushare.app`
- `lib/core/config/flavor.dart`：packageName を各 flavor で `com.tekushare.app` に更新
- `android/app/google-services.json`：`com.tekushare.app` / `.dev` / `.stg` のエントリを追加
- `public/.well-known/assetlinks.json`：package_name を `com.tekushare.app` に更新

## マージ後の作業
- `flutter build appbundle --flavor prod --target lib/main_prod.dart` で AAB を再ビルド
- Google Play Console にアップロード

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Androidアプリのパッケージ識別子を正式な名称に統一しました。
  - 開発・ステージング・本番環境ごとの設定を更新し、環境間の識別を明確化しました。
  - Webサイトからアプリを開くリンク設定を更新し、各環境で正しいアプリが起動するよう改善しました。
  - Firebase連携設定を新しいアプリ識別子に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->