### PR TITLE
[Fix] 撮影直後の写真がビューアーで壊れて表示されるバグを修正 (#145)

### DIFF
--- a/lib/core/constants/app_colors.dart
+++ b/lib/core/constants/app_colors.dart
@@ -18,4 +18,5 @@ abstract class AppColors {
   static const shareLinkBg = Color(0xFF3A3A3A);
   static const shareLinkLabel = Color(0x80FFFFFF);
   static const shareLinkButton = Color(0x3DFFFFFF);
+  static const viewerIcon = Color(0x8AFFFFFF);
 }

--- a/lib/screens/widgets/common/photo_viewer_dialog.dart
+++ b/lib/screens/widgets/common/photo_viewer_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
 import 'package:tekushare/core/constants/app_text_style.dart';
@@ -14,11 +15,11 @@ Widget _buildImage(String path) {
     return CachedNetworkImage(
       imageUrl: path,
       fit: BoxFit.contain,
-      placeholder: (_, __) =>
-          const Center(child: CircularProgressIndicator(color: Colors.white54)),
+      placeholder: (_, __) => const Center(
+          child: CircularProgressIndicator(color: AppColors.viewerIcon)),
       errorWidget: (_, __, ___) => const Icon(
         Icons.broken_image,
-        color: Colors.white54,
+        color: AppColors.viewerIcon,
         size: AppSize.iconXl,
       ),
     );
@@ -28,7 +29,7 @@ Widget _buildImage(String path) {
     fit: BoxFit.contain,
     errorBuilder: (_, __, ___) => const Icon(
       Icons.broken_image,
-      color: Colors.white54,
+      color: AppColors.viewerIcon,
       size: AppSize.iconXl,
     ),
   );

--- a/lib/screens/widgets/common/photo_viewer_dialog.dart
+++ b/lib/screens/widgets/common/photo_viewer_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
@@ -7,6 +9,31 @@ import 'package:tekushare/core/constants/map_constants.dart';
 
 /// 写真をフルスクリーンで表示するビューアーを開く。
 /// [onDelete] を渡すと削除ボタンを表示する。
+Widget _buildImage(String path) {
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return CachedNetworkImage(
+      imageUrl: path,
+      fit: BoxFit.contain,
+      placeholder: (_, __) =>
+          const Center(child: CircularProgressIndicator(color: Colors.white54)),
+      errorWidget: (_, __, ___) => const Icon(
+        Icons.broken_image,
+        color: Colors.white54,
+        size: AppSize.iconXl,
+      ),
+    );
+  }
+  return Image.file(
+    File(path),
+    fit: BoxFit.contain,
+    errorBuilder: (_, __, ___) => const Icon(
+      Icons.broken_image,
+      color: Colors.white54,
+      size: AppSize.iconXl,
+    ),
+  );
+}
+
 void showPhotoViewer(
   BuildContext context,
   String path, {
@@ -25,18 +52,7 @@ void showPhotoViewer(
               child: SizedBox.expand(
                 child: InteractiveViewer(
                   child: Center(
-                    child: CachedNetworkImage(
-                      imageUrl: path,
-                      fit: BoxFit.contain,
-                      placeholder: (_, __) => const Center(
-                        child: CircularProgressIndicator(color: Colors.white54),
-                      ),
-                      errorWidget: (_, __, ___) => const Icon(
-                        Icons.broken_image,
-                        color: Colors.white54,
-                        size: AppSize.iconXl,
-                      ),
-                    ),
+                    child: _buildImage(path),
                   ),
                 ),
               ),

--- a/test/screens/widgets/common/photo_viewer_dialog_test.dart
+++ b/test/screens/widgets/common/photo_viewer_dialog_test.dart
@@ -4,12 +4,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tekushare/screens/widgets/common/photo_viewer_dialog.dart';
 
 void main() {
-  // showDialog は Navigator が必要なので MaterialApp(home:) で包む
-  Widget wrap(VoidCallback onOpen) => MaterialApp(
+  // Builder 内の context を onPressed でキャプチャすることで stale context を回避
+  Widget buildApp(String path, {void Function()? onDelete}) => MaterialApp(
         home: Scaffold(
           body: Builder(builder: (context) {
             return TextButton(
-              onPressed: onOpen,
+              onPressed: () =>
+                  showPhotoViewer(context, path, onDelete: onDelete),
               child: const Text('open'),
             );
           }),
@@ -18,29 +19,21 @@ void main() {
 
   group('showPhotoViewer', () {
     // 【バグ再現テスト】ローカルパスに CachedNetworkImage を使うと壊れる問題 (#145)
-    testWidgets('ローカルパスのとき CachedNetworkImage を使わない', (tester) async {
-      await tester.pumpWidget(wrap(() {}));
-
-      // ignore: use_build_context_synchronously
-      final context = tester.element(find.text('open'));
-      await tester.pumpWidget(wrap(() {
-        showPhotoViewer(context, '/local/path/photo.jpg');
-      }));
-
+    testWidgets('ローカルパスのとき CachedNetworkImage を使わず Image.file を使う',
+        (tester) async {
+      await tester.pumpWidget(buildApp('/local/path/photo.jpg'));
       await tester.tap(find.text('open'));
       await tester.pump();
 
       expect(find.byType(CachedNetworkImage), findsNothing);
+      expect(
+        find.byWidgetPredicate((w) => w is Image && w.image is FileImage),
+        findsOneWidget,
+      );
     });
 
     testWidgets('http URL のとき CachedNetworkImage を使う', (tester) async {
-      await tester.pumpWidget(wrap(() {}));
-
-      final context = tester.element(find.text('open'));
-      await tester.pumpWidget(wrap(() {
-        showPhotoViewer(context, 'https://example.com/photo.jpg');
-      }));
-
+      await tester.pumpWidget(buildApp('https://example.com/photo.jpg'));
       await tester.tap(find.text('open'));
       await tester.pump();
 
@@ -48,13 +41,7 @@ void main() {
     });
 
     testWidgets('閉じるボタンでダイアログが閉じる', (tester) async {
-      await tester.pumpWidget(wrap(() {}));
-
-      final context = tester.element(find.text('open'));
-      await tester.pumpWidget(wrap(() {
-        showPhotoViewer(context, '/local/path/photo.jpg');
-      }));
-
+      await tester.pumpWidget(buildApp('/local/path/photo.jpg'));
       await tester.tap(find.text('open'));
       await tester.pump();
 
@@ -68,16 +55,9 @@ void main() {
 
     testWidgets('onDelete あり: 削除ボタンが表示され、タップで onDelete が呼ばれる', (tester) async {
       var deleted = false;
-      await tester.pumpWidget(wrap(() {}));
-
-      final context = tester.element(find.text('open'));
-      await tester.pumpWidget(wrap(() {
-        showPhotoViewer(
-          context,
-          '/local/path/photo.jpg',
-          onDelete: () => deleted = true,
-        );
-      }));
+      await tester.pumpWidget(
+        buildApp('/local/path/photo.jpg', onDelete: () => deleted = true),
+      );
 
       await tester.tap(find.text('open'));
       await tester.pump();
@@ -92,13 +72,7 @@ void main() {
     });
 
     testWidgets('onDelete なし: 削除ボタンが表示されない', (tester) async {
-      await tester.pumpWidget(wrap(() {}));
-
-      final context = tester.element(find.text('open'));
-      await tester.pumpWidget(wrap(() {
-        showPhotoViewer(context, '/local/path/photo.jpg');
-      }));
-
+      await tester.pumpWidget(buildApp('/local/path/photo.jpg'));
       await tester.tap(find.text('open'));
       await tester.pump();
 

--- a/test/screens/widgets/common/photo_viewer_dialog_test.dart
+++ b/test/screens/widgets/common/photo_viewer_dialog_test.dart
@@ -1,0 +1,108 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tekushare/screens/widgets/common/photo_viewer_dialog.dart';
+
+void main() {
+  // showDialog は Navigator が必要なので MaterialApp(home:) で包む
+  Widget wrap(VoidCallback onOpen) => MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (context) {
+            return TextButton(
+              onPressed: onOpen,
+              child: const Text('open'),
+            );
+          }),
+        ),
+      );
+
+  group('showPhotoViewer', () {
+    // 【バグ再現テスト】ローカルパスに CachedNetworkImage を使うと壊れる問題 (#145)
+    testWidgets('ローカルパスのとき CachedNetworkImage を使わない', (tester) async {
+      await tester.pumpWidget(wrap(() {}));
+
+      // ignore: use_build_context_synchronously
+      final context = tester.element(find.text('open'));
+      await tester.pumpWidget(wrap(() {
+        showPhotoViewer(context, '/local/path/photo.jpg');
+      }));
+
+      await tester.tap(find.text('open'));
+      await tester.pump();
+
+      expect(find.byType(CachedNetworkImage), findsNothing);
+    });
+
+    testWidgets('http URL のとき CachedNetworkImage を使う', (tester) async {
+      await tester.pumpWidget(wrap(() {}));
+
+      final context = tester.element(find.text('open'));
+      await tester.pumpWidget(wrap(() {
+        showPhotoViewer(context, 'https://example.com/photo.jpg');
+      }));
+
+      await tester.tap(find.text('open'));
+      await tester.pump();
+
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+    });
+
+    testWidgets('閉じるボタンでダイアログが閉じる', (tester) async {
+      await tester.pumpWidget(wrap(() {}));
+
+      final context = tester.element(find.text('open'));
+      await tester.pumpWidget(wrap(() {
+        showPhotoViewer(context, '/local/path/photo.jpg');
+      }));
+
+      await tester.tap(find.text('open'));
+      await tester.pump();
+
+      expect(find.byType(Dialog), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Dialog), findsNothing);
+    });
+
+    testWidgets('onDelete あり: 削除ボタンが表示され、タップで onDelete が呼ばれる', (tester) async {
+      var deleted = false;
+      await tester.pumpWidget(wrap(() {}));
+
+      final context = tester.element(find.text('open'));
+      await tester.pumpWidget(wrap(() {
+        showPhotoViewer(
+          context,
+          '/local/path/photo.jpg',
+          onDelete: () => deleted = true,
+        );
+      }));
+
+      await tester.tap(find.text('open'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.delete_outline));
+      await tester.pumpAndSettle();
+
+      expect(deleted, isTrue);
+      expect(find.byType(Dialog), findsNothing);
+    });
+
+    testWidgets('onDelete なし: 削除ボタンが表示されない', (tester) async {
+      await tester.pumpWidget(wrap(() {}));
+
+      final context = tester.element(find.text('open'));
+      await tester.pumpWidget(wrap(() {
+        showPhotoViewer(context, '/local/path/photo.jpg');
+      }));
+
+      await tester.tap(find.text('open'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.delete_outline), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

散歩中に撮影した写真を「行きたい場所」に保存する前にタップすると、写真が壊れた表示（broken_image）になるバグを修正。

## 原因

`photo_viewer_dialog.dart` で画像表示に `CachedNetworkImage` のみを使用していたが、撮影直後はローカルファイルパス（`/data/...`）が渡されるため、HTTP URL 専用の `CachedNetworkImage` では読み込めなかった。

保存後は Firebase Storage の URL（`https://...`）に変わるため、再起動後は正常に表示されていた。

## 修正内容

- パスが `http://` / `https://` で始まる場合 → `CachedNetworkImage`
- それ以外（ローカルファイルパス）の場合 → `Image.file`

## テスト

`test/screens/widgets/common/photo_viewer_dialog_test.dart` を新規追加。

- ローカルパス → `CachedNetworkImage` を使わないことを検証
- http URL → `CachedNetworkImage` を使うことを検証
- 閉じるボタン・削除ボタンの動作を検証

## 関連 issue

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ローカル画像を表示する際に、ネットワーク画像用の処理を使用しないよう改善しました。
  * URL画像とローカル画像を適切に表示できるようになりました。
  * 画像ビューアの閉じる操作や削除ボタンの動作を確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->