### PR TITLE
[Fix] 安否通知の SMS・通知・文言改善

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/tekushare/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/tekushare/app/MainActivity.kt
@@ -1,5 +1,11 @@
 package tekushare.app
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        flutterEngine.plugins.add(SmsDirectPlugin())
+    }
+}

--- a/android/app/src/main/kotlin/tekushare/app/SmsDirectPlugin.kt
+++ b/android/app/src/main/kotlin/tekushare/app/SmsDirectPlugin.kt
@@ -1,0 +1,55 @@
+package tekushare.app
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.telephony.SmsManager
+import androidx.core.content.ContextCompat
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+class SmsDirectPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+    private lateinit var channel: MethodChannel
+    private lateinit var binding: FlutterPlugin.FlutterPluginBinding
+
+    override fun onAttachedToEngine(b: FlutterPlugin.FlutterPluginBinding) {
+        binding = b
+        channel = MethodChannel(b.binaryMessenger, "tekushare/sms_direct")
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onDetachedFromEngine(b: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        if (call.method != "sendSms") {
+            result.notImplemented()
+            return
+        }
+        val number = call.argument<String>("number")
+        val message = call.argument<String>("message")
+        if (number == null || message == null) {
+            result.error("INVALID_ARGS", "number と message は必須です", null)
+            return
+        }
+
+        val ctx = binding.applicationContext
+        if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.SEND_SMS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            result.error("PERMISSION_DENIED", "SEND_SMS 権限がありません", null)
+            return
+        }
+
+        try {
+            @Suppress("DEPRECATION")
+            val smsManager = SmsManager.getDefault()
+            val parts = smsManager.divideMessage(message)
+            smsManager.sendMultipartTextMessage(number, null, parts, null, null)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("SEND_FAILED", e.message, null)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/tekushare/app/SmsDirectPlugin.kt
+++ b/android/app/src/main/kotlin/tekushare/app/SmsDirectPlugin.kt
@@ -1,7 +1,14 @@
 package tekushare.app
 
 import android.Manifest
+import android.app.Activity
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.os.Build
 import android.telephony.SmsManager
 import androidx.core.content.ContextCompat
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -23,31 +30,67 @@ class SmsDirectPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-        if (call.method != "sendSms") {
-            result.notImplemented()
-            return
-        }
+        if (call.method != "sendSms") { result.notImplemented(); return }
         val number = call.argument<String>("number")
         val message = call.argument<String>("message")
         if (number == null || message == null) {
-            result.error("INVALID_ARGS", "number と message は必須です", null)
-            return
+            result.error("INVALID_ARGS", "number と message は必須です", null); return
         }
-
         val ctx = binding.applicationContext
         if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.SEND_SMS)
             != PackageManager.PERMISSION_GRANTED
         ) {
-            result.error("PERMISSION_DENIED", "SEND_SMS 権限がありません", null)
-            return
+            result.error("PERMISSION_DENIED", "SEND_SMS 権限がありません", null); return
         }
-
         try {
-            @Suppress("DEPRECATION")
-            val smsManager = SmsManager.getDefault()
+            val smsManager = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                ctx.getSystemService(SmsManager::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                SmsManager.getDefault()
+            }
             val parts = smsManager.divideMessage(message)
-            smsManager.sendMultipartTextMessage(number, null, parts, null, null)
-            result.success(null)
+            val actionName = "SMS_SENT_${System.nanoTime()}"
+
+            val sentIntents = ArrayList(parts.map {
+                PendingIntent.getBroadcast(
+                    ctx, 0,
+                    Intent(actionName),
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                )
+            })
+
+            val completed = intArrayOf(0)
+            val failed = intArrayOf(0)
+            val total = parts.size
+
+            val receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context, intent: Intent) {
+                    if (resultCode == Activity.RESULT_OK) completed[0]++
+                    else failed[0]++
+                    if (completed[0] + failed[0] >= total) {
+                        context.unregisterReceiver(this)
+                        if (failed[0] == 0) {
+                            result.success(null)
+                        } else {
+                            result.error(
+                                "SEND_FAILED",
+                                "${failed[0]}/${total}件の送信に失敗しました",
+                                null,
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                ctx.registerReceiver(receiver, IntentFilter(actionName), Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                @Suppress("UnspecifiedRegisterReceiverFlag")
+                ctx.registerReceiver(receiver, IntentFilter(actionName))
+            }
+
+            smsManager.sendMultipartTextMessage(number, null, parts, sentIntents, null)
         } catch (e: Exception) {
             result.error("SEND_FAILED", e.message, null)
         }

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -71,7 +71,8 @@ abstract class AppStrings {
   static const emailAuthPasswordHint = '6文字以上';
   static const emailAuthPasswordAlphanumericError = 'パスワードは英字と数字を両方含めてください';
   static const emailAuthRegisteredDescription =
-      'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。\n届いていない場合は迷惑メールフォルダもご確認ください。';
+      'ご登録のメールアドレスに確認メールをお送りしました。\nメール内のリンクをクリックして確認を完了してから、ログインしてください。';
+  static const emailSpamFolderWarning = 'メールが届かない場合は、迷惑メールフォルダをご確認ください。';
   static const emailAuthLoginButton = 'ログインへ';
 
   // メールアドレス確認

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -26,7 +26,7 @@ abstract class AppStrings {
   static const wantToGo = '行きたい！';
   static const recenterMap = '現在地に戻る';
   static const timerTurnaround = '折り返し';
-  static const timerInactivity = '不活動';
+  static const timerInactivity = '安否通知';
   static const timerReset = 'リセット';
   static const timerFinishedTitle = '散歩タイマー';
   static const timerFinishedMessage = '設定した時間になりました。';
@@ -41,6 +41,9 @@ abstract class AppStrings {
   static const safetyConfirmTitle = '大丈夫ですか？';
   static const smsSendError = 'SMS送信に失敗しました';
   static const safetyConfirmBody = '動きがありません。\n応答がない場合、登録した通知先にSMSを送信します。';
+  static const safetySmsSentBody = 'SMSで通知しました。\n元気な場合はボタンを押してください。';
+  static const smsSentNotificationTitle = '安否通知を送信しました';
+  static const smsSentNotificationBody = '登録した通知先にSMSを送信しました。';
 
   // 行きたい！ページ
   static const wantToGoPageTitle = '行きたい！';

--- a/lib/infrastructure/notification_service.dart
+++ b/lib/infrastructure/notification_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:tekushare/core/constants/app_strings.dart';
@@ -39,6 +41,12 @@ class NotificationService {
         iOS: iosSettings,
       ),
     );
+
+    if (Platform.isAndroid) {
+      final androidPlugin = _plugin.resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>();
+      await androidPlugin?.requestNotificationsPermission();
+    }
   }
 
   /// SMS 送信後の通知を表示する（バックグラウンド時でも気づけるよう）

--- a/lib/infrastructure/notification_service.dart
+++ b/lib/infrastructure/notification_service.dart
@@ -22,6 +22,7 @@ class NotificationService {
   static const _idInactivity = 1;
   static const _idTurnaround = 2;
   static const _idRoundTrip = 3;
+  static const _idSmsSent = 4;
 
   Future<void> initialize() async {
     const androidSettings =
@@ -37,6 +38,16 @@ class NotificationService {
         android: androidSettings,
         iOS: iosSettings,
       ),
+    );
+  }
+
+  /// SMS 送信後の通知を表示する（バックグラウンド時でも気づけるよう）
+  Future<void> showSmsSentNotification() async {
+    await _plugin.show(
+      id: _idSmsSent,
+      title: AppStrings.smsSentNotificationTitle,
+      body: AppStrings.smsSentNotificationBody,
+      notificationDetails: _notificationDetails(),
     );
   }
 

--- a/lib/infrastructure/sms_service.dart
+++ b/lib/infrastructure/sms_service.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter_sms/flutter_sms.dart';
+import 'package:flutter/services.dart';
 import 'package:tekushare/domain/entities/contact.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -14,6 +14,7 @@ abstract interface class SmsService {
 class SmsServiceImpl implements SmsService {
   const SmsServiceImpl();
 
+  static const _channel = MethodChannel('tekushare/sms_direct');
   static const _messageTemplate = '【てくしぇあ】{name}さんから連絡がありません。確認してください。';
 
   @override
@@ -32,18 +33,17 @@ class SmsServiceImpl implements SmsService {
     }
   }
 
-  /// Android: flutter_sms で SMS アプリを開き宛先・本文をセット（1件失敗しても残りへ継続）
+  /// Android: Method Channel 経由で SmsManager を使って直接送信
   Future<void> _sendAndroid(List<String> numbers, String message) async {
     for (final number in numbers) {
-      try {
-        await sendSMS(message: message, recipients: [number]);
-      } catch (_) {
-        // 送信失敗をスキップして次の連絡先へ
-      }
+      await _channel.invokeMethod<void>('sendSms', {
+        'number': number,
+        'message': message,
+      });
     }
   }
 
-  /// iOS: SMSアプリを開き宛先・本文をセット
+  /// iOS: SMS アプリを開き宛先・本文をセット
   Future<void> _openIosSms(List<String> numbers, String message) async {
     final recipients = numbers.join(',');
     final uri = Uri(

--- a/lib/screens/pages/auth/view/email_auth_page.dart
+++ b/lib/screens/pages/auth/view/email_auth_page.dart
@@ -230,6 +230,33 @@ class _EmailAuthPageState extends ConsumerState<EmailAuthPage> {
                 textAlign: TextAlign.center,
                 style: AppTextStyle.bodyMedium,
               ),
+              const SizedBox(height: AppSpacing.x2l),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.sm,
+                  vertical: AppSpacing.xs,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.warning.withValues(alpha: 0.1),
+                  border: Border.all(color: AppColors.warning),
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                ),
+                child: const Row(
+                  children: [
+                    Icon(
+                      Icons.warning_amber_outlined,
+                      color: AppColors.warning,
+                    ),
+                    SizedBox(width: AppSpacing.xs),
+                    Expanded(
+                      child: Text(
+                        AppStrings.emailSpamFolderWarning,
+                        style: TextStyle(color: AppColors.warning),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
               const SizedBox(height: AppSpacing.x4l),
               SizedBox(
                 height: AppSize.buttonHeight,

--- a/lib/screens/pages/auth/view/email_verification_page.dart
+++ b/lib/screens/pages/auth/view/email_verification_page.dart
@@ -126,6 +126,33 @@ class _EmailVerificationPageState extends ConsumerState<EmailVerificationPage> {
                 style: AppTextStyle.bodyMedium
                     .copyWith(color: AppColors.textDisabled),
               ),
+              const SizedBox(height: AppSpacing.x2l),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.sm,
+                  vertical: AppSpacing.xs,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.warning.withValues(alpha: 0.1),
+                  border: Border.all(color: AppColors.warning),
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                ),
+                child: const Row(
+                  children: [
+                    Icon(
+                      Icons.warning_amber_outlined,
+                      color: AppColors.warning,
+                    ),
+                    SizedBox(width: AppSpacing.xs),
+                    Expanded(
+                      child: Text(
+                        AppStrings.emailSpamFolderWarning,
+                        style: TextStyle(color: AppColors.warning),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
               const SizedBox(height: AppSpacing.x4l),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:tekushare/core/constants/app_colors.dart';
 import 'package:tekushare/core/constants/app_spacing.dart';
@@ -503,7 +507,11 @@ class _InactivityCard extends StatelessWidget {
   final VoidCallback onAddContact;
   final VoidCallback onShowContacts;
 
-  static final _inactivityOptions = List.generate(24, (i) => (i + 1) * 5);
+  static final _inactivityOptions = [
+    1,
+    2,
+    ...List.generate(24, (i) => (i + 1) * 5)
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -597,7 +605,12 @@ class _InactivityCard extends StatelessWidget {
             children: [
               _CustomSwitch(
                 value: state.inactivityEnabled,
-                onChanged: vm.setInactivityEnabled,
+                onChanged: (v) {
+                  vm.setInactivityEnabled(v);
+                  if (v && Platform.isAndroid) {
+                    unawaited(Permission.sms.request());
+                  }
+                },
               ),
               const SizedBox(width: AppSpacing.sm),
               Text(

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -507,7 +507,7 @@ class _InactivityCard extends StatelessWidget {
   final VoidCallback onAddContact;
   final VoidCallback onShowContacts;
 
-  static final _inactivityOptions = List.generate(24, (i) => (i + 1) * 5);
+  static final _inactivityOptions = List.generate(8, (i) => (i + 1) * 15);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
@@ -601,11 +600,15 @@ class _InactivityCard extends StatelessWidget {
             children: [
               _CustomSwitch(
                 value: state.inactivityEnabled,
-                onChanged: (v) {
-                  vm.setInactivityEnabled(v);
+                onChanged: (v) async {
                   if (v && Platform.isAndroid) {
-                    unawaited(Permission.sms.request());
+                    final status = await Permission.sms.request();
+                    if (status.isPermanentlyDenied) {
+                      await openAppSettings();
+                    }
+                    if (!status.isGranted) return;
                   }
+                  vm.setInactivityEnabled(v);
                 },
               ),
               const SizedBox(width: AppSpacing.sm),

--- a/lib/screens/pages/settings/view/settings_page.dart
+++ b/lib/screens/pages/settings/view/settings_page.dart
@@ -507,11 +507,7 @@ class _InactivityCard extends StatelessWidget {
   final VoidCallback onAddContact;
   final VoidCallback onShowContacts;
 
-  static final _inactivityOptions = [
-    1,
-    2,
-    ...List.generate(24, (i) => (i + 1) * 5)
-  ];
+  static final _inactivityOptions = List.generate(24, (i) => (i + 1) * 5);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -131,6 +131,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
             contacts: contacts,
             senderName: senderName,
           );
+      await ref.read(notificationServiceProvider).showSmsSentNotification();
     } catch (_) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -798,6 +799,7 @@ class _SafetyConfirmDialog extends StatefulWidget {
 class _SafetyConfirmDialogState extends State<_SafetyConfirmDialog> {
   late int _secondsLeft;
   Timer? _timer;
+  bool _smsSent = false;
 
   @override
   void initState() {
@@ -811,8 +813,9 @@ class _SafetyConfirmDialogState extends State<_SafetyConfirmDialog> {
     setState(() => _secondsLeft--);
     if (_secondsLeft <= 0) {
       _timer?.cancel();
-      Navigator.of(context).pop();
       await widget.onTimeout();
+      if (!mounted) return;
+      setState(() => _smsSent = true);
     }
   }
 
@@ -831,16 +834,22 @@ class _SafetyConfirmDialogState extends State<_SafetyConfirmDialog> {
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text(AppStrings.safetyConfirmBody),
-            const SizedBox(height: AppSpacing.x2l),
             Text(
-              '$_secondsLeft秒',
-              style: const TextStyle(
-                fontSize: AppTextStyle.x3l,
-                fontWeight: AppTextStyle.bold,
-                color: AppColors.error,
-              ),
+              _smsSent
+                  ? AppStrings.safetySmsSentBody
+                  : AppStrings.safetyConfirmBody,
             ),
+            if (!_smsSent) ...[
+              const SizedBox(height: AppSpacing.x2l),
+              Text(
+                '$_secondsLeft秒',
+                style: const TextStyle(
+                  fontSize: AppTextStyle.x3l,
+                  fontWeight: AppTextStyle.bold,
+                  color: AppColors.error,
+                ),
+              ),
+            ],
           ],
         ),
         actions: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1199,6 +1199,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.3"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.10"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   shared_preferences: ^2.3.4
   firebase_storage: 13.4.3
   cached_network_image: ^3.4.1
+  permission_handler: ^12.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

- Closes #152
- Closes #153
- Closes #154
- Closes #155
- Closes #143

## 変更内容

### #152 SMS が届かない
- `flutter_sms` を廃止し、Android Method Channel (`SmsDirectPlugin.kt`) + `SmsManager` で直接 SMS 送信に変更
- `SEND_SMS` 実行時権限を安否通知を ON にしたタイミングで要求するよう実装

### #153 バックグラウンド時も安否確認の通知を飛ばす
- SMS 送信後に `showSmsSentNotification()` を呼び出し、バックグラウンド時でも「安否通知を送信しました」通知が届くよう対応
- `POST_NOTIFICATIONS` を AndroidManifest に追加し、起動時に通知権限を要求

### #154 1 分後に SMS 送信済み文言に変更・元気ですボタンで閉じるまで消えない
- カウントダウンが 0 になってもダイアログを自動クローズしないよう変更
- タイムアウト後は「SMSで通知しました。元気な場合はボタンを押してください。」に文言を切り替え
- 「元気です」ボタンが押されるまでダイアログが表示され続ける

### #155 「不活動」→「安否通知」文言変更
- タイマーラベルの「不活動」を「安否通知」に変更

### #143 迷惑メールフォルダ確認の案内を目立たせる
- 新規登録完了画面・メール確認待ち画面に警告バナー（`Icons.warning_amber_outlined`）を追加
- 迷惑メールフォルダの案内を通常テキストから分離して強調表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 安否通知機能で、登録した連絡先へSMSを送信できるようになりました。
  * SMS送信完了時に通知を表示します。
  * Androidで通知・SMS権限を適切に確認できるようになりました。
* **改善**
  * 安否通知の送信後、画面上でSMS送信済みの状態を確認できるようになりました。
  * メール認証画面に、迷惑メールフォルダの確認案内を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->