### PR TITLE
[Fix] 行きたい保存後の画面遷移・GPS取得改善

### DIFF
--- a/lib/infrastructure/location_service.dart
+++ b/lib/infrastructure/location_service.dart
@@ -4,7 +4,7 @@ class LocationService {
   static const _distanceFilterMeters = 3;
 
   // 通常精度しきい値：これ以下の誤差のみ採用
-  static const _maxAccuracyMeters = 20.0;
+  static const _maxAccuracyMeters = 30.0;
 
   // フォールバックしきい値：一定時間良好なポイントが来なければ緩和
   static const _fallbackAccuracyMeters = 50.0;

--- a/lib/screens/pages/spot/view/want_to_go_page.dart
+++ b/lib/screens/pages/spot/view/want_to_go_page.dart
@@ -121,7 +121,7 @@ class _WantToGoPageState extends ConsumerState<WantToGoPage> {
             builder: (_) => _SavedDialog(
               onClose: () {
                 Navigator.pop(context); // ダイアログを閉じる
-                Navigator.popUntil(context, (route) => route.isFirst);
+                Navigator.pop(context); // WalkPage へ戻る
               },
             ),
           );

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -34,7 +34,7 @@ import 'package:tekushare/screens/widgets/common/app_bottom_nav.dart';
 import 'package:tekushare/screens/widgets/common/clock_header.dart';
 import 'package:tekushare/screens/widgets/common/primary_button.dart';
 
-const _gpsTimeoutSeconds = 30;
+const _gpsTimeoutSeconds = 60;
 
 /// 散歩モード画面
 class WalkPage extends ConsumerStatefulWidget {


### PR DESCRIPTION
## 概要

テスターからのフィードバックをもとに2点修正。

## 修正内容

### 1. 「行きたい」保存後に WalkPage へ戻るよう修正 (#147)

`Navigator.popUntil(isFirst)` で HomePage まで戻っていたのを、`Navigator.pop()` で WalkPage へ戻るよう変更。

### 2. GPS タイムアウト延長・精度フィルター緩和 (#151)

バスや建物内など GPS 信号が弱い環境で「GPS を取得できません」が頻繁に表示される問題を緩和。

- タイムアウト: 30秒 → 60秒
- 精度フィルター: 20m → 30m

## 確認事項

- [x] 散歩開始 → 「行きたい」でスポット保存 → WalkPage に戻ることを確認
- [x] GPS が弱い環境でのタイムアウトダイアログの頻度が改善されることを確認

## 関連 issue

- Closes #147
- Closes #151