### PR TITLE
[Fix] バックグラウンド・外部アプリ移動時に散歩状態がリセットされる

### DIFF
--- a/lib/screens/pages/home/view/home_page.dart
+++ b/lib/screens/pages/home/view/home_page.dart
@@ -73,6 +73,18 @@ class _HomePageState extends ConsumerState<HomePage>
     });
 
     _controller.forward();
+
+    // プロセスキル後の復元: SharedPreferences から walking 状態が復元されていたら
+    // ref.listen は初期値で発火しないため、initState で明示的にチェックして遷移する
+    Future.microtask(() {
+      if (!mounted) return;
+      if (ref.read(walkSessionProvider).status == WalkStatus.walking) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const WalkPage()),
+        );
+      }
+    });
   }
 
   @override

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -189,12 +189,14 @@ class _WalkPageState extends ConsumerState<WalkPage> {
         content: const Text(AppStrings.gpsTimeoutMessage),
         actions: [
           TextButton(
-            onPressed: () {
+            onPressed: () async {
               Navigator.pop(dialogContext);
               ref.read(notificationServiceProvider).cancelAll();
               ref.read(walkTimerProvider.notifier).reset();
-              ref.read(walkSessionProvider.notifier).resetWalk();
-              Navigator.popUntil(context, (route) => route.isFirst);
+              await ref.read(walkSessionProvider.notifier).resetWalk();
+              if (mounted) {
+                Navigator.popUntil(context, (route) => route.isFirst);
+              }
             },
             child: const Text(AppStrings.gpsTimeoutRetry),
           ),

--- a/lib/screens/providers/walk_session_provider.dart
+++ b/lib/screens/providers/walk_session_provider.dart
@@ -28,6 +28,10 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
     if (id == null || statusIndex == null) {
       return const WalkSession(id: '', status: WalkStatus.idle);
     }
+    // 範囲外インデックスはクラッシュを防ぐため idle に戻す
+    if (statusIndex < 0 || statusIndex >= WalkStatus.values.length) {
+      return const WalkSession(id: '', status: WalkStatus.idle);
+    }
     final status = WalkStatus.values[statusIndex];
     if (status != WalkStatus.walking) {
       return const WalkSession(id: '', status: WalkStatus.idle);
@@ -44,38 +48,43 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
     );
   }
 
-  void _persist(WalkSession session) {
+  Future<void> _persist(WalkSession session) async {
     if (session.status == WalkStatus.walking) {
-      _prefs.setString(_kId, session.id);
-      _prefs.setInt(_kStatus, session.status.index);
-      if (session.startedAt != null) {
-        _prefs.setInt(_kStartedAt, session.startedAt!.millisecondsSinceEpoch);
-      }
-      _prefs.setInt(_kElapsed, session.elapsedSeconds);
+      await Future.wait([
+        _prefs.setString(_kId, session.id),
+        _prefs.setInt(_kStatus, session.status.index),
+        if (session.startedAt != null)
+          _prefs.setInt(_kStartedAt, session.startedAt!.millisecondsSinceEpoch)
+        else
+          _prefs.remove(_kStartedAt),
+        _prefs.setInt(_kElapsed, session.elapsedSeconds),
+      ]);
     } else {
-      _prefs.remove(_kId);
-      _prefs.remove(_kStatus);
-      _prefs.remove(_kStartedAt);
-      _prefs.remove(_kElapsed);
+      await Future.wait([
+        _prefs.remove(_kId),
+        _prefs.remove(_kStatus),
+        _prefs.remove(_kStartedAt),
+        _prefs.remove(_kElapsed),
+      ]);
     }
   }
 
-  void startWalk() {
+  Future<void> startWalk() async {
     final session = _startWalk.call();
-    _persist(session);
+    await _persist(session);
     state = session;
   }
 
   Future<void> endWalk(WalkRoute route) async {
     if (state.status != WalkStatus.walking) return;
     final finished = await _endWalk.call(state, route);
-    _persist(finished);
+    await _persist(finished);
     state = finished;
   }
 
-  void resetWalk() {
+  Future<void> resetWalk() async {
     const session = WalkSession(id: '', status: WalkStatus.idle);
-    _persist(session);
+    await _persist(session);
     state = session;
   }
 }

--- a/lib/screens/providers/walk_session_provider.dart
+++ b/lib/screens/providers/walk_session_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/domain/usecases/walk/end_walk.dart';
@@ -6,25 +7,76 @@ import 'package:tekushare/domain/usecases/walk/start_walk.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 
 class WalkSessionNotifier extends StateNotifier<WalkSession> {
-  WalkSessionNotifier({required EndWalk endWalk})
+  WalkSessionNotifier(
+      {required EndWalk endWalk, required SharedPreferences prefs})
       : _endWalk = endWalk,
-        super(const WalkSession(id: '', status: WalkStatus.idle));
+        _prefs = prefs,
+        super(_restore(prefs));
 
   static const _startWalk = StartWalk();
   final EndWalk _endWalk;
+  final SharedPreferences _prefs;
+
+  static const _kId = 'walk_id';
+  static const _kStatus = 'walk_status';
+  static const _kStartedAt = 'walk_started_at';
+  static const _kElapsed = 'walk_elapsed';
+
+  static WalkSession _restore(SharedPreferences prefs) {
+    final id = prefs.getString(_kId);
+    final statusIndex = prefs.getInt(_kStatus);
+    if (id == null || statusIndex == null) {
+      return const WalkSession(id: '', status: WalkStatus.idle);
+    }
+    final status = WalkStatus.values[statusIndex];
+    if (status != WalkStatus.walking) {
+      return const WalkSession(id: '', status: WalkStatus.idle);
+    }
+    final startedAtMs = prefs.getInt(_kStartedAt);
+    final elapsed = prefs.getInt(_kElapsed) ?? 0;
+    return WalkSession(
+      id: id,
+      status: status,
+      startedAt: startedAtMs != null
+          ? DateTime.fromMillisecondsSinceEpoch(startedAtMs)
+          : null,
+      elapsedSeconds: elapsed,
+    );
+  }
+
+  void _persist(WalkSession session) {
+    if (session.status == WalkStatus.walking) {
+      _prefs.setString(_kId, session.id);
+      _prefs.setInt(_kStatus, session.status.index);
+      if (session.startedAt != null) {
+        _prefs.setInt(_kStartedAt, session.startedAt!.millisecondsSinceEpoch);
+      }
+      _prefs.setInt(_kElapsed, session.elapsedSeconds);
+    } else {
+      _prefs.remove(_kId);
+      _prefs.remove(_kStatus);
+      _prefs.remove(_kStartedAt);
+      _prefs.remove(_kElapsed);
+    }
+  }
 
   void startWalk() {
-    state = _startWalk.call();
+    final session = _startWalk.call();
+    _persist(session);
+    state = session;
   }
 
   Future<void> endWalk(WalkRoute route) async {
     if (state.status != WalkStatus.walking) return;
     final finished = await _endWalk.call(state, route);
+    _persist(finished);
     state = finished;
   }
 
   void resetWalk() {
-    state = const WalkSession(id: '', status: WalkStatus.idle);
+    const session = WalkSession(id: '', status: WalkStatus.idle);
+    _persist(session);
+    state = session;
   }
 }
 
@@ -35,5 +87,6 @@ final walkSessionProvider =
       ref.watch(walkSessionRepositoryProvider),
       ref.watch(routeRepositoryProvider),
     ),
+    prefs: ref.watch(sharedPrefsProvider).requireValue,
   );
 });

--- a/test/screens/pages/home/view/home_page_test.dart
+++ b/test/screens/pages/home/view/home_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tekushare/core/config/flavor.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
@@ -33,21 +34,50 @@ class _FakeRouteRepository implements RouteRepository {
   Future<List<WalkRoute>> getAllRoutes() async => [];
 }
 
-/// 共通のプロバイダーオーバーライド（clockProvider のタイマーを回避）
-List<Override> get _baseOverrides => [
-      // Stream.periodic によるタイマーをテストで残さないよう単発ストリームに差し替え
-      clockProvider.overrideWith((ref) => Stream.value(DateTime.now())),
-      walkSessionRepositoryProvider
-          .overrideWithValue(_FakeWalkSessionRepository()),
-      routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
-      // WalkPage の CircularProgressIndicator で pumpAndSettle がタイムアウトしないよう静的ストリームに差し替え
-      locationProvider.overrideWith(
-        (ref) => Stream<Position>.error(Exception('GPS unavailable')),
-      ),
-    ];
+Widget _buildApp(ProviderContainer container) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      builder: (context, child) {
+        final sw = MediaQuery.sizeOf(context).width;
+        return Theme(
+          data: Theme.of(context).copyWith(
+            extensions: [AppSizingTheme.fromScreenWidth(sw)],
+          ),
+          child: child!,
+        );
+      },
+      home: const HomePage(),
+    ),
+  );
+}
 
 void main() {
   AppConfig.setFlavor(Flavor.dev);
+
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  List<Override> baseOverrides() => [
+        clockProvider.overrideWith((ref) => Stream.value(DateTime.now())),
+        walkSessionRepositoryProvider
+            .overrideWithValue(_FakeWalkSessionRepository()),
+        routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+        locationProvider.overrideWith(
+          (ref) => Stream<Position>.error(Exception('GPS unavailable')),
+        ),
+        sharedPrefsProvider.overrideWith((ref) async => prefs),
+      ];
+
+  Future<ProviderContainer> makeContainer() async {
+    final container = ProviderContainer(overrides: baseOverrides());
+    await container.read(sharedPrefsProvider.future);
+    return container;
+  }
 
   group('HomePage', () {
     testWidgets('初期状態でホーム画面が表示される', (tester) async {
@@ -56,23 +86,10 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: _baseOverrides,
-          child: MaterialApp(
-            builder: (context, child) {
-              final sw = MediaQuery.sizeOf(context).width;
-              return Theme(
-                data: Theme.of(context).copyWith(
-                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
-                ),
-                child: child!,
-              );
-            },
-            home: const HomePage(),
-          ),
-        ),
-      );
+      final container = await makeContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(_buildApp(container));
       await tester.pump();
 
       expect(find.byType(HomePage), findsOneWidget);
@@ -84,27 +101,10 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      final container = ProviderContainer(overrides: _baseOverrides);
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp(
-            builder: (context, child) {
-              final sw = MediaQuery.sizeOf(context).width;
-              return Theme(
-                data: Theme.of(context).copyWith(
-                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
-                ),
-                child: child!,
-              );
-            },
-            home: const HomePage(),
-          ),
-        ),
-      );
-      // アニメーション完了まで進める
+      await tester.pumpWidget(_buildApp(container));
       await tester.pump(const Duration(milliseconds: 3000));
 
       await tester.tap(find.byType(ElevatedButton).first);
@@ -117,32 +117,15 @@ void main() {
     });
 
     testWidgets('walking 状態になったら WalkPage へ遷移する', (tester) async {
-      // WalkPage のコンテンツが収まるよう縦に広いサイズを指定
       tester.view.physicalSize = const Size(1170, 3600);
       tester.view.devicePixelRatio = 3.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      final container = ProviderContainer(overrides: _baseOverrides);
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp(
-            builder: (context, child) {
-              final sw = MediaQuery.sizeOf(context).width;
-              return Theme(
-                data: Theme.of(context).copyWith(
-                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
-                ),
-                child: child!,
-              );
-            },
-            home: const HomePage(),
-          ),
-        ),
-      );
+      await tester.pumpWidget(_buildApp(container));
       await tester.pump(const Duration(milliseconds: 3000));
 
       await tester.tap(find.byType(ElevatedButton).first);
@@ -157,26 +140,10 @@ void main() {
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      final container = ProviderContainer(overrides: _baseOverrides);
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp(
-            builder: (context, child) {
-              final sw = MediaQuery.sizeOf(context).width;
-              return Theme(
-                data: Theme.of(context).copyWith(
-                  extensions: [AppSizingTheme.fromScreenWidth(sw)],
-                ),
-                child: child!,
-              );
-            },
-            home: const HomePage(),
-          ),
-        ),
-      );
+      await tester.pumpWidget(_buildApp(container));
       await tester.pump(const Duration(milliseconds: 3000));
 
       // 1回目：WalkPage へ遷移
@@ -193,6 +160,42 @@ void main() {
       // 2回目：再度ボタンを押しても WalkPage へ遷移する
       await tester.tap(find.byType(ElevatedButton).first);
       await tester.pumpAndSettle();
+      expect(find.byType(WalkPage), findsOneWidget);
+    });
+
+    testWidgets('プロセスキル後の復元: walking 状態で起動したら WalkPage へ自動遷移する',
+        (tester) async {
+      tester.view.physicalSize = const Size(1170, 3600);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      // SharedPreferences に walking 状態を事前書き込み（プロセスキル後の再起動をシミュレート）
+      SharedPreferences.setMockInitialValues({
+        'walk_id': 'restored_walk_id',
+        'walk_status': WalkStatus.walking.index,
+        'walk_started_at': DateTime.now().millisecondsSinceEpoch,
+        'walk_elapsed': 300,
+      });
+      final walkingPrefs = await SharedPreferences.getInstance();
+
+      final container = ProviderContainer(overrides: [
+        clockProvider.overrideWith((ref) => Stream.value(DateTime.now())),
+        walkSessionRepositoryProvider
+            .overrideWithValue(_FakeWalkSessionRepository()),
+        routeRepositoryProvider.overrideWithValue(_FakeRouteRepository()),
+        locationProvider.overrideWith(
+          (ref) => Stream<Position>.error(Exception('GPS unavailable')),
+        ),
+        sharedPrefsProvider.overrideWith((ref) async => walkingPrefs),
+      ]);
+      addTearDown(container.dispose);
+      // sharedPrefsProvider を先に解決しておく（walkSessionProvider が requireValue で参照するため）
+      await container.read(sharedPrefsProvider.future);
+
+      await tester.pumpWidget(_buildApp(container));
+      await tester.pumpAndSettle();
+
       expect(find.byType(WalkPage), findsOneWidget);
     });
   });

--- a/test/screens/pages/settings/settings_page_test.dart
+++ b/test/screens/pages/settings/settings_page_test.dart
@@ -196,8 +196,11 @@ final _contactOverride =
 
 void main() {
   group('SettingsPage', () {
-    setUp(() {
+    late SharedPreferences settingsPrefs;
+
+    setUp(() async {
       SharedPreferences.setMockInitialValues({});
+      settingsPrefs = await SharedPreferences.getInstance();
     });
 
     Future<void> pumpPage(WidgetTester tester) async {
@@ -764,6 +767,7 @@ void main() {
                   _FakeWalkSessionRepository(),
                   _FakeWalkRouteRepository(),
                 ),
+                prefs: settingsPrefs,
               ),
             ),
           ],
@@ -810,6 +814,7 @@ void main() {
                   _FakeWalkSessionRepository(),
                   _FakeWalkRouteRepository(),
                 ),
+                prefs: settingsPrefs,
               ),
             ),
           ],
@@ -857,6 +862,7 @@ void main() {
                   _FakeWalkSessionRepository(),
                   _FakeWalkRouteRepository(),
                 ),
+                prefs: settingsPrefs,
               ),
             ),
           ],
@@ -907,6 +913,7 @@ void main() {
                   _FakeWalkSessionRepository(),
                   _FakeWalkRouteRepository(),
                 ),
+                prefs: settingsPrefs,
               ),
             ),
           ],
@@ -954,6 +961,7 @@ void main() {
                   _FakeWalkSessionRepository(),
                   _FakeWalkRouteRepository(),
                 ),
+                prefs: settingsPrefs,
               ),
             ),
           ],
@@ -1002,6 +1010,7 @@ void main() {
                   _FakeWalkSessionRepository(),
                   _FakeWalkRouteRepository(),
                 ),
+                prefs: settingsPrefs,
               ),
             ),
           ],

--- a/test/screens/providers/walk_session_provider_test.dart
+++ b/test/screens/providers/walk_session_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tekushare/domain/entities/lat_lng.dart';
 import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/domain/entities/walk_session.dart';
@@ -18,6 +19,7 @@ void main() {
   late MockRouteRepository mockRouteRepo;
 
   setUp(() {
+    SharedPreferences.setMockInitialValues({});
     mockSessionRepo = MockWalkSessionRepository();
     mockRouteRepo = MockRouteRepository();
     when(mockSessionRepo.saveSession(any))
@@ -25,13 +27,19 @@ void main() {
     when(mockRouteRepo.saveRoute(any)).thenAnswer((_) => Future<void>.value());
   });
 
-  ProviderContainer makeContainer() {
-    return ProviderContainer(
+  Future<ProviderContainer> makeContainer({
+    Map<String, Object> prefsData = const {},
+  }) async {
+    SharedPreferences.setMockInitialValues(prefsData);
+    final container = ProviderContainer(
       overrides: [
         walkSessionRepositoryProvider.overrideWithValue(mockSessionRepo),
         routeRepositoryProvider.overrideWithValue(mockRouteRepo),
       ],
     );
+    // sharedPrefsProvider (FutureProvider) を先に解決しておく
+    await container.read(sharedPrefsProvider.future);
+    return container;
   }
 
   WalkRoute makeRoute() => WalkRoute(
@@ -42,16 +50,16 @@ void main() {
       );
 
   group('WalkSessionNotifier', () {
-    test('初期状態は idle', () {
-      final container = makeContainer();
+    test('初期状態は idle', () async {
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
       final session = container.read(walkSessionProvider);
       expect(session.status, WalkStatus.idle);
     });
 
-    test('startWalk で walking 状態になる', () {
-      final container = makeContainer();
+    test('startWalk で walking 状態になる', () async {
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
       container.read(walkSessionProvider.notifier).startWalk();
@@ -62,7 +70,7 @@ void main() {
     });
 
     test('endWalk で finished 状態になる', () async {
-      final container = makeContainer();
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
       container.read(walkSessionProvider.notifier).startWalk();
@@ -74,7 +82,7 @@ void main() {
     });
 
     test('endWalk で saveSession が呼ばれる', () async {
-      final container = makeContainer();
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
       container.read(walkSessionProvider.notifier).startWalk();
@@ -84,7 +92,7 @@ void main() {
     });
 
     test('endWalk で saveRoute が呼ばれる', () async {
-      final container = makeContainer();
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
       container.read(walkSessionProvider.notifier).startWalk();
@@ -94,13 +102,39 @@ void main() {
     });
 
     test('idle 状態で endWalk を呼んでもリポジトリが呼ばれない', () async {
-      final container = makeContainer();
+      final container = await makeContainer();
       addTearDown(container.dispose);
 
       await container.read(walkSessionProvider.notifier).endWalk(makeRoute());
 
       verifyNever(mockSessionRepo.saveSession(any));
       verifyNever(mockRouteRepo.saveRoute(any));
+    });
+
+    test('walking 状態が SharedPreferences に保存されていたら起動時に復元される', () async {
+      final container = await makeContainer(prefsData: {
+        'walk_id': 'restored_id',
+        'walk_status': WalkStatus.walking.index,
+        'walk_started_at': DateTime.now().millisecondsSinceEpoch,
+        'walk_elapsed': 120,
+      });
+      addTearDown(container.dispose);
+
+      final session = container.read(walkSessionProvider);
+      expect(session.status, WalkStatus.walking);
+      expect(session.id, 'restored_id');
+      expect(session.elapsedSeconds, 120);
+    });
+
+    test('SharedPreferences の状態が idle なら起動時は idle になる', () async {
+      final container = await makeContainer(prefsData: {
+        'walk_id': 'old_id',
+        'walk_status': WalkStatus.idle.index,
+      });
+      addTearDown(container.dispose);
+
+      final session = container.read(walkSessionProvider);
+      expect(session.status, WalkStatus.idle);
     });
   });
 }

--- a/test/screens/providers/walk_session_provider_test.dart
+++ b/test/screens/providers/walk_session_provider_test.dart
@@ -62,7 +62,7 @@ void main() {
       final container = await makeContainer();
       addTearDown(container.dispose);
 
-      container.read(walkSessionProvider.notifier).startWalk();
+      await container.read(walkSessionProvider.notifier).startWalk();
 
       final session = container.read(walkSessionProvider);
       expect(session.status, WalkStatus.walking);
@@ -73,7 +73,7 @@ void main() {
       final container = await makeContainer();
       addTearDown(container.dispose);
 
-      container.read(walkSessionProvider.notifier).startWalk();
+      await container.read(walkSessionProvider.notifier).startWalk();
       await container.read(walkSessionProvider.notifier).endWalk(makeRoute());
 
       final session = container.read(walkSessionProvider);
@@ -85,7 +85,7 @@ void main() {
       final container = await makeContainer();
       addTearDown(container.dispose);
 
-      container.read(walkSessionProvider.notifier).startWalk();
+      await container.read(walkSessionProvider.notifier).startWalk();
       await container.read(walkSessionProvider.notifier).endWalk(makeRoute());
 
       verify(mockSessionRepo.saveSession(any)).called(1);
@@ -95,7 +95,7 @@ void main() {
       final container = await makeContainer();
       addTearDown(container.dispose);
 
-      container.read(walkSessionProvider.notifier).startWalk();
+      await container.read(walkSessionProvider.notifier).startWalk();
       await container.read(walkSessionProvider.notifier).endWalk(makeRoute());
 
       verify(mockRouteRepo.saveRoute(any)).called(1);


### PR DESCRIPTION
## 概要
散歩中にバックグラウンド移行・スリープ・外部ブラウザ起動などでOSがプロセスをキルした際、散歩状態がリセットされてしまう問題を修正。

## 原因
`WalkSession` がメモリ上にのみ保持されていたため、プロセス再起動時に状態が失われていた。

## 修正内容
- `WalkSessionNotifier` に `SharedPreferences` を注入
- `startWalk` / `endWalk` / `resetWalk` 時にセッション状態を保存・削除
- 起動時に `walking` 状態を復元する `_restore()` を追加

## 確認事項
- [ ] 散歩開始後にアプリをバックグラウンドにして戻ると散歩中の画面が維持される
- [ ] 散歩開始後にスリープにして戻ると散歩中の画面が維持される
- [ ] 散歩開始後にブラウザを開いて戻ると散歩中の画面が維持される
- [ ] 散歩終了後はリセットされている

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ウォーキングセッションの状態を端末に保存し、アプリ再起動後も復元できるようになりました。
  * セッション開始・終了・リセット時に状態が自動保存されます。
  * 不完全または無効な保存データがある場合は、待機状態に戻ります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->