### PR TITLE
[Fix] 散歩再開時にフォアグラウンド通知が表示されないバグを修正

### DIFF
--- a/lib/infrastructure/location_service.dart
+++ b/lib/infrastructure/location_service.dart
@@ -35,6 +35,7 @@ class LocationService {
               notificationTitle: AppStrings.walkForegroundNotificationTitle,
               notificationText: AppStrings.walkForegroundNotificationBody,
               enableWakeLock: true,
+              setOngoing: true,
             ),
           )
         : AppleSettings(

--- a/lib/infrastructure/notification_service.dart
+++ b/lib/infrastructure/notification_service.dart
@@ -27,6 +27,10 @@ class NotificationService {
   static const _idSmsSent = 4;
   static const _idWalkReminder = 5;
   static const _idWalkAutoEnd = 6;
+  static const _idWalkOngoing = 10;
+
+  static const _walkOngoingChannelId = 'tekushare_walk_ongoing';
+  static const _walkOngoingChannelName = '散歩記録中';
 
   Future<void> initialize() async {
     const androidSettings =
@@ -119,6 +123,34 @@ class NotificationService {
       body: AppStrings.timerFinishedMessage,
       notificationDetails: _notificationDetails(),
     );
+  }
+
+  /// 散歩中の ongoing 通知を表示する。
+  /// 通常通知（フォアグラウンドサービスとは別）のため Android 14 でも消せない。
+  Future<void> showWalkOngoingNotification() async {
+    await _plugin.show(
+      id: _idWalkOngoing,
+      title: AppStrings.walkForegroundNotificationTitle,
+      body: AppStrings.walkForegroundNotificationBody,
+      notificationDetails: const NotificationDetails(
+        android: AndroidNotificationDetails(
+          _walkOngoingChannelId,
+          _walkOngoingChannelName,
+          importance: Importance.low,
+          priority: Priority.low,
+          ongoing: true,
+          autoCancel: false,
+          showWhen: false,
+          playSound: false,
+          enableVibration: false,
+        ),
+      ),
+    );
+  }
+
+  /// 散歩中の ongoing 通知をキャンセルする
+  Future<void> cancelWalkOngoingNotification() async {
+    await _plugin.cancel(id: _idWalkOngoing);
   }
 
   /// 表示中の通知をすべてキャンセルする

--- a/lib/infrastructure/notification_service.dart
+++ b/lib/infrastructure/notification_service.dart
@@ -27,10 +27,6 @@ class NotificationService {
   static const _idSmsSent = 4;
   static const _idWalkReminder = 5;
   static const _idWalkAutoEnd = 6;
-  static const _idWalkOngoing = 10;
-
-  static const _walkOngoingChannelId = 'tekushare_walk_ongoing';
-  static const _walkOngoingChannelName = '散歩記録中';
 
   Future<void> initialize() async {
     const androidSettings =
@@ -123,34 +119,6 @@ class NotificationService {
       body: AppStrings.timerFinishedMessage,
       notificationDetails: _notificationDetails(),
     );
-  }
-
-  /// 散歩中の ongoing 通知を表示する。
-  /// 通常通知（フォアグラウンドサービスとは別）のため Android 14 でも消せない。
-  Future<void> showWalkOngoingNotification() async {
-    await _plugin.show(
-      id: _idWalkOngoing,
-      title: AppStrings.walkForegroundNotificationTitle,
-      body: AppStrings.walkForegroundNotificationBody,
-      notificationDetails: const NotificationDetails(
-        android: AndroidNotificationDetails(
-          _walkOngoingChannelId,
-          _walkOngoingChannelName,
-          importance: Importance.low,
-          priority: Priority.low,
-          ongoing: true,
-          autoCancel: false,
-          showWhen: false,
-          playSound: false,
-          enableVibration: false,
-        ),
-      ),
-    );
-  }
-
-  /// 散歩中の ongoing 通知をキャンセルする
-  Future<void> cancelWalkOngoingNotification() async {
-    await _plugin.cancel(id: _idWalkOngoing);
   }
 
   /// 表示中の通知をすべてキャンセルする

--- a/lib/screens/providers/walk_session_provider.dart
+++ b/lib/screens/providers/walk_session_provider.dart
@@ -5,6 +5,7 @@ import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/domain/repositories/walk_status_repository.dart';
 import 'package:tekushare/domain/usecases/walk/end_walk.dart';
 import 'package:tekushare/domain/usecases/walk/start_walk.dart';
+import 'package:tekushare/infrastructure/notification_service.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 
 class WalkSessionNotifier extends StateNotifier<WalkSession> {
@@ -12,15 +13,24 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
     required EndWalk endWalk,
     required SharedPreferences prefs,
     required WalkStatusRepository walkStatusRepository,
+    NotificationService? notificationService,
   })  : _endWalk = endWalk,
         _prefs = prefs,
         _walkStatusRepository = walkStatusRepository,
-        super(_restore(prefs));
+        _notificationService = notificationService,
+        super(_restore(prefs)) {
+    // アプリ再起動時に散歩中だった場合は ongoing 通知を再表示
+    if (state.status == WalkStatus.walking) {
+      Future.microtask(
+          () => _notificationService?.showWalkOngoingNotification());
+    }
+  }
 
   static const _startWalk = StartWalk();
   final EndWalk _endWalk;
   final SharedPreferences _prefs;
   final WalkStatusRepository _walkStatusRepository;
+  final NotificationService? _notificationService;
 
   static const _kId = 'walk_id';
   static const _kStatus = 'walk_status';
@@ -88,6 +98,7 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
       _walkStatusRepository.setWalking(),
     ]);
     state = session;
+    await _notificationService?.showWalkOngoingNotification();
   }
 
   Future<void> endWalk(WalkRoute route) async {
@@ -98,6 +109,7 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
       _walkStatusRepository.clearWalking(),
     ]);
     state = finished;
+    await _notificationService?.cancelWalkOngoingNotification();
   }
 
   Future<void> resetWalk() async {
@@ -107,6 +119,7 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
       _walkStatusRepository.clearWalking(),
     ]);
     state = session;
+    await _notificationService?.cancelWalkOngoingNotification();
   }
 }
 
@@ -119,5 +132,6 @@ final walkSessionProvider =
     ),
     prefs: ref.watch(sharedPrefsProvider).requireValue,
     walkStatusRepository: ref.watch(walkStatusRepositoryProvider),
+    notificationService: ref.watch(notificationServiceProvider),
   );
 });

--- a/lib/screens/providers/walk_session_provider.dart
+++ b/lib/screens/providers/walk_session_provider.dart
@@ -5,7 +5,6 @@ import 'package:tekushare/domain/entities/walk_session.dart';
 import 'package:tekushare/domain/repositories/walk_status_repository.dart';
 import 'package:tekushare/domain/usecases/walk/end_walk.dart';
 import 'package:tekushare/domain/usecases/walk/start_walk.dart';
-import 'package:tekushare/infrastructure/notification_service.dart';
 import 'package:tekushare/screens/providers/app_providers.dart';
 
 class WalkSessionNotifier extends StateNotifier<WalkSession> {
@@ -13,24 +12,15 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
     required EndWalk endWalk,
     required SharedPreferences prefs,
     required WalkStatusRepository walkStatusRepository,
-    NotificationService? notificationService,
   })  : _endWalk = endWalk,
         _prefs = prefs,
         _walkStatusRepository = walkStatusRepository,
-        _notificationService = notificationService,
-        super(_restore(prefs)) {
-    // アプリ再起動時に散歩中だった場合は ongoing 通知を再表示
-    if (state.status == WalkStatus.walking) {
-      Future.microtask(
-          () => _notificationService?.showWalkOngoingNotification());
-    }
-  }
+        super(_restore(prefs));
 
   static const _startWalk = StartWalk();
   final EndWalk _endWalk;
   final SharedPreferences _prefs;
   final WalkStatusRepository _walkStatusRepository;
-  final NotificationService? _notificationService;
 
   static const _kId = 'walk_id';
   static const _kStatus = 'walk_status';
@@ -98,7 +88,6 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
       _walkStatusRepository.setWalking(),
     ]);
     state = session;
-    await _notificationService?.showWalkOngoingNotification();
   }
 
   Future<void> endWalk(WalkRoute route) async {
@@ -109,7 +98,6 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
       _walkStatusRepository.clearWalking(),
     ]);
     state = finished;
-    await _notificationService?.cancelWalkOngoingNotification();
   }
 
   Future<void> resetWalk() async {
@@ -119,7 +107,6 @@ class WalkSessionNotifier extends StateNotifier<WalkSession> {
       _walkStatusRepository.clearWalking(),
     ]);
     state = session;
-    await _notificationService?.cancelWalkOngoingNotification();
   }
 }
 
@@ -132,6 +119,5 @@ final walkSessionProvider =
     ),
     prefs: ref.watch(sharedPrefsProvider).requireValue,
     walkStatusRepository: ref.watch(walkStatusRepositoryProvider),
-    notificationService: ref.watch(notificationServiceProvider),
   );
 });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 name: tekushare
 description: 散歩の記録・共有・見守りができるアプリ
 publish_to: 'none'
-version: 1.0.0+7
+version: 1.0.0+8
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## 概要

散歩を一度終了して再開したとき、またはユーザーが通知をスワイプで消した後に散歩を再開したときに、フォアグラウンド通知が表示されないバグを修正。

## 原因

`ForegroundNotificationConfig` に `setOngoing: true` が設定されていなかったため、ユーザーが通知をスワイプで消した後にフォアグラウンドサービスを再起動しても通知が再表示されなかった。

## 修正内容

- `lib/infrastructure/location_service.dart`: `ForegroundNotificationConfig` に `setOngoing: true` を追加
  - 散歩中は通知をスワイプで消せなくなる（フォアグラウンドサービスとして適切な挙動）
  - 何度散歩を終了・再開しても毎回通知が表示されるようになる

## その他

- `pubspec.yaml`: versionCode を 7 → 8 に更新（リリース用）

## チェックリスト

- [x] dart format 適用済み
- [x] flutter analyze 通過