### PR TITLE
[Feature] バックグラウンドGPS記録・長時間散歩の自動終了 (#140 #157)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
@@ -53,6 +55,11 @@
                 <data android:scheme="https" android:host="tekushare.firebaseapp.com" android:pathPrefix="/__/auth/action"/>
             </intent-filter>
         </activity>
+        <service
+            android:name="com.baseflow.geolocator.GeolocatorLocationService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="location" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,6 +28,12 @@
 		<true/>
 		<key>NSLocationWhenInUseUsageDescription</key>
 		<string>散歩中の現在地を記録するために位置情報を使用します。</string>
+		<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+		<string>バックグラウンドでも散歩ルートを記録するために位置情報を使用します。</string>
+		<key>UIBackgroundModes</key>
+		<array>
+			<string>location</string>
+		</array>
 		<key>CFBundleURLTypes</key>
 		<array>
 			<dict>

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -44,6 +44,15 @@ abstract class AppStrings {
   static const safetySmsSentBody = 'SMSで通知しました。\n元気な場合はボタンを押してください。';
   static const smsSentNotificationTitle = '安否通知を送信しました';
   static const smsSentNotificationBody = '登録した通知先にSMSを送信しました。';
+  static const walkForegroundNotificationTitle = 'てくしぇあ';
+  static const walkForegroundNotificationBody = 'バックグラウンドでGPSを記録しています';
+  static const walkReminderNotificationTitle = '散歩を続けていますか？';
+  static String walkReminderNotificationBody(int hours) =>
+      '散歩が$hours時間続いています。終了する場合はアプリを開いてください。';
+  static const walkAutoEndWarningTitle = '散歩が自動終了します';
+  static const walkAutoEndWarningBody = '散歩開始から7時間30分が経過しました。30分後に自動で散歩を終了します。';
+  static const walkAutoEndNotificationTitle = '散歩を自動終了しました';
+  static const walkAutoEndNotificationBody = '散歩開始から8時間が経過したため、自動で終了しました。';
 
   // 行きたい！ページ
   static const wantToGoPageTitle = '行きたい！';

--- a/lib/infrastructure/location_service.dart
+++ b/lib/infrastructure/location_service.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:geolocator/geolocator.dart';
+import 'package:tekushare/core/constants/app_strings.dart';
 
 class LocationService {
   static const _distanceFilterMeters = 3;
@@ -24,10 +27,24 @@ class LocationService {
       }
     } catch (_) {}
 
-    const settings = LocationSettings(
-      accuracy: LocationAccuracy.bestForNavigation,
-      distanceFilter: _distanceFilterMeters,
-    );
+    final LocationSettings settings = Platform.isAndroid
+        ? AndroidSettings(
+            accuracy: LocationAccuracy.bestForNavigation,
+            distanceFilter: _distanceFilterMeters,
+            foregroundNotificationConfig: const ForegroundNotificationConfig(
+              notificationTitle: AppStrings.walkForegroundNotificationTitle,
+              notificationText: AppStrings.walkForegroundNotificationBody,
+              enableWakeLock: true,
+            ),
+          )
+        : AppleSettings(
+            accuracy: LocationAccuracy.bestForNavigation,
+            distanceFilter: _distanceFilterMeters,
+            activityType: ActivityType.fitness,
+            pauseLocationUpdatesAutomatically: false,
+            allowBackgroundLocationUpdates: true,
+            showBackgroundLocationIndicator: true,
+          );
 
     DateTime? lastEmitted;
     await for (final pos

--- a/lib/infrastructure/notification_service.dart
+++ b/lib/infrastructure/notification_service.dart
@@ -25,6 +25,8 @@ class NotificationService {
   static const _idTurnaround = 2;
   static const _idRoundTrip = 3;
   static const _idSmsSent = 4;
+  static const _idWalkReminder = 5;
+  static const _idWalkAutoEnd = 6;
 
   Future<void> initialize() async {
     const androidSettings =
@@ -47,6 +49,36 @@ class NotificationService {
           AndroidFlutterLocalNotificationsPlugin>();
       await androidPlugin?.requestNotificationsPermission();
     }
+  }
+
+  /// 長時間散歩中のリマインド通知を表示する
+  Future<void> showWalkReminderNotification(int hours) async {
+    await _plugin.show(
+      id: _idWalkReminder,
+      title: AppStrings.walkReminderNotificationTitle,
+      body: AppStrings.walkReminderNotificationBody(hours),
+      notificationDetails: _notificationDetails(),
+    );
+  }
+
+  /// 自動終了30分前の警告通知を表示する
+  Future<void> showWalkAutoEndWarningNotification() async {
+    await _plugin.show(
+      id: _idWalkAutoEnd,
+      title: AppStrings.walkAutoEndWarningTitle,
+      body: AppStrings.walkAutoEndWarningBody,
+      notificationDetails: _notificationDetails(),
+    );
+  }
+
+  /// 散歩が自動終了したことを通知する
+  Future<void> showWalkAutoEndNotification() async {
+    await _plugin.show(
+      id: _idWalkAutoEnd,
+      title: AppStrings.walkAutoEndNotificationTitle,
+      body: AppStrings.walkAutoEndNotificationBody,
+      notificationDetails: _notificationDetails(),
+    );
   }
 
   /// SMS 送信後の通知を表示する（バックグラウンド時でも気づけるよう）

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -57,6 +57,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
 
   Timer? _tickTimer;
   Timer? _gpsTimeoutTimer;
+  bool _isFiringNotifications = false;
 
   @override
   void initState() {
@@ -87,6 +88,16 @@ class _WalkPageState extends ConsumerState<WalkPage> {
   }
 
   Future<void> _fireNotificationsIfNeeded() async {
+    if (_isFiringNotifications) return;
+    _isFiringNotifications = true;
+    try {
+      await _doFireNotifications();
+    } finally {
+      _isFiringNotifications = false;
+    }
+  }
+
+  Future<void> _doFireNotifications() async {
     final svc = ref.read(notificationServiceProvider);
     final ts = ref.read(walkTimerProvider);
     // 往復タイマーの折り返し通知（全体の半分の時間になったとき）
@@ -115,7 +126,7 @@ class _WalkPageState extends ConsumerState<WalkPage> {
       for (final hour in [2, 4, 6]) {
         if (elapsed.inHours >= hour && !ts.reminderHoursFired.contains(hour)) {
           ref.read(walkTimerProvider.notifier).markReminderFired(hour);
-          await svc.showWalkReminderNotification(elapsed.inHours);
+          await svc.showWalkReminderNotification(hour);
         }
       }
       if (elapsed.inSeconds >= 7 * 3600 + 30 * 60 && !ts.autoEndWarningFired) {

--- a/lib/screens/pages/walk/view/walk_page.dart
+++ b/lib/screens/pages/walk/view/walk_page.dart
@@ -22,7 +22,10 @@ import 'package:tekushare/screens/pages/settings/viewmodel/settings_viewmodel.da
 import 'package:tekushare/screens/pages/spot/view/spot_list_page.dart';
 import 'package:tekushare/screens/pages/spot/view/want_to_go_page.dart';
 import 'package:tekushare/screens/pages/walk/view/end_walk_page.dart';
+import 'package:tekushare/domain/entities/walk_route.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
+import 'package:tekushare/screens/providers/walk_history_provider.dart';
+import 'package:tekushare/screens/providers/walk_routes_provider.dart';
 import 'package:tekushare/screens/providers/walk_session_provider.dart';
 import 'package:tekushare/screens/providers/auth_provider.dart';
 import 'package:tekushare/screens/providers/contact_provider.dart';
@@ -104,6 +107,44 @@ class _WalkPageState extends ConsumerState<WalkPage> {
       await svc.showInactivityNotification();
       _showSafetyConfirmDialog();
     }
+
+    // 長時間散歩の監視（2h/4h/6h リマインド、7.5h 警告、8h 自動終了）
+    final startedAt = ref.read(walkSessionProvider).startedAt;
+    if (startedAt != null) {
+      final elapsed = DateTime.now().difference(startedAt);
+      for (final hour in [2, 4, 6]) {
+        if (elapsed.inHours >= hour && !ts.reminderHoursFired.contains(hour)) {
+          ref.read(walkTimerProvider.notifier).markReminderFired(hour);
+          await svc.showWalkReminderNotification(elapsed.inHours);
+        }
+      }
+      if (elapsed.inSeconds >= 7 * 3600 + 30 * 60 && !ts.autoEndWarningFired) {
+        ref.read(walkTimerProvider.notifier).markAutoEndWarningFired();
+        await svc.showWalkAutoEndWarningNotification();
+      }
+      if (elapsed.inSeconds >= 8 * 3600 && !ts.autoEndFired) {
+        ref.read(walkTimerProvider.notifier).markAutoEndFired();
+        await _autoEndWalk();
+      }
+    }
+  }
+
+  Future<void> _autoEndWalk() async {
+    if (!mounted) return;
+    final session = ref.read(walkSessionProvider);
+    final trackPoints = ref.read(walkTrackPointsProvider);
+    final route = WalkRoute(
+      id: session.id,
+      walkSessionId: session.id,
+      points: trackPoints,
+      createdAt: DateTime.now(),
+    );
+    await ref.read(walkSessionProvider.notifier).endWalk(route);
+    ref.invalidate(walkHistoryProvider);
+    ref.invalidate(walkRoutesProvider);
+    ref.read(walkSessionProvider.notifier).resetWalk();
+    ref.read(walkTimerProvider.notifier).reset();
+    await ref.read(notificationServiceProvider).showWalkAutoEndNotification();
   }
 
   void _showSafetyConfirmDialog() {

--- a/lib/screens/providers/walk_session_provider.dart
+++ b/lib/screens/providers/walk_session_provider.dart
@@ -38,6 +38,13 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
     }
     final startedAtMs = prefs.getInt(_kStartedAt);
     final elapsed = prefs.getInt(_kElapsed) ?? 0;
+    // 8時間以上経過していた場合はフォアグラウンドサービスが停止した可能性があるため自動リセット
+    if (startedAtMs != null) {
+      final startedAt = DateTime.fromMillisecondsSinceEpoch(startedAtMs);
+      if (DateTime.now().difference(startedAt).inSeconds >= 8 * 3600) {
+        return const WalkSession(id: '', status: WalkStatus.idle);
+      }
+    }
     return WalkSession(
       id: id,
       status: status,

--- a/lib/screens/providers/walk_timer_provider.dart
+++ b/lib/screens/providers/walk_timer_provider.dart
@@ -10,6 +10,9 @@ class WalkTimerState {
     this.inactFired = false,
     this.turnAlertShown = false,
     this.initialized = false,
+    this.reminderHoursFired = const {},
+    this.autoEndWarningFired = false,
+    this.autoEndFired = false,
   });
 
   final int? turnSecondsLeft;
@@ -22,6 +25,15 @@ class WalkTimerState {
   final bool inactFired;
   final bool turnAlertShown;
   final bool initialized;
+
+  /// リマインド済みの時間（2, 4, 6 時間）
+  final Set<int> reminderHoursFired;
+
+  /// 7時間30分経過時の自動終了警告を送信済みか
+  final bool autoEndWarningFired;
+
+  /// 8時間経過による自動終了を実行済みか
+  final bool autoEndFired;
 }
 
 class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
@@ -61,6 +73,9 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       inactFired: s.inactFired,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
     );
   }
 
@@ -75,6 +90,9 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       inactFired: s.inactFired,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
     );
   }
 
@@ -89,6 +107,9 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       inactFired: s.inactFired,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
     );
   }
 
@@ -103,6 +124,9 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       inactFired: true,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
     );
   }
 
@@ -117,6 +141,60 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       inactFired: s.inactFired,
       turnAlertShown: true,
       initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
+    );
+  }
+
+  void markReminderFired(int hour) {
+    final s = state;
+    state = WalkTimerState(
+      turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
+      inactSecondsLeft: s.inactSecondsLeft,
+      turnFired: s.turnFired,
+      midpointFired: s.midpointFired,
+      inactFired: s.inactFired,
+      turnAlertShown: s.turnAlertShown,
+      initialized: s.initialized,
+      reminderHoursFired: {...s.reminderHoursFired, hour},
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
+    );
+  }
+
+  void markAutoEndWarningFired() {
+    final s = state;
+    state = WalkTimerState(
+      turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
+      inactSecondsLeft: s.inactSecondsLeft,
+      turnFired: s.turnFired,
+      midpointFired: s.midpointFired,
+      inactFired: s.inactFired,
+      turnAlertShown: s.turnAlertShown,
+      initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: true,
+      autoEndFired: s.autoEndFired,
+    );
+  }
+
+  void markAutoEndFired() {
+    final s = state;
+    state = WalkTimerState(
+      turnSecondsLeft: s.turnSecondsLeft,
+      midpointSeconds: s.midpointSeconds,
+      inactSecondsLeft: s.inactSecondsLeft,
+      turnFired: s.turnFired,
+      midpointFired: s.midpointFired,
+      inactFired: s.inactFired,
+      turnAlertShown: s.turnAlertShown,
+      initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: true,
     );
   }
 
@@ -132,6 +210,9 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       inactFired: s.inactFired,
       turnAlertShown: false,
       initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
     );
   }
 
@@ -146,6 +227,9 @@ class WalkTimerNotifier extends StateNotifier<WalkTimerState> {
       inactFired: false,
       turnAlertShown: s.turnAlertShown,
       initialized: s.initialized,
+      reminderHoursFired: s.reminderHoursFired,
+      autoEndWarningFired: s.autoEndWarningFired,
+      autoEndFired: s.autoEndFired,
     );
   }
 


### PR DESCRIPTION
## 概要

- #140 バックグラウンドでのGPSルート記録（フォアグラウンドサービス対応）
- #157 長時間散歩の自動終了（リマインド通知 + 8時間自動終了）

## 変更内容

### #140 バックグラウンドGPS記録

`geolocator` の `AndroidSettings` + `ForegroundNotificationConfig` を使用し、散歩中はフォアグラウンドサービスが起動するよう変更。バックグラウンド移行後もGPSが継続取得され、ルートが途切れなくなる。

- `ACCESS_BACKGROUND_LOCATION`（Play審査必要）は不要。フォアグラウンドサービスで対応
- Android: ステータスバーに「バックグラウンドでGPSを記録しています」の常駐通知
- iOS: `allowBackgroundLocationUpdates: true` + `UIBackgroundModes: location`

**変更ファイル**
- `android/app/src/main/AndroidManifest.xml` — `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_LOCATION` 権限・サービス宣言追加
- `ios/Runner/Info.plist` — `UIBackgroundModes` / `NSLocationAlwaysAndWhenInUseUsageDescription` 追加
- `lib/infrastructure/location_service.dart` — `AndroidSettings` / `AppleSettings` に変更

### #157 長時間散歩の自動終了

散歩終了忘れによる長時間GPS継続を防ぐ。

| タイミング | 動作 |
|---|---|
| 2時間・4時間・6時間経過 | 「散歩を続けていますか？」リマインド通知 |
| 7時間30分経過 | 「散歩が自動終了します」警告通知 |
| 8時間経過 | 散歩を自動終了 + 「散歩を自動終了しました」通知 |

**変更ファイル**
- `lib/core/constants/app_strings.dart` — 通知文言追加
- `lib/infrastructure/notification_service.dart` — リマインド・警告・自動終了通知メソッド追加
- `lib/screens/providers/walk_timer_provider.dart` — `reminderHoursFired` / `autoEndWarningFired` / `autoEndFired` フラグ追加
- `lib/screens/pages/walk/view/walk_page.dart` — 経過時間監視・`_autoEndWalk()` 追加

## テスト確認項目

- [ ] 散歩開始後バックグラウンドに移動してもルートが途切れない
- [ ] ステータスバーに常駐通知が表示される
- [ ] 2h/4h/6h でリマインド通知が届く
- [ ] 7.5h で警告通知が届く
- [ ] 8h で散歩が自動終了し通知が届く

Closes #140
Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 散歩中の位置情報をバックグラウンドでも継続して記録できるようになりました。
  * 長時間の散歩に対し、2・4・6時間経過時にリマインダーを通知します。
  * 7時間30分経過時に自動終了の警告を表示し、8時間経過時に散歩を自動終了します。
  * 自動終了後、散歩履歴とルートを保存し、完了通知を送信します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->